### PR TITLE
fix(restore): tolerate duplicate-keyed rows in diff + merge paths

### DIFF
--- a/Done/Models/EventStore.swift
+++ b/Done/Models/EventStore.swift
@@ -1190,8 +1190,15 @@ final class EventStore: ObservableObject {
         resolution: ConflictResolution,
         perRowDecisions: [ID: ConflictResolution]? = nil
     ) -> Int {
+        // `CalendarOccurrenceKey.==` for `.singleEvent` only compares the
+        // eventID, so two log/feedback records pointing at the same single
+        // event collide on this map. We don't want to crash on
+        // `Dictionary(uniqueKeysWithValues:)` for that case — keep the first
+        // occurrence's index; subsequent duplicates with the same key inherit
+        // its merge decision and are left alone otherwise.
         let localIDIndex: [ID: Int] = Dictionary(
-            uniqueKeysWithValues: local.enumerated().map { ($0.element[keyPath: id], $0.offset) }
+            local.enumerated().map { ($0.element[keyPath: id], $0.offset) },
+            uniquingKeysWith: { first, _ in first }
         )
         var added = 0
         for c in cloud {

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -415,18 +415,33 @@ final class RestoreCoordinator: ObservableObject {
     private func diffByID<T: Equatable, ID: Hashable>(
         local: [T], cloud: [T], id: KeyPath<T, ID>
     ) -> DiffSummary<ID> {
-        let localByID = Dictionary(uniqueKeysWithValues: local.map { ($0[keyPath: id], $0) })
+        // Some ID types deliberately collapse multiple rows to the same
+        // hashable identity (most notably `CalendarOccurrenceKey` for log /
+        // feedback records, whose `==` for `.singleEvent` only compares
+        // `eventID`). If user data ever ends up with duplicate-keyed rows we
+        // must not crash on `Dictionary(uniqueKeysWithValues:)` — keep the
+        // first occurrence and treat subsequent duplicates as already-counted.
+        let localByID = Dictionary(
+            local.map { ($0[keyPath: id], $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         let cloudIDs = Set(cloud.map { $0[keyPath: id] })
         var result = DiffSummary<ID>()
+        var seenCloudIDs = Set<ID>()
         for c in cloud {
             let cid = c[keyPath: id]
+            // Skip duplicate cloud rows so the conflict count doesn't inflate.
+            guard seenCloudIDs.insert(cid).inserted else { continue }
             if let l = localByID[cid] {
                 if l != c { result.conflicts.append(cid) }
             } else {
                 result.addsFromCloud += 1
             }
         }
+        var seenLocalIDs = Set<ID>()
         for l in local where !cloudIDs.contains(l[keyPath: id]) {
+            let lid = l[keyPath: id]
+            guard seenLocalIDs.insert(lid).inserted else { continue }
             result.keepsLocalOnly += 1
         }
         return result


### PR DESCRIPTION
## Summary

Hotfix for a real crash discovered during end-to-end testing of PR #18 (Supabase restore) + PR #19 (iCloud backup hardening). Restore from Cloud reproducibly **crashed** the moment the user's local data contained two log records sharing the same \`CalendarOccurrenceKey\` identity.

## Crash

\`\`\`
Thread 0:
  _assertionFailure  (Swift stdlib)
  _NativeDictionary.merge<A>(_:isUnique:uniquingKeysWith:)
  Dictionary.init<A>(uniqueKeysWithValues:)
  RestoreCoordinator.diffByID  (RestoreCoordinator.swift:418)
  RestoreCoordinator.computeMergePreview
  RestoreCoordinator.prepareMerge
  closure in RestoreSheet.readyView
\`\`\`

## Root cause

\`CalendarOccurrenceKey.==\` for \`.singleEvent\` only compares \`eventID\`. That's by design (see comment on the equality implementation) so log/feedback lookups stay attached when an event is later edited into an exception. But it means: any duplicate \`CalendarEventLogRecord\` or \`CalendarEventFeedbackRecord\` on the same single event collides on a Hashable key map.

Both restore-side code paths built \`Dictionary(uniqueKeysWithValues:)\` from those collections, which traps on duplicates.

## Fix

Switch both sites to \`Dictionary(_, uniquingKeysWith:)\` with first-wins, plus dedupe the iteration sides in \`diffByID\` so the conflict / add / keep counters in the merge-review UI don't double-count duplicate-keyed rows either.

- \`Done/Services/RestoreCoordinator.swift\` (\`diffByID\`)
- \`Done/Models/EventStore.swift\` (\`mergeByID\`)

## Reproduction

End-to-end in iOS Simulator:

1. Corrupt UserDefaults \`events\` key with non-JSON bytes
2. Relaunch app → \`EventStore.load()\` correctly writes \`Documents/quarantine-events-<timestamp>.json\` (this part works thanks to PR #19's hardening)
3. Open Settings → Data & Privacy → "Restore from Cloud"
4. **Before fix:** crash inside \`computeMergePreview\` → \`diffByID\` → \`Dictionary.init\`
5. **After fix:** merge-review phase renders the preview cleanly, applying the merge restores the cloud todos into local

## Risk

Minimal. Duplicate-keyed local rows are left in place (we just stop crashing on them); merge decisions don't double-apply to the same key. A separate upstream investigation should still happen for **why** duplicate log records can exist in the first place — that's outside this PR's scope.

## Origin

The bad code shipped in PR #18 (already merged). The crash didn't surface earlier because previous testing used a freshly-seeded local store. The first real-data Restore attempt found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)