### PR TITLE
feat(backup): Supabase Storage for event image binaries (L2)

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -117,6 +117,8 @@
 		SYNC10022FE2000000000002 /* SupabaseSyncService+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */; };
 		RSTR10012FE2000000000003 /* RestoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = RSTR00012FE2000000000003 /* RestoreCoordinator.swift */; };
 		BKSN10012FE2000000000006 /* BackupSnapshotService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BKSN00012FE2000000000006 /* BackupSnapshotService.swift */; };
+		IMGSTOR10012FE2000000000007 /* SupabaseImageStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = IMGSTOR00012FE2000000000007 /* SupabaseImageStorageService.swift */; };
+		IMGBC10012FE2000000000008 /* ImageBackupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IMGBC00012FE2000000000008 /* ImageBackupCoordinator.swift */; };
 		RSTR10022FE2000000000004 /* Agent/RestoreSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */; };
 		TBSLIDE0022FB0000000000002 /* TabBarSlideHider.swift in Sources */ = {isa = PBXBuildFile; fileRef = TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */; };
 		W1D600010000000000000001 /* SharedEventSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1D600000000000000000001 /* SharedEventSnapshot.swift */; };
@@ -276,6 +278,8 @@
 		SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SupabaseSyncService+Restore.swift"; sourceTree = "<group>"; };
 		RSTR00012FE2000000000003 /* RestoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreCoordinator.swift; sourceTree = "<group>"; };
 		BKSN00012FE2000000000006 /* BackupSnapshotService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSnapshotService.swift; sourceTree = "<group>"; };
+		IMGSTOR00012FE2000000000007 /* SupabaseImageStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseImageStorageService.swift; sourceTree = "<group>"; };
+		IMGBC00012FE2000000000008 /* ImageBackupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackupCoordinator.swift; sourceTree = "<group>"; };
 		RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/RestoreSheet.swift; sourceTree = "<group>"; };
 		TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSlideHider.swift; sourceTree = "<group>"; };
 		W1D600000000000000000001 /* SharedEventSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEventSnapshot.swift; sourceTree = "<group>"; };
@@ -373,6 +377,8 @@
 				SYNC00022FE2000000000002 /* SupabaseSyncService+Restore.swift */,
 				RSTR00012FE2000000000003 /* RestoreCoordinator.swift */,
 				BKSN00012FE2000000000006 /* BackupSnapshotService.swift */,
+				IMGSTOR00012FE2000000000007 /* SupabaseImageStorageService.swift */,
+				IMGBC00012FE2000000000008 /* ImageBackupCoordinator.swift */,
 				AUTH00012FE3000000000001 /* AuthService.swift */,
 			);
 			path = Services;
@@ -732,6 +738,8 @@
 				SYNC10022FE2000000000002 /* SupabaseSyncService+Restore.swift in Sources */,
 				RSTR10012FE2000000000003 /* RestoreCoordinator.swift in Sources */,
 				BKSN10012FE2000000000006 /* BackupSnapshotService.swift in Sources */,
+				IMGSTOR10012FE2000000000007 /* SupabaseImageStorageService.swift in Sources */,
+				IMGBC10012FE2000000000008 /* ImageBackupCoordinator.swift in Sources */,
 				AUTH10012FE3000000000001 /* AuthService.swift in Sources */,
 				AUTH10022FE3000000000002 /* Agent/AccountView.swift in Sources */,
 				AABB200E2F60000000000014 /* Agent/ConversationHistoryView.swift in Sources */,

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -322,6 +322,7 @@ struct ContentView: View {
         .sheet(isPresented: $isPresentingRestoreSheet) {
             RestoreSheet()
                 .environmentObject(restoreCoordinator)
+                .environmentObject(imageBackupCoordinator)
         }
     }
 

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -157,6 +157,7 @@ struct ContentView: View {
     @StateObject private var syncService = SupabaseSyncService()
     @StateObject private var restoreCoordinator = RestoreCoordinator()
     @StateObject private var backupSnapshotService = BackupSnapshotService()
+    @StateObject private var imageBackupCoordinator = ImageBackupCoordinator()
     @State private var skillAnalysisService: SkillAnalysisService?
     @State private var tokenInferenceCoordinator: TokenInferenceCoordinator?
     @State private var selectedTab: RootTab = .wanna
@@ -244,6 +245,7 @@ struct ContentView: View {
         }
         .environmentObject(calendarState)
         .environmentObject(restoreCoordinator)
+        .environmentObject(imageBackupCoordinator)
         // RestoreSheet's per-row review needs SkillInsightStore in env (the
         // sheet is presented from this view's body, outside the Profile-tab
         // NavigationStack where the store is otherwise injected).
@@ -296,12 +298,17 @@ struct ContentView: View {
                 syncService: syncService,
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
-                skillStore: skillInsightStore
+                skillStore: skillInsightStore,
+                imageBackupCoordinator: imageBackupCoordinator
             )
             backupSnapshotService.attach(
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
                 skillStore: skillInsightStore
+            )
+            imageBackupCoordinator.attach(
+                eventStore: store,
+                authService: authService
             )
         }
         .onChange(of: selectedTab) { _, newValue in

--- a/Done/Services/AuthService.swift
+++ b/Done/Services/AuthService.swift
@@ -228,6 +228,11 @@ final class AuthService: ObservableObject {
     /// Sharing one task across callers means: first caller starts the
     /// refresh, all callers await its completion, all read the new
     /// `accessToken` afterwards.
+    ///
+    /// `AuthService` is `@MainActor`, so the read-check-assign sequence on
+    /// this property is atomic w.r.t. concurrent callers — no lock needed.
+    /// The defensive re-check inside `performTokenRefresh` exists purely as
+    /// a belt-and-suspenders if this class ever loses its MainActor isolation.
     private var refreshTask: Task<Void, Never>?
 
     func refreshTokenIfNeeded() async {

--- a/Done/Services/AuthService.swift
+++ b/Done/Services/AuthService.swift
@@ -221,11 +221,43 @@ final class AuthService: ObservableObject {
 
     // MARK: - Token Refresh
 
+    /// Shared in-flight refresh task so concurrent callers don't all fire
+    /// their own `grant_type=refresh_token` request with the SAME (about to
+    /// be rotated) refresh token — Supabase rotates on use, so only the
+    /// first wins; the rest would 400 and produce spurious log noise.
+    /// Sharing one task across callers means: first caller starts the
+    /// refresh, all callers await its completion, all read the new
+    /// `accessToken` afterwards.
+    private var refreshTask: Task<Void, Never>?
+
     func refreshTokenIfNeeded() async {
         guard let session else { return }
         // Refresh if within 5 minutes of expiry
         guard session.expiresAt.timeIntervalSinceNow < 300 else { return }
 
+        // If a refresh is already in flight, just wait for it. The
+        // post-await read of `accessToken` will see the new token.
+        if let inflight = refreshTask {
+            await inflight.value
+            return
+        }
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.performTokenRefresh()
+        }
+        refreshTask = task
+        await task.value
+        refreshTask = nil
+    }
+
+    private func performTokenRefresh() async {
+        // Re-check after potential micro-race on `refreshTask` assignment:
+        // if another caller beat us into the network and the session was
+        // refreshed in between, exit early without making a redundant call.
+        guard let session, session.expiresAt.timeIntervalSinceNow < 300 else {
+            return
+        }
         do {
             let body: [String: Any] = [
                 "refresh_token": session.refreshToken,

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -91,73 +91,139 @@ final class ImageBackupCoordinator: ObservableObject {
               let userID = authService?.session?.user.id
         else { return }
 
-        let allEvents = eventStore.events + eventStore.calendarEvents
         var newlyUploaded = 0
         var failed = 0
+
+        // 1. Agentic-intake images on the event itself.
+        let allEvents = eventStore.events + eventStore.calendarEvents
         for event in allEvents {
             guard let intake = event.agenticIntake else { continue }
             for ref in intake.images {
-                guard !attemptedImageIDs.contains(ref.id) else { continue }
-                attemptedImageIDs.insert(ref.id)
-
-                let localURL = assetStore.absoluteURL(for: ref)
-                guard let data = try? Data(contentsOf: localURL) else {
-                    // Local file missing — nothing to upload. Could be a
-                    // restore-imminent state. Skip without erroring; will
-                    // try again if local file ever materializes.
-                    continue
-                }
-                let path = storageService.storagePath(
-                    userID: userID,
+                await uploadIfNeeded(
+                    ref: ref,
                     eventID: event.id,
-                    imageID: ref.id
+                    userID: userID,
+                    storageService: storageService,
+                    newlyUploaded: &newlyUploaded,
+                    failed: &failed
                 )
-                do {
-                    try await storageService.upload(path: path, data: data)
-                    newlyUploaded += 1
-                } catch SupabaseImageStorageService.Error.uploadsDisabled {
-                    // DEBUG path. Expected. No retry.
-                } catch SupabaseImageStorageService.Error.notSignedIn {
-                    // Will retry once user signs in (re-attach triggers
-                    // a fresh scan). Don't keep this in attempted so the
-                    // next pass picks it up.
-                    attemptedImageIDs.remove(ref.id)
-                } catch SupabaseImageStorageService.Error.emptyData {
-                    // Permanent: the local file is corrupt (0 bytes). KEEP
-                    // it in attemptedImageIDs so we don't log the same error
-                    // every store change. User would need to re-attach the
-                    // image to recover.
-                    logger.error("Image \(ref.id, privacy: .private) local file is empty/corrupt — skipping permanently this session")
-                } catch {
-                    attemptedImageIDs.remove(ref.id)
-                    failed += 1
-                    logger.error("Image \(ref.id, privacy: .private) upload failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+
+        // 2. Timeline-note images attached during logging. These live on
+        //    `CalendarEventLogRecord.timelineItems[*].note(EventLogTimelineNote).images`
+        //    and use the same on-disk layout (`AgenticIntakeAssets/{eventID}/{imageID}.jpg`,
+        //    keyed by the parent event's ID — see saveImages call sites in
+        //    `CalendarEventLogSheet` and `CalendarEventDetailView`). Without
+        //    this loop they sync as refs across devices but the binaries
+        //    stay orphaned on the originating device.
+        for log in eventStore.calendarEventLogRecords {
+            for item in log.timelineItems {
+                guard let note = item.noteValue else { continue }
+                for ref in note.images {
+                    await uploadIfNeeded(
+                        ref: ref,
+                        eventID: log.eventID,
+                        userID: userID,
+                        storageService: storageService,
+                        newlyUploaded: &newlyUploaded,
+                        failed: &failed
+                    )
                 }
             }
         }
+
         if newlyUploaded > 0 || failed > 0 {
             logger.info("Scan (\(reason, privacy: .public)): uploaded \(newlyUploaded, privacy: .public), failed \(failed, privacy: .public)")
         }
     }
 
+    private func uploadIfNeeded(
+        ref: AgenticIntakeImageRef,
+        eventID: UUID,
+        userID: String,
+        storageService: SupabaseImageStorageService,
+        newlyUploaded: inout Int,
+        failed: inout Int
+    ) async {
+        guard !attemptedImageIDs.contains(ref.id) else { return }
+        attemptedImageIDs.insert(ref.id)
+
+        let localURL = assetStore.absoluteURL(for: ref)
+        guard let data = try? Data(contentsOf: localURL) else {
+            // Local file missing — nothing to upload. Could be a
+            // restore-imminent state. Skip without erroring; will
+            // try again if local file ever materializes.
+            return
+        }
+        let path = storageService.storagePath(
+            userID: userID,
+            eventID: eventID,
+            imageID: ref.id
+        )
+        do {
+            try await storageService.upload(path: path, data: data)
+            newlyUploaded += 1
+        } catch SupabaseImageStorageService.Error.uploadsDisabled {
+            // DEBUG path. Expected. No retry.
+        } catch SupabaseImageStorageService.Error.notSignedIn {
+            attemptedImageIDs.remove(ref.id)
+        } catch SupabaseImageStorageService.Error.emptyData {
+            // Permanent: local file is corrupt (0 bytes). Keep in
+            // attemptedImageIDs to suppress retry; user would need to
+            // re-attach the image to recover.
+            logger.error("Image \(ref.id, privacy: .private) local file is empty/corrupt — skipping permanently this session")
+        } catch {
+            attemptedImageIDs.remove(ref.id)
+            failed += 1
+            logger.error("Image \(ref.id, privacy: .private) upload failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     /// Called by `RestoreCoordinator` after `applyRestore` mutates events.
-    /// For every event with an `agenticIntake.images` ref whose local file
-    /// is missing, download from Supabase Storage and write to the local
-    /// path the rest of the app expects. Sequential — typical restore won't
-    /// have thousands of images and we want to be a polite cloud citizen.
+    /// Walks both surfaces that carry image refs in the restored state —
+    /// `event.agenticIntake.images` AND `log.timelineItems.note(...).images`
+    /// — and downloads any whose local file is missing. Sequential; we
+    /// want to be a polite cloud citizen and a typical restore won't have
+    /// thousands of images.
     func downloadMissing(forEvents events: [Event]) async {
-        guard let storageService,
+        guard let eventStore,
+              let storageService,
               let userID = authService?.session?.user.id
         else { return }
 
-        struct Pending { let event: Event; let ref: AgenticIntakeImageRef; let localURL: URL }
+        // Tuple carries the `eventID` to use for the cloud path. For
+        // agentic-intake images that's the event's own id; for timeline-note
+        // images it's the parent log's `eventID` (same on-disk path scheme).
+        struct Pending {
+            let eventID: UUID
+            let ref: AgenticIntakeImageRef
+            let localURL: URL
+        }
         var pending: [Pending] = []
+
+        // 1. Agentic-intake images on events
         for event in events {
             guard let intake = event.agenticIntake else { continue }
             for ref in intake.images {
                 let localURL = assetStore.absoluteURL(for: ref)
                 if !FileManager.default.fileExists(atPath: localURL.path) {
-                    pending.append(Pending(event: event, ref: ref, localURL: localURL))
+                    pending.append(Pending(eventID: event.id, ref: ref, localURL: localURL))
+                }
+            }
+        }
+        // 2. Timeline-note images on log records (read live from store so
+        //    we cover all restored logs, not just those for the events we
+        //    were handed). Without this, log photos wouldn't survive
+        //    cross-device restore.
+        for log in eventStore.calendarEventLogRecords {
+            for item in log.timelineItems {
+                guard let note = item.noteValue else { continue }
+                for ref in note.images {
+                    let localURL = assetStore.absoluteURL(for: ref)
+                    if !FileManager.default.fileExists(atPath: localURL.path) {
+                        pending.append(Pending(eventID: log.eventID, ref: ref, localURL: localURL))
+                    }
                 }
             }
         }
@@ -179,7 +245,7 @@ final class ImageBackupCoordinator: ObservableObject {
             )
             let path = storageService.storagePath(
                 userID: userID,
-                eventID: p.event.id,
+                eventID: p.eventID,
                 imageID: p.ref.id
             )
             do {

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -122,6 +122,12 @@ final class ImageBackupCoordinator: ObservableObject {
                     // a fresh scan). Don't keep this in attempted so the
                     // next pass picks it up.
                     attemptedImageIDs.remove(ref.id)
+                } catch SupabaseImageStorageService.Error.emptyData {
+                    // Permanent: the local file is corrupt (0 bytes). KEEP
+                    // it in attemptedImageIDs so we don't log the same error
+                    // every store change. User would need to re-attach the
+                    // image to recover.
+                    logger.error("Image \(ref.id, privacy: .private) local file is empty/corrupt — skipping permanently this session")
                 } catch {
                     attemptedImageIDs.remove(ref.id)
                     failed += 1
@@ -157,13 +163,20 @@ final class ImageBackupCoordinator: ObservableObject {
         }
         guard !pending.isEmpty else { return }
         logger.info("Restore: downloading \(pending.count, privacy: .public) missing image(s)")
-        restoreDownloadProgress = DownloadProgress(current: 0, total: pending.count)
         defer { restoreDownloadProgress = nil }
 
         var ok = 0
         var fail = 0
         for (index, p) in pending.enumerated() {
-            restoreDownloadProgress = DownloadProgress(current: index, total: pending.count)
+            // 1-indexed for display: "Downloading images: 1 / N" while the
+            // first image is in flight (not "0 / N", which is confusing).
+            // The redundant final "(N, N)" assignment was dropped — `defer`
+            // nils the value immediately after method return so a frame at
+            // 100% is never actually visible to the user.
+            restoreDownloadProgress = DownloadProgress(
+                current: index + 1,
+                total: pending.count
+            )
             let path = storageService.storagePath(
                 userID: userID,
                 eventID: p.event.id,
@@ -188,7 +201,6 @@ final class ImageBackupCoordinator: ObservableObject {
                 logger.error("Image \(p.ref.id, privacy: .private) download failed: \(error.localizedDescription, privacy: .public)")
             }
         }
-        restoreDownloadProgress = DownloadProgress(current: pending.count, total: pending.count)
         logger.info("Restore: image download complete (\(ok, privacy: .public)/\(pending.count, privacy: .public) ok, \(fail, privacy: .public) failed)")
     }
 }

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Combine
+import os
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "Done",
+    category: "ImageBackup"
+)
+
+/// Observes the event stores and pushes any locally-attached image binaries
+/// to Supabase Storage. Per the L2 architecture in #21, this is the
+/// cross-platform / cross-Apple-ID image-backup path.
+///
+/// Design choices:
+///
+/// - **Pull-based, not push-based.** Rather than hooking every call site of
+///   `AgenticIntakeAssetStore.saveImages(...)` (5+ places), this coordinator
+///   observes `EventStore.$events` / `$calendarEvents` and uploads anything
+///   that hasn't been uploaded yet this session. Eventual consistency:
+///   crash / app-quit between save and upload is recovered on next launch.
+///
+/// - **In-memory attempt tracking** to avoid spamming the API. A `Set<UUID>`
+///   of image IDs we've already tried this session prevents repeat work for
+///   images we know are uploaded (or that just failed and we shouldn't
+///   hammer). On failure we remove from the set so the next store-change
+///   scan retries.
+///
+/// - **No cloud-side deletion in v1.** When the user deletes an event, the
+///   local image files are removed (`AgenticIntakeAssetStore.removeAssets`)
+///   but the corresponding Supabase Storage objects remain orphaned. A
+///   periodic garbage-collect follow-up will clean these up later — they
+///   don't affect correctness and the user is paying for their own egress
+///   anyway. Tracked separately.
+///
+/// - **DEBUG safety** is delegated to `SupabaseImageStorageService.upload`,
+///   which throws `.uploadsDisabled` in DEBUG and we silently swallow.
+@MainActor
+final class ImageBackupCoordinator: ObservableObject {
+    /// Live progress for the in-flight restore image fetch. Nil when no
+    /// restore download is happening. `RestoreSheet` observes this so the
+    /// "Applying restore…" view can surface a "Downloading N/M images"
+    /// line instead of a blind spinner during long downloads.
+    struct DownloadProgress: Equatable {
+        var current: Int
+        var total: Int
+    }
+    @Published private(set) var restoreDownloadProgress: DownloadProgress?
+
+    /// Long enough to coalesce a burst of edits, short enough that a freshly
+    /// attached photo lands in the cloud within seconds.
+    private static let scanDebounce: TimeInterval = 5
+
+    private let assetStore = AgenticIntakeAssetStore()
+    private weak var eventStore: EventStore?
+    private weak var authService: AuthService?
+    private var storageService: SupabaseImageStorageService?
+    private var attemptedImageIDs: Set<UUID> = []
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {}
+
+    /// Wire up. Idempotent — repeated calls clear prior subscriptions to
+    /// avoid duplicate uploads on view-graph rebuilds.
+    func attach(eventStore: EventStore, authService: AuthService) {
+        cancellables.removeAll()
+        self.eventStore = eventStore
+        self.authService = authService
+        self.storageService = SupabaseImageStorageService(authService: authService)
+
+        // Initial scan + change-driven scans. Merge both event lists into
+        // a unit-publisher so we don't run two parallel scans.
+        Publishers
+            .Merge(
+                eventStore.$events.map { _ in () },
+                eventStore.$calendarEvents.map { _ in () }
+            )
+            .debounce(for: .seconds(Self.scanDebounce), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { await self?.scanAndUpload(reason: "storeChange") }
+            }
+            .store(in: &cancellables)
+
+        // Also run once on attach so we pick up images attached before
+        // first observation fires (e.g. saved during prior launch).
+        Task { await scanAndUpload(reason: "attach") }
+    }
+
+    func scanAndUpload(reason: String) async {
+        guard let eventStore,
+              let storageService,
+              let userID = authService?.session?.user.id
+        else { return }
+
+        let allEvents = eventStore.events + eventStore.calendarEvents
+        var newlyUploaded = 0
+        var failed = 0
+        for event in allEvents {
+            guard let intake = event.agenticIntake else { continue }
+            for ref in intake.images {
+                guard !attemptedImageIDs.contains(ref.id) else { continue }
+                attemptedImageIDs.insert(ref.id)
+
+                let localURL = assetStore.absoluteURL(for: ref)
+                guard let data = try? Data(contentsOf: localURL) else {
+                    // Local file missing — nothing to upload. Could be a
+                    // restore-imminent state. Skip without erroring; will
+                    // try again if local file ever materializes.
+                    continue
+                }
+                let path = storageService.storagePath(
+                    userID: userID,
+                    eventID: event.id,
+                    imageID: ref.id
+                )
+                do {
+                    try await storageService.upload(path: path, data: data)
+                    newlyUploaded += 1
+                } catch SupabaseImageStorageService.Error.uploadsDisabled {
+                    // DEBUG path. Expected. No retry.
+                } catch SupabaseImageStorageService.Error.notSignedIn {
+                    // Will retry once user signs in (re-attach triggers
+                    // a fresh scan). Don't keep this in attempted so the
+                    // next pass picks it up.
+                    attemptedImageIDs.remove(ref.id)
+                } catch {
+                    attemptedImageIDs.remove(ref.id)
+                    failed += 1
+                    logger.error("Image \(ref.id, privacy: .private) upload failed: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+        if newlyUploaded > 0 || failed > 0 {
+            logger.info("Scan (\(reason, privacy: .public)): uploaded \(newlyUploaded, privacy: .public), failed \(failed, privacy: .public)")
+        }
+    }
+
+    /// Called by `RestoreCoordinator` after `applyRestore` mutates events.
+    /// For every event with an `agenticIntake.images` ref whose local file
+    /// is missing, download from Supabase Storage and write to the local
+    /// path the rest of the app expects. Sequential — typical restore won't
+    /// have thousands of images and we want to be a polite cloud citizen.
+    func downloadMissing(forEvents events: [Event]) async {
+        guard let storageService,
+              let userID = authService?.session?.user.id
+        else { return }
+
+        struct Pending { let event: Event; let ref: AgenticIntakeImageRef; let localURL: URL }
+        var pending: [Pending] = []
+        for event in events {
+            guard let intake = event.agenticIntake else { continue }
+            for ref in intake.images {
+                let localURL = assetStore.absoluteURL(for: ref)
+                if !FileManager.default.fileExists(atPath: localURL.path) {
+                    pending.append(Pending(event: event, ref: ref, localURL: localURL))
+                }
+            }
+        }
+        guard !pending.isEmpty else { return }
+        logger.info("Restore: downloading \(pending.count, privacy: .public) missing image(s)")
+        restoreDownloadProgress = DownloadProgress(current: 0, total: pending.count)
+        defer { restoreDownloadProgress = nil }
+
+        var ok = 0
+        var fail = 0
+        for (index, p) in pending.enumerated() {
+            restoreDownloadProgress = DownloadProgress(current: index, total: pending.count)
+            let path = storageService.storagePath(
+                userID: userID,
+                eventID: p.event.id,
+                imageID: p.ref.id
+            )
+            do {
+                guard let data = try await storageService.download(path: path) else {
+                    // 404 → not in cloud either. Image is lost; nothing to do.
+                    continue
+                }
+                try FileManager.default.createDirectory(
+                    at: p.localURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: p.localURL, options: .atomic)
+                // Mark as "attempted" so the upload scan doesn't try to
+                // re-upload the same bytes we just pulled down.
+                attemptedImageIDs.insert(p.ref.id)
+                ok += 1
+            } catch {
+                fail += 1
+                logger.error("Image \(p.ref.id, privacy: .private) download failed: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+        restoreDownloadProgress = DownloadProgress(current: pending.count, total: pending.count)
+        logger.info("Restore: image download complete (\(ok, privacy: .public)/\(pending.count, privacy: .public) ok, \(fail, privacy: .public) failed)")
+    }
+}

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -182,21 +182,28 @@ final class RestoreCoordinator: ObservableObject {
     private weak var eventStore: EventStore?
     private weak var eventTypeStore: EventTypeTemplateStore?
     private weak var skillStore: SkillInsightStore?
+    private weak var imageBackupCoordinator: ImageBackupCoordinator?
 
     init() {}
 
     /// Wire up dependencies after init. Must be called before `startFetch()`;
     /// allows the coordinator to be a `@StateObject` whose deps are created later.
+    /// `imageBackupCoordinator` is optional — when present, restore will pull
+    /// down any missing image binaries from Supabase Storage after applying
+    /// events (so user-attached photos survive cross-device / cross-account
+    /// recovery, per #22). Passing nil keeps the structured-only restore.
     func configure(
         syncService: SupabaseSyncService,
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
-        skillStore: SkillInsightStore
+        skillStore: SkillInsightStore,
+        imageBackupCoordinator: ImageBackupCoordinator? = nil
     ) {
         self.syncService = syncService
         self.eventStore = eventStore
         self.eventTypeStore = eventTypeStore
         self.skillStore = skillStore
+        self.imageBackupCoordinator = imageBackupCoordinator
     }
 
     var isConfigured: Bool { syncService != nil && eventStore != nil }
@@ -347,6 +354,18 @@ final class RestoreCoordinator: ObservableObject {
             eventTypeStore: eventTypeStore,
             skillStore: skillStore
         )
+
+        // After structured restore, pull any cloud-backed image binaries
+        // whose local files are missing (cross-device / cross-account
+        // recovery per #22). We await this on purpose so the user doesn't
+        // see "Restore complete" while photos are still streaming in.
+        // For very large image libraries this can be slow; a future polish
+        // could surface per-image progress in `RestoreSheet`'s applying view.
+        if let imageBackupCoordinator {
+            let allRestoredEvents = eventStore.events + eventStore.calendarEvents
+            await imageBackupCoordinator.downloadMissing(forEvents: allRestoredEvents)
+        }
+
         let resolutionForSummary: ConflictResolution? = strategy == .merge ? resolution : nil
         phase = .finished(summary, strategy, resolutionForSummary)
     }

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -1,0 +1,205 @@
+import Foundation
+import os
+
+private let logger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "Done",
+    category: "ImageStorage"
+)
+
+/// Supabase Storage client scoped to the `event-images` bucket. This is the
+/// L2 image-backup layer per the architecture in issue #21 — cross-platform,
+/// cross-Apple-ID recoverable, our cost.
+///
+/// **Auth model** (intentionally different from `SupabaseSyncService`):
+///
+/// `SupabaseSyncService` currently sends the project's service_role key in
+/// both `apikey` and `Authorization: Bearer ...` headers, which bypasses RLS
+/// entirely — the per-user isolation it provides is enforced application-side
+/// only. That's a pre-existing security debt tracked separately.
+///
+/// This service does it correctly: `apikey` carries the project key (for
+/// project routing) and `Authorization` carries the **user's session JWT**,
+/// so the RLS policies on `storage.objects` (`auth.uid()` checks on the path
+/// prefix) actually enforce isolation at the database. Anyone with the
+/// embedded project key can no longer read other users' images.
+///
+/// **DEBUG safety**: respects `uploadsDisabled` so simulator runs with a real
+/// Apple ID can't pollute the production bucket. Read paths stay live.
+@MainActor
+final class SupabaseImageStorageService {
+    static let bucket = "event-images"
+
+    private let url: String
+    private let projectAPIKey: String
+    private weak var authService: AuthService?
+
+    /// Mirrors `SupabaseSyncService.uploadsDisabled` — flipped on for DEBUG.
+    /// Reads are always allowed.
+    #if DEBUG
+    private static let uploadsDisabled = true
+    #else
+    private static let uploadsDisabled = false
+    #endif
+
+    init(
+        url: String = SupabaseSyncConfig.url,
+        projectAPIKey: String = SupabaseSyncConfig.anonKey,
+        authService: AuthService
+    ) {
+        self.url = url
+        self.projectAPIKey = projectAPIKey
+        self.authService = authService
+    }
+
+    // MARK: - Public API
+
+    /// Path convention `event-images/{user_id}/{eventID}/{imageID}.jpg`.
+    /// First path segment MUST be the user_id — RLS depends on it.
+    func storagePath(userID: String, eventID: UUID, imageID: UUID) -> String {
+        "\(userID)/\(eventID.uuidString)/\(imageID.uuidString).jpg"
+    }
+
+    /// Upload an image's bytes. Caller is responsible for compression; we
+    /// just pipe the bytes through. Throws `Error.uploadsDisabled` in DEBUG
+    /// so callers can no-op without surprising error logs.
+    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws {
+        if Self.uploadsDisabled {
+            throw Error.uploadsDisabled
+        }
+        // Don't let a 0-byte local file silently become a 0-byte cloud
+        // "image". `Data(contentsOf:)` on a truncated/corrupt file returns
+        // empty bytes without erroring; we'd otherwise upload garbage.
+        guard !data.isEmpty else {
+            throw Error.emptyData
+        }
+        // Refresh the JWT if it's close to expiry — a long upload that
+        // started with <5 min validity would otherwise 401 mid-flight.
+        await authService?.refreshTokenIfNeeded()
+        guard let token = authService?.accessToken else {
+            throw Error.notSignedIn
+        }
+        guard let requestURL = URL(string: "\(url)/storage/v1/object/\(Self.bucket)/\(path)") else {
+            throw Error.invalidPath(path)
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "POST"
+        request.setValue(projectAPIKey, forHTTPHeaderField: "apikey")
+        // ↓ User JWT, not the project key. This is what makes RLS work.
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        // x-upsert: false (default) so we don't silently overwrite when the
+        // same image ID is uploaded twice. Forces 409 instead and we can
+        // detect and skip.
+        request.setValue("false", forHTTPHeaderField: "x-upsert")
+        request.httpBody = data
+
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw Error.networkFailure
+        }
+
+        if http.statusCode == 409 {
+            // Object already exists at this path — treat as success since
+            // image IDs are UUIDs (uniqueness is on us; collision means we
+            // already uploaded the same image earlier).
+            logger.info("Image already uploaded, skipping: \(path, privacy: .private)")
+            return
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: responseData, encoding: .utf8) ?? ""
+            logger.error("Upload failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: http.statusCode)
+        }
+    }
+
+    /// Download an image's bytes. Returns nil if the object doesn't exist
+    /// (HTTP 404) — caller can interpret that as "not yet uploaded" rather
+    /// than a hard failure.
+    func download(path: String) async throws -> Data? {
+        await authService?.refreshTokenIfNeeded()
+        guard let token = authService?.accessToken else {
+            throw Error.notSignedIn
+        }
+        guard let requestURL = URL(string: "\(url)/storage/v1/object/\(Self.bucket)/\(path)") else {
+            throw Error.invalidPath(path)
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.setValue(projectAPIKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw Error.networkFailure
+        }
+        if http.statusCode == 404 {
+            return nil
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            logger.error("Download failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: http.statusCode)
+        }
+        return data
+    }
+
+    /// Delete one or more images. Best-effort — partial failures log and
+    /// proceed rather than throw, so a single missing key doesn't block the
+    /// rest of an event-deletion cleanup.
+    func delete(paths: [String]) async {
+        if Self.uploadsDisabled { return }
+        guard !paths.isEmpty else { return }
+        guard let token = authService?.accessToken else { return }
+
+        // Supabase Storage's REST DELETE endpoint accepts a JSON body
+        // `{ "prefixes": [...] }` for batch delete on
+        // `/storage/v1/object/<bucket>`. One round trip per call.
+        guard let requestURL = URL(string: "\(url)/storage/v1/object/\(Self.bucket)") else { return }
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "DELETE"
+        request.setValue(projectAPIKey, forHTTPHeaderField: "apikey")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["prefixes": paths])
+
+        do {
+            let (responseData, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse,
+               !(200..<300).contains(http.statusCode) {
+                let body = String(data: responseData, encoding: .utf8) ?? ""
+                logger.error("Delete (\(paths.count, privacy: .public) paths) HTTP \(http.statusCode, privacy: .public): \(body.prefix(200), privacy: .public)")
+            }
+        } catch {
+            logger.error("Delete failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    enum Error: Swift.Error, LocalizedError {
+        case notSignedIn
+        case uploadsDisabled
+        case emptyData
+        case invalidPath(String)
+        case networkFailure
+        case httpFailure(status: Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .notSignedIn:
+                return "Sign in before backing up images to the cloud."
+            case .uploadsDisabled:
+                return "Image uploads are disabled in this build (DEBUG safety net)."
+            case .emptyData:
+                return "Refusing to upload an empty (0-byte) image."
+            case .invalidPath(let p):
+                return "Invalid storage path: \(p)"
+            case .networkFailure:
+                return "Network failure during image storage call."
+            case .httpFailure(let s):
+                return "Image storage call failed (HTTP \(s))"
+            }
+        }
+    }
+}

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -612,6 +612,7 @@ struct DataPrivacySettingsView: View {
     @EnvironmentObject private var agentRuntime: AgentRuntime
     @EnvironmentObject private var skillStore: SkillInsightStore
     @EnvironmentObject private var restoreCoordinator: RestoreCoordinator
+    @EnvironmentObject private var imageBackupCoordinator: ImageBackupCoordinator
     @State private var isConfirmingSkillClear = false
     @State private var isConfirmingInferenceClear = false
     @State private var isConfirmingResetAll = false
@@ -671,10 +672,12 @@ struct DataPrivacySettingsView: View {
         .sheet(isPresented: $isPresentingRestoreSheet) {
             RestoreSheet()
                 .environmentObject(restoreCoordinator)
+                .environmentObject(imageBackupCoordinator)
         }
         .sheet(isPresented: $isPresentingPreviewSheet) {
             RestoreSheet(previewOnly: true)
                 .environmentObject(restoreCoordinator)
+                .environmentObject(imageBackupCoordinator)
         }
         .alert(L(.alertClearSkillInsights), isPresented: $isConfirmingSkillClear) {
             Button(L(.cancel), role: .cancel) {}

--- a/Done/Views/Agent/RestoreSheet.swift
+++ b/Done/Views/Agent/RestoreSheet.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// in the cloud before a real restore.
 struct RestoreSheet: View {
     @EnvironmentObject private var coordinator: RestoreCoordinator
+    @EnvironmentObject private var imageBackupCoordinator: ImageBackupCoordinator
     @Environment(\.dismiss) private var dismiss
     @State private var isConfirmingOverwrite = false
 
@@ -87,6 +88,15 @@ struct RestoreSheet: View {
                 .controlSize(.large)
             Text(label)
                 .foregroundStyle(.secondary)
+            // Surfaced specifically during the apply phase of restore when
+            // the image backup coordinator is fetching cloud-stored photos.
+            // Nil at all other times.
+            if let progress = imageBackupCoordinator.restoreDownloadProgress {
+                Text("Downloading images: \(progress.current) / \(progress.total)")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .monospacedDigit()
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding()

--- a/done-mcp/supabase/migrations/007_event_images_storage.sql
+++ b/done-mcp/supabase/migrations/007_event_images_storage.sql
@@ -1,0 +1,100 @@
+-- Event image binaries → Supabase Storage.
+--
+-- This is the L2 (cross-platform / cross-Apple-ID) layer for image backup,
+-- per the architecture decided in issue #21. Issue #16 (CloudKit) will
+-- eventually add an L1 same-Apple-ID fast path on top of this; today this
+-- bucket is the only cloud-side image backup.
+--
+-- Safety properties:
+--   - Bucket creation is idempotent (ON CONFLICT DO NOTHING) so re-running
+--     this migration won't fail if the bucket was created out-of-band.
+--   - Bucket is private; no anonymous access. All reads/writes must
+--     authenticate.
+--   - File size capped at 5 MB to match the compressed JPEG ceiling we
+--     produce in `AgenticIntakeAssetStore` (resized to 2048px,
+--     `jpegQuality: 0.82`, typically 200–500 KB). The 5 MB ceiling
+--     catches accidental upload of uncompressed raw images while leaving
+--     enough headroom for the occasional larger photo.
+--   - MIME types restricted to JPEG / PNG (the only formats we currently
+--     produce). HEIC isn't on the list because the asset store converts
+--     incoming HEIC to JPEG before storing.
+--   - RLS policies use the path's first folder segment as the user-id
+--     prefix. The bucket name is stored separately in `storage.objects.bucket_id`,
+--     so the `name` column actually contains `{user_id}/{eventID}/{imageID}.jpg`
+--     (no leading `event-images/`). `storage.foldername(name)[1]` returns
+--     the first segment, which equals `auth.uid()::text` when the path was
+--     written by the right user. The iOS client uploads to the URL
+--     `…/storage/v1/object/event-images/{user_id}/{eventID}/{imageID}.jpg`,
+--     and Supabase Storage parses out `bucket_id = 'event-images'` and
+--     `name = '{user_id}/{eventID}/{imageID}.jpg'`.
+--
+-- Auth note: the iOS client for these operations MUST pass the user's
+-- session JWT in `Authorization: Bearer <user_jwt>` for `auth.uid()` to
+-- resolve correctly. Existing PostgREST code in `SupabaseSyncService`
+-- uses the project's service_role key for both headers, which bypasses
+-- RLS — that's a separate security gap unrelated to this migration. New
+-- image-storage code uses user-JWT auth from day one (see
+-- `SupabaseImageStorageService`).
+
+-- ============================================================
+-- Bucket
+-- ============================================================
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'event-images',
+  'event-images',
+  false,                              -- private
+  5 * 1024 * 1024,                    -- 5 MB ceiling
+  array['image/jpeg', 'image/png']    -- only what AgenticIntakeAssetStore produces
+)
+on conflict (id) do nothing;
+
+-- ============================================================
+-- RLS — per-user folder isolation
+-- ============================================================
+-- `storage.objects.name` contains the path WITHIN the bucket (the bucket
+-- itself lives in `bucket_id`), so the stored value is
+-- `{user_id}/{eventID}/{imageID}.jpg`. `storage.foldername(name)` returns
+-- the path as a 1-indexed array; `[1]` is the first segment (= user_id).
+-- Comparing against `auth.uid()::text` restricts access to the
+-- authenticated user's own folder.
+--
+-- All four operations (SELECT/INSERT/UPDATE/DELETE) get policies even
+-- though the iOS client only currently issues SELECT/INSERT/DELETE — an
+-- explicit UPDATE policy is cheap insurance against future code paths.
+
+drop policy if exists "Users can read their own event images" on storage.objects;
+create policy "Users can read their own event images"
+  on storage.objects for select
+  using (
+    bucket_id = 'event-images'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "Users can insert their own event images" on storage.objects;
+create policy "Users can insert their own event images"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'event-images'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "Users can update their own event images" on storage.objects;
+create policy "Users can update their own event images"
+  on storage.objects for update
+  using (
+    bucket_id = 'event-images'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'event-images'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "Users can delete their own event images" on storage.objects;
+create policy "Users can delete their own event images"
+  on storage.objects for delete
+  using (
+    bucket_id = 'event-images'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary

Implements **#22** — cross-platform / cross-Apple-ID image backup, the L2 image layer per the architecture in **#21**. #16 (CloudKit L1 fast path) will later layer on top of this; this PR is the foundation.

Three new pieces:
- **Migration 007** (already applied to prod): private `event-images` bucket with file-size cap + MIME allowlist + four RLS policies keyed on path prefix
- **`SupabaseImageStorageService`** — REST wrapper using **user JWT** auth (not service_role), so RLS actually enforces per-user folder isolation
- **`ImageBackupCoordinator`** — pull-based upload (debounced scan on store changes) + restore-time download (called from `RestoreCoordinator.applyInternal`)

## Pre-push safety review

Ran a focused subagent review before applying migration to production. **No 🚨 blockers.** Verified migration idempotency, RLS correctness (path indexing into `storage.foldername` etc.), DEBUG safety net, env wiring, edge cases. Pre-push polish landed in this PR:
- Token pre-refresh before upload/download (avoids 401-mid-flight)
- 0-byte data guard (refuses to upload corrupt local files as 0-byte cloud objects)
- Restore download progress UI (\"Downloading images: X / N\" in applying-phase view)

## Auth pattern note

Intentionally **different** from existing `SupabaseSyncService`:
- `SupabaseSyncService` sends `apikey + Authorization` both with the service_role key → bypasses RLS → per-user isolation enforced **app-side only**. Pre-existing security debt.
- `SupabaseImageStorageService` sends `apikey = project_key` + `Authorization = Bearer <user_JWT>` → RLS actually enforces. Reverse-engineered service_role can't read other users' images.

Following the existing pattern would have widened the security gap to image data. Doing it right here costs one extra `await refreshTokenIfNeeded()` per call. A follow-up should migrate `SupabaseSyncService` to user-JWT to retire the service_role-in-client pattern entirely.

## DEBUG safety

Same gating pattern as `SupabaseSyncService` / `BackupSnapshotService`. In DEBUG: upload + delete are no-ops (throw `.uploadsDisabled`); only the download path stays live. Simulator runs with a real Apple ID cannot pollute the production bucket.

## What this doesn't do (follow-ups)

1. **Cloud-side deletion of orphans** — when an event is deleted, only local files are removed; the cloud object stays. Will fix in a periodic GC follow-up. Doesn't affect correctness, just storage cost.
2. **Pre-existing-image backfill on first run** — images attached before this ships will upload on the next time their parent event mutates (triggering a scan). To force-backfill all, you'd touch every event once.
3. **Per-image restore retry policy** — failed downloads log + skip; next launch + edit + scan retries.
4. **`SupabaseSyncService` user-JWT migration** — security upgrade, separate PR worth.

## Test plan

- [ ] Build clean: `xcodebuild -project Done.xcodeproj -scheme Done -destination 'generic/platform=iOS Simulator' build` returns BUILD SUCCEEDED
- [ ] DEBUG-readonly verified: in simulator, console shows no \`[ImageBackup]\` upload lines (only Release builds upload)
- [ ] Restore download path: in simulator, after running \"Restore from Cloud\" with restored events that have image refs, console shows \`[ImageBackup] Restore: downloading N missing image(s)\` followed by \`Restore: image download complete (X/N ok)\` — and the RestoreSheet's applying view shows \"Downloading images: X / N\"
- [ ] RLS sanity check: in Supabase dashboard, attempt to read \`event-images/<other-user-uuid>/...\` from a different user's auth context — should 401/403
- [ ] Migration 007 idempotency: re-running \`supabase db push\` is a no-op (already applied)

## Closes

Closes #22. Architecture: #21. Deferred companion: #16 (CloudKit L1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)