### PR TITLE
feat(backup): harden iCloud Device Backup recovery path

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		SYNC10012FE2000000000001 /* SupabaseSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNC00012FE2000000000001 /* SupabaseSyncService.swift */; };
 		SYNC10022FE2000000000002 /* SupabaseSyncService+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */; };
 		RSTR10012FE2000000000003 /* RestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = RSTR00012FE2000000000003 /* RestoreCoordinator.swift */; };
+		BKSN10012FE2000000000006 /* BackupSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BKSN00012FE2000000000006 /* BackupSnapshotService.swift */; };
 		RSTR10022FE2000000000004 /* Agent/RestoreSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */; };
 		TBSLIDE0022FB0000000000002 /* TabBarSlideHider.swift in Sources */ = {isa = PBXBuildFile; fileRef = TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */; };
 		W1D600010000000000000001 /* SharedEventSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1D600000000000000000001 /* SharedEventSnapshot.swift */; };
@@ -274,6 +275,7 @@
 		SYNC00012FE2000000000001 /* SupabaseSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseSyncService.swift; sourceTree = "<group>"; };
 		SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SupabaseSyncService+Restore.swift"; sourceTree = "<group>"; };
 		RSTR00012FE2000000000003 /* RestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreCoordinator.swift; sourceTree = "<group>"; };
+		BKSN00012FE2000000000006 /* BackupSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSnapshotService.swift; sourceTree = "<group>"; };
 		RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/RestoreSheet.swift; sourceTree = "<group>"; };
 		TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSlideHider.swift; sourceTree = "<group>"; };
 		W1D600000000000000000001 /* SharedEventSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEventSnapshot.swift; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 				SYNC00012FE2000000000001 /* SupabaseSyncService.swift */,
 				SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */,
 				RSTR00012FE2000000000003 /* RestoreCoordinator.swift */,
+				BKSN00012FE2000000000006 /* BackupSnapshotService.swift */,
 				AUTH00012FE3000000000001 /* AuthService.swift */,
 			);
 			path = Services;
@@ -728,6 +731,7 @@
 				SYNC10012FE2000000000001 /* SupabaseSyncService.swift in Sources */,
 				SYNC10022FE2000000000002 /* SupabaseSyncService+Restore.swift in Sources */,
 				RSTR10012FE2000000000003 /* RestoreCoordinator.swift in Sources */,
+				BKSN10012FE2000000000006 /* BackupSnapshotService.swift in Sources */,
 				AUTH10012FE3000000000001 /* AuthService.swift in Sources */,
 				AUTH10022FE3000000000002 /* Agent/AccountView.swift in Sources */,
 				AABB200E2F60000000000014 /* Agent/ConversationHistoryView.swift in Sources */,

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -156,6 +156,7 @@ struct ContentView: View {
     @StateObject private var authService = AuthService()
     @StateObject private var syncService = SupabaseSyncService()
     @StateObject private var restoreCoordinator = RestoreCoordinator()
+    @StateObject private var backupSnapshotService = BackupSnapshotService()
     @State private var skillAnalysisService: SkillAnalysisService?
     @State private var tokenInferenceCoordinator: TokenInferenceCoordinator?
     @State private var selectedTab: RootTab = .wanna
@@ -293,6 +294,11 @@ struct ContentView: View {
             )
             restoreCoordinator.configure(
                 syncService: syncService,
+                eventStore: store,
+                eventTypeStore: agentRuntime.eventTypeTemplateStore,
+                skillStore: skillInsightStore
+            )
+            backupSnapshotService.attach(
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
                 skillStore: skillInsightStore

--- a/Done/Models/EventStore.swift
+++ b/Done/Models/EventStore.swift
@@ -8,6 +8,12 @@
 import Foundation
 import Combine
 import WidgetKit
+import os
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "Done",
+    category: "EventStore"
+)
 
 /// Protocol unifying CalendarEventFeedbackRecord and CalendarEventLogRecord
 /// for shared pruning logic.
@@ -59,54 +65,59 @@ final class EventStore: ObservableObject {
     }
 
     func load() {
-        if let data = defaults.data(forKey: storageKey) {
-            do {
-                let decoded = try JSONDecoder().decode([Event].self, from: data)
-                events = decoded
-            } catch {
-                events = []
-            }
-        } else {
-            events = []
-        }
-
-        if let calData = defaults.data(forKey: calendarStorageKey) {
-            do {
-                calendarEvents = try JSONDecoder().decode([Event].self, from: calData)
-            } catch {
-                calendarEvents = []
-            }
-        }
-
-        if let feedbackData = defaults.data(forKey: calendarEventFeedbackStorageKey) {
-            do {
-                calendarEventFeedbackRecords = try JSONDecoder().decode([CalendarEventFeedbackRecord].self, from: feedbackData)
-            } catch {
-                calendarEventFeedbackRecords = []
-            }
-        }
-
-        if let logData = defaults.data(forKey: calendarEventLogStorageKey) {
-            do {
-                calendarEventLogRecords = try JSONDecoder().decode([CalendarEventLogRecord].self, from: logData)
-            } catch {
-                calendarEventLogRecords = []
-            }
-        }
-
-        if let listData = defaults.data(forKey: todoListsStorageKey) {
-            do {
-                todoLists = try JSONDecoder().decode([TodoList].self, from: listData)
-            } catch {
-                todoLists = []
-            }
-        }
+        events = decodeOrQuarantine([Event].self, forKey: storageKey)
+        calendarEvents = decodeOrQuarantine([Event].self, forKey: calendarStorageKey)
+        calendarEventFeedbackRecords = decodeOrQuarantine(
+            [CalendarEventFeedbackRecord].self, forKey: calendarEventFeedbackStorageKey
+        )
+        calendarEventLogRecords = decodeOrQuarantine(
+            [CalendarEventLogRecord].self, forKey: calendarEventLogStorageKey
+        )
+        todoLists = decodeOrQuarantine([TodoList].self, forKey: todoListsStorageKey)
 
         if calendarEvents.isEmpty {
             seedSampleCalendarEvents()
         }
         migrateOrphanEvents()
         syncWidgetSnapshots()
+    }
+
+    /// Read & decode a stored UserDefaults JSON blob. On decode failure, copy
+    /// the raw bytes to `Documents/quarantine-<key>-<timestamp>.json` (so the
+    /// next iCloud Device Backup captures the corrupted data for forensic
+    /// recovery) and log loudly, then fall back to empty. The previous
+    /// behavior was a silent `[] `which let the next `save()` overwrite the
+    /// corrupted blob with empty bytes — effectively destroying it.
+    private func decodeOrQuarantine<T: Decodable>(_ type: T.Type, forKey key: String) -> T
+    where T: ExpressibleByArrayLiteral {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        do {
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            quarantineCorruptedBlob(data, key: key, error: error)
+            return []
+        }
+    }
+
+    /// Persist a copy of the unreadable bytes outside UserDefaults so iCloud
+    /// Device Backup can preserve them (Documents/ is always included in
+    /// device backup). Filename uses the storage key + timestamp so multiple
+    /// quarantines coexist without overwriting each other.
+    private func quarantineCorruptedBlob(_ data: Data, key: String, error: Error) {
+        let isoTimestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let filename = "quarantine-\(key)-\(isoTimestamp).json"
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            logger.error("Failed to locate Documents directory while quarantining \(key, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            return
+        }
+        let url = docs.appendingPathComponent(filename)
+        do {
+            try data.write(to: url, options: [.atomic])
+            logger.error("Quarantined corrupted UserDefaults blob for \(key, privacy: .public) to \(filename, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        } catch let writeError {
+            logger.error("Failed to write quarantine file \(filename, privacy: .public) for \(key, privacy: .public): \(writeError.localizedDescription, privacy: .public). Original decode error: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private func seedSampleCalendarEvents() {

--- a/Done/Services/Agent/AgenticIntakeAssetStore.swift
+++ b/Done/Services/Agent/AgenticIntakeAssetStore.swift
@@ -118,6 +118,13 @@ final class AgenticIntakeAssetStore {
         }
     }
 
+    /// Images live under `Library/Application Support/AgenticIntakeAssets/`.
+    /// This location is **deliberately included in iOS Device Backup**: we
+    /// rely on it so user-attached event photos survive device loss when
+    /// they're not separately synced to Supabase (CloudKit-based image sync
+    /// is tracked in issue #16). Do **not** set
+    /// `URLResourceKey.isExcludedFromBackupKey = true` on this directory or
+    /// its contents without a follow-up cloud backup plan in place.
     private static func defaultBaseDirectoryURL(fileManager: FileManager) -> URL {
         let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fileManager.temporaryDirectory

--- a/Done/Services/BackupSnapshotService.swift
+++ b/Done/Services/BackupSnapshotService.swift
@@ -46,12 +46,16 @@ final class BackupSnapshotService: ObservableObject {
 
     init() {}
 
-    /// Wire up subscribers. Idempotent; safe to call once after stores exist.
+    /// Wire up subscribers. Idempotent — calling it more than once (e.g. if
+    /// `onAppear` re-fires due to SwiftUI view-graph rebuilds) clears the
+    /// previous subscriptions before installing fresh ones, so we never end
+    /// up with duplicate snapshot writers racing each other.
     func attach(
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
         skillStore: SkillInsightStore
     ) {
+        cancellables.removeAll()
         self.eventStore = eventStore
         self.eventTypeStore = eventTypeStore
         self.skillStore = skillStore
@@ -69,6 +73,11 @@ final class BackupSnapshotService: ObservableObject {
         // five core lists triggers a (debounced) snapshot. Event-types and
         // skills are quieter so we skip per-store debounces for them — the
         // background trigger covers infrequent edits.
+        // Each of the five `@Published` arrays emits its current value the
+        // moment we subscribe, so the merged stream produces five initial
+        // emissions. Drop all five so we don't write a spurious snapshot
+        // ~30s after every launch with no real user activity. Genuine edits
+        // afterwards still flow through the debounce.
         let storeChanges = Publishers
             .Merge5(
                 eventStore.$events.map { _ in () },
@@ -77,7 +86,7 @@ final class BackupSnapshotService: ObservableObject {
                 eventStore.$calendarEventFeedbackRecords.map { _ in () },
                 eventStore.$todoLists.map { _ in () }
             )
-            .dropFirst()
+            .dropFirst(5)
             .debounce(for: .seconds(Self.storeChangeDebounce), scheduler: RunLoop.main)
 
         storeChanges
@@ -146,8 +155,9 @@ final class BackupSnapshotService: ObservableObject {
         )
     }
 
-    /// Write to a temp file then `replaceItem` so readers never see a partial
-    /// file (especially important if a future foreground reader is added).
+    /// `Data.write(options: .atomic)` is implemented by Foundation as
+    /// write-to-temp-then-rename, so readers never see a partial file —
+    /// important if a future foreground reader is added.
     private func writeAtomically(_ data: Data) throws {
         let url = try Self.snapshotURL()
         try data.write(to: url, options: [.atomic])

--- a/Done/Services/BackupSnapshotService.swift
+++ b/Done/Services/BackupSnapshotService.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Combine
+import SwiftUI
+import os
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "Done",
+    category: "BackupSnapshot"
+)
+
+/// Writes a comprehensive JSON snapshot of all user-specific data to
+/// `Documents/backup-snapshot.json`. This file is automatically included in
+/// iOS Device Backup (and thus iCloud Backup if the user has it on), giving
+/// us a recovery layer independent of Supabase.
+///
+/// Two triggers keep the snapshot fresh:
+///   1. `UIApplication.didEnterBackgroundNotification` — most important; iOS
+///      Backup typically runs at night when the app is backgrounded.
+///   2. EventStore / EventTypeTemplateStore / SkillInsightStore changes with
+///      a 30s debounce — captures in-foreground edits in case the user uses
+///      the app continuously without backgrounding before a corruption event.
+///
+/// The file is intentionally redundant with Supabase. When Supabase is the
+/// preferred recovery source, this file is just belt-and-suspenders. When
+/// Supabase is unreachable or the user wants offline recovery, this is the
+/// fallback.
+@MainActor
+final class BackupSnapshotService: ObservableObject {
+    /// Bump when the on-disk shape changes in an incompatible way.
+    private static let snapshotVersion = 1
+
+    /// One file, always at the same path. Rolled atomically on every write so
+    /// readers never see a half-written file.
+    private static let snapshotFilename = "backup-snapshot.json"
+
+    /// 30s debounce on store changes — much longer than the Supabase sync
+    /// debounce (2s) since this writes to disk locally and there's no
+    /// network cost. Enough to coalesce a burst of edits.
+    private static let storeChangeDebounce: TimeInterval = 30
+
+    private weak var eventStore: EventStore?
+    private weak var eventTypeStore: EventTypeTemplateStore?
+    private weak var skillStore: SkillInsightStore?
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {}
+
+    /// Wire up subscribers. Idempotent; safe to call once after stores exist.
+    func attach(
+        eventStore: EventStore,
+        eventTypeStore: EventTypeTemplateStore,
+        skillStore: SkillInsightStore
+    ) {
+        self.eventStore = eventStore
+        self.eventTypeStore = eventTypeStore
+        self.skillStore = skillStore
+
+        // ── App backgrounding ──
+        NotificationCenter.default
+            .publisher(for: UIApplication.didEnterBackgroundNotification)
+            .sink { [weak self] _ in
+                self?.writeSnapshotSync(reason: "didEnterBackground")
+            }
+            .store(in: &cancellables)
+
+        // ── Store-change debounce (30s) ──
+        // We piggyback on EventStore's @Published arrays; any change in the
+        // five core lists triggers a (debounced) snapshot. Event-types and
+        // skills are quieter so we skip per-store debounces for them — the
+        // background trigger covers infrequent edits.
+        let storeChanges = Publishers
+            .Merge5(
+                eventStore.$events.map { _ in () },
+                eventStore.$calendarEvents.map { _ in () },
+                eventStore.$calendarEventLogRecords.map { _ in () },
+                eventStore.$calendarEventFeedbackRecords.map { _ in () },
+                eventStore.$todoLists.map { _ in () }
+            )
+            .dropFirst()
+            .debounce(for: .seconds(Self.storeChangeDebounce), scheduler: RunLoop.main)
+
+        storeChanges
+            .sink { [weak self] _ in
+                self?.writeSnapshotSync(reason: "storeChange")
+            }
+            .store(in: &cancellables)
+    }
+
+    /// On-demand write (e.g. from a "Snapshot now" UI button, if we add one).
+    /// Public so the restore UI can offer manual triggers if needed.
+    func writeSnapshotNow(reason: String = "manual") {
+        writeSnapshotSync(reason: reason)
+    }
+
+    // MARK: - Implementation
+
+    private func writeSnapshotSync(reason: String) {
+        guard let eventStore, let eventTypeStore, let skillStore else { return }
+
+        do {
+            let data = try buildSnapshotData(
+                eventStore: eventStore,
+                eventTypeStore: eventTypeStore,
+                skillStore: skillStore
+            )
+            try writeAtomically(data)
+            logger.info("Snapshot written (\(data.count, privacy: .public) bytes, reason: \(reason, privacy: .public))")
+        } catch {
+            logger.error("Snapshot write failed (reason: \(reason, privacy: .public)): \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Build the snapshot payload as a single JSON-serializable dictionary so
+    /// it's both human-readable and tolerant of the heterogeneous data we
+    /// carry (typed models + an untyped settings blob).
+    private func buildSnapshotData(
+        eventStore: EventStore,
+        eventTypeStore: EventTypeTemplateStore,
+        skillStore: SkillInsightStore
+    ) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+
+        func jsonArray<T: Encodable>(_ items: [T]) throws -> [Any] {
+            let data = try encoder.encode(items)
+            return (try JSONSerialization.jsonObject(with: data) as? [Any]) ?? []
+        }
+
+        let dict: [String: Any] = [
+            "version": Self.snapshotVersion,
+            "createdAt": ISO8601DateFormatter.iso8601WithFraction.string(from: Date()),
+            "events": try jsonArray(eventStore.events),
+            "calendarEvents": try jsonArray(eventStore.calendarEvents),
+            "logs": try jsonArray(eventStore.calendarEventLogRecords),
+            "feedback": try jsonArray(eventStore.calendarEventFeedbackRecords),
+            "todoLists": try jsonArray(eventStore.todoLists),
+            "eventTypes": try jsonArray(eventTypeStore.templates),
+            "skills": try jsonArray(skillStore.insights),
+            "settings": SyncedSettings.currentSnapshot(),
+        ]
+
+        return try JSONSerialization.data(
+            withJSONObject: dict,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+    }
+
+    /// Write to a temp file then `replaceItem` so readers never see a partial
+    /// file (especially important if a future foreground reader is added).
+    private func writeAtomically(_ data: Data) throws {
+        let url = try Self.snapshotURL()
+        try data.write(to: url, options: [.atomic])
+    }
+
+    /// Public so a future "Restore from local snapshot" UI can read it.
+    static func snapshotURL() throws -> URL {
+        guard let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw NSError(domain: "BackupSnapshot", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Documents directory unavailable",
+            ])
+        }
+        return docs.appendingPathComponent(snapshotFilename)
+    }
+}
+
+private extension ISO8601DateFormatter {
+    static let iso8601WithFraction: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+}


### PR DESCRIPTION
## Summary

Make the Done app's data reliably survive an iOS Device Backup → restore cycle. iCloud Backup is a system-level feature the user already controls in iOS Settings; this PR closes three gaps so that when they use it, the app's data actually comes back intact.

Three changes:

- **Quarantine corrupted UserDefaults blobs.** `EventStore.load()` had five silent `catch { events = [] }` paths — if a restored JSON blob ever became unreadable, the array would fall back to empty and the next user edit would `save()` empty bytes over the corrupted blob, destroying it. Now the raw bytes get copied to `Documents/quarantine-<key>-<ISO8601>.json` with a loud `logger.error` line; Documents/ is in iOS Device Backup so the corrupted bytes survive forensically.

- **Periodic JSON snapshot to `Documents/backup-snapshot.json`.** New `BackupSnapshotService` writes a single comprehensive JSON file (all 7 stores + `SyncedSettings` blob + version + ISO timestamp) on `UIApplication.didEnterBackgroundNotification` (iOS backs up at night when the app is backgrounded) and after a 30 s debounce on any store change (covers continuous foreground use). Atomic write, overwrite-in-place, single canonical path.

- **Document image directory backup inclusion.** `AgenticIntakeAssetStore` already stores event photos at `Library/Application Support/AgenticIntakeAssets/` — that location is in iOS Device Backup by default. Added a comment pinning this as load-bearing so a future contributor doesn't silently break it by setting `isExcludedFromBackupKey`. Tracked-elsewhere note: cross-device image sync still needs #16 (CloudKit).

## What this doesn't do

- No in-app "Restore from local snapshot" UI yet — the snapshot exists and is preserved by iCloud Backup; recovery is currently via iOS device-level restore (automatic) or a future reader (deferred).
- iCloud Device Backup is **only** same-Apple-ID, same-device-class recovery. Cross-account / cloud-only recovery is covered by the Supabase restore feature (#18).
- Image binaries across devices in real time → still #16.

## Test plan

- [ ] Build clean: `xcodebuild -project Done.xcodeproj -scheme Done -destination 'generic/platform=iOS Simulator' build` returns BUILD SUCCEEDED
- [ ] Snapshot writes on background: launch in simulator, edit something, send to background (Cmd+L locks the simulator) — console shows `[BackupSnapshot] Snapshot written (X bytes, reason: didEnterBackground)`
- [ ] Snapshot debounce on edit: in foreground, edit a calendar event, wait 30s without further edits — console shows `[BackupSnapshot] Snapshot written (X bytes, reason: storeChange)`
- [ ] Snapshot content sanity: `cat ~/Library/Developer/CoreSimulator/.../Documents/backup-snapshot.json | jq .events[0]` shows a valid event row
- [ ] Quarantine path: in simulator, manually corrupt a UserDefaults blob (e.g. `defaults write com.example.done events <bogus>`), relaunch app — console shows `[EventStore] Quarantined corrupted UserDefaults blob for events to quarantine-events-<timestamp>.json`; the file exists in Documents/; app still loads with empty events
- [ ] Image dir confirmed not excluded from backup: `ls -la@ <sandbox>/Library/Application\ Support/AgenticIntakeAssets/` shows no `com.apple.metadata:com_apple_backup_excludeFromBackup` xattr

## Closes

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)