### PR TITLE
feat(sync): per-device upload toggle + Supabase Storage fixes from real-device test

### DIFF
--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -119,6 +119,10 @@ enum AppSettingsKeys {
     /// nothing is uploaded. Defaults to OFF so a fresh install on a new
     /// device doesn't surprise-write the user's cloud data. Independent of
     /// the DEBUG safety net, which always blocks uploads regardless.
+    ///
+    /// **DO NOT add to `SyncedSettings.allKeys`.** This key is per-device by
+    /// design — syncing it to the cloud would let one device override another
+    /// device's upload preference, which defeats the whole point of the toggle.
     static let syncUploadsEnabled = "syncUploadsEnabled"
 
     static let resettableUserDefaultsKeys: [String] = [

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -112,6 +112,15 @@ enum AppSettingsKeys {
     /// daily share sheet.
     static let calendarShareStyle = "calendarShareStyle"
 
+    // MARK: - Sync upload gate
+
+    /// User-controlled gate: when ON, this device pushes local changes to
+    /// Supabase. When OFF, the device only reads (restore still works) and
+    /// nothing is uploaded. Defaults to OFF so a fresh install on a new
+    /// device doesn't surprise-write the user's cloud data. Independent of
+    /// the DEBUG safety net, which always blocks uploads regardless.
+    static let syncUploadsEnabled = "syncUploadsEnabled"
+
     static let resettableUserDefaultsKeys: [String] = [
         agentProvider,
         agentAPIKey,
@@ -248,6 +257,7 @@ struct ContentView: View {
         .environmentObject(restoreCoordinator)
         .environmentObject(imageBackupCoordinator)
         .environmentObject(syncStatusReporter)
+        .environmentObject(syncService)
         // RestoreSheet's per-row review needs SkillInsightStore in env (the
         // sheet is presented from this view's body, outside the Profile-tab
         // NavigationStack where the store is otherwise injected).

--- a/Done/Models/SyncedSettings.swift
+++ b/Done/Models/SyncedSettings.swift
@@ -7,6 +7,13 @@ import Foundation
 /// Keep this list aligned with `AppSettingsKeys` + the misc `@AppStorage`
 /// keys used directly by views. Adding a key here automatically opts it into
 /// the sync — no schema migration needed (it's a JSON blob).
+///
+/// **Deliberately excluded — per-device by design:**
+///   - `AppSettingsKeys.syncUploadsEnabled` — the upload gate itself. If we
+///     synced it, one device flipping it on would push that choice to every
+///     other device on next restore, defeating the purpose of a per-device
+///     gate. Each device must own its own upload posture.
+///   - `agentAPIKey` — third-party provider credential (see note in line list).
 enum SyncedSettings {
     static let allKeys: [String] = [
         // ── General / tab behavior ──

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -140,6 +140,7 @@ final class ImageBackupCoordinator: ObservableObject {
         if trackInUI { statusReporter?.imagesDidStart() }
 
         var newlyUploaded = 0
+        var alreadyInCloud = 0
         var failed = 0
 
         // 1. Agentic-intake images on the event itself.
@@ -153,6 +154,7 @@ final class ImageBackupCoordinator: ObservableObject {
                     userID: userID,
                     storageService: storageService,
                     newlyUploaded: &newlyUploaded,
+                    alreadyInCloud: &alreadyInCloud,
                     failed: &failed
                 )
             }
@@ -175,20 +177,31 @@ final class ImageBackupCoordinator: ObservableObject {
                         userID: userID,
                         storageService: storageService,
                         newlyUploaded: &newlyUploaded,
+                        alreadyInCloud: &alreadyInCloud,
                         failed: &failed
                     )
                 }
             }
         }
 
-        if newlyUploaded > 0 || failed > 0 {
-            logger.info("Scan (\(reason, privacy: .public)): uploaded \(newlyUploaded, privacy: .public), failed \(failed, privacy: .public)")
+        if newlyUploaded > 0 || alreadyInCloud > 0 || failed > 0 {
+            logger.info("Scan (\(reason, privacy: .public)): \(newlyUploaded, privacy: .public) new, \(alreadyInCloud, privacy: .public) already in cloud, \(failed, privacy: .public) failed")
         }
         if trackInUI {
             if failed == 0 {
-                statusReporter?.imagesDidSucceed(detail: "\(newlyUploaded) uploaded")
+                // Compose a useful detail string that doesn't lie. "0 new"
+                // when everything was already in cloud is honest; "N uploaded"
+                // when it was really a no-op dedup pass would be misleading.
+                let detail: String
+                switch (newlyUploaded, alreadyInCloud) {
+                case (0, 0):                 detail = "no changes"
+                case (0, let dedup):         detail = "\(dedup) already in cloud"
+                case (let n, 0):             detail = "\(n) uploaded"
+                case (let n, let dedup):     detail = "\(n) new, \(dedup) already in cloud"
+                }
+                statusReporter?.imagesDidSucceed(detail: detail)
             } else {
-                statusReporter?.imagesDidFail("\(failed) of \(newlyUploaded + failed) failed")
+                statusReporter?.imagesDidFail("\(failed) of \(newlyUploaded + alreadyInCloud + failed) failed")
             }
         }
     }
@@ -238,6 +251,7 @@ final class ImageBackupCoordinator: ObservableObject {
         userID: String,
         storageService: SupabaseImageStorageService,
         newlyUploaded: inout Int,
+        alreadyInCloud: inout Int,
         failed: inout Int
     ) async {
         guard !attemptedImageIDs.contains(ref.id) else { return }
@@ -256,8 +270,12 @@ final class ImageBackupCoordinator: ObservableObject {
             imageID: ref.id
         )
         do {
-            try await storageService.upload(path: path, data: data)
-            newlyUploaded += 1
+            let didWriteNewBytes = try await storageService.upload(path: path, data: data)
+            if didWriteNewBytes {
+                newlyUploaded += 1
+            } else {
+                alreadyInCloud += 1
+            }
         } catch SupabaseImageStorageService.Error.uploadsDisabled {
             // DEBUG path. Expected. No retry.
         } catch SupabaseImageStorageService.Error.notSignedIn {

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -56,6 +56,11 @@ final class ImageBackupCoordinator: ObservableObject {
     weak var statusReporter: SyncStatusReporter?
     private var storageService: SupabaseImageStorageService?
     private var attemptedImageIDs: Set<UUID> = []
+    /// Re-entry guard for `scanAndUpload`. `storeChange` debounce +
+    /// `userDidEnableUploads` + `attach`-time scan can otherwise overlap.
+    /// The work is per-image idempotent at the Storage layer, but overlap
+    /// would emit double `imagesDidStart` and clutter the status timeline.
+    private var scanInFlight = false
     private var cancellables = Set<AnyCancellable>()
 
     init() {}
@@ -100,6 +105,12 @@ final class ImageBackupCoordinator: ObservableObject {
               let storageService,
               let userID = authService?.session?.user.id
         else { return }
+        // Re-entry guard. The in-flight scan will already pick up any new
+        // candidates that landed since it started, so dropping the duplicate
+        // is correct, not just an optimization.
+        if scanInFlight { return }
+        scanInFlight = true
+        defer { scanInFlight = false }
 
         // Pre-scan: count work so we can decide whether to surface activity.
         // Cheap relative to the actual upload; avoids spinner flicker on

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -86,6 +86,15 @@ final class ImageBackupCoordinator: ObservableObject {
         Task { await scanAndUpload(reason: "attach") }
     }
 
+    /// Called by the settings UI when the user flips the upload toggle from
+    /// OFF → ON. Clears the in-session suppression cache so images we tagged
+    /// as "attempted" during the disabled period get re-evaluated and pushed
+    /// to the cloud on this fresh scan.
+    func userDidEnableUploads() {
+        attemptedImageIDs.removeAll()
+        Task { await scanAndUpload(reason: "userEnabledUploads") }
+    }
+
     func scanAndUpload(reason: String) async {
         guard let eventStore,
               let storageService,
@@ -99,14 +108,21 @@ final class ImageBackupCoordinator: ObservableObject {
             eventStore: eventStore,
             attemptedImageIDs: attemptedImageIDs
         )
-        // In DEBUG the upload throws `.uploadsDisabled` immediately; we
-        // shouldn't emit a fake "0 uploaded ✓" — surface a no-op note
-        // instead so the user can see why nothing is moving. Mark current
-        // candidates as "attempted" so the no-op is one-shot per image,
-        // not re-pinged on every store edit for the rest of the session.
-        if candidateCount > 0 && SupabaseImageStorageService.uploadsDisabled {
+        // Two independent gates can disable uploads:
+        //  1. DEBUG safety net (compile-time) — simulator/dev builds never write
+        //  2. User toggle (`syncUploadsEnabled`) — Release users opt-in per device
+        // Either gate active → surface a one-shot "disabled" note + suppress
+        // future re-pings (mark all current candidates as attempted), and
+        // bail before any I/O. The reason label distinguishes the two so a
+        // confused user can tell whether it's a dev build or their toggle.
+        let userToggle = UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
+        if candidateCount > 0,
+           SupabaseImageStorageService.uploadsDisabled || !userToggle {
             Self.collectCandidateIDs(eventStore: eventStore, into: &attemptedImageIDs)
-            statusReporter?.imagesDidNoOp(detail: "disabled (DEBUG)")
+            let reason = SupabaseImageStorageService.uploadsDisabled
+                ? "disabled (DEBUG)"
+                : "uploads off (Settings)"
+            statusReporter?.imagesDidNoOp(detail: reason)
             return
         }
         let trackInUI = candidateCount > 0

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -141,6 +141,18 @@ final class SupabaseImageStorageService {
             return nil
         }
         guard (200..<300).contains(http.statusCode) else {
+            // Supabase Storage doesn't always honor the outer HTTP status —
+            // a missing object can come back as HTTP 400 with a JSON body
+            // that says `{"statusCode":"404","error":"not_found",...}`.
+            // Without inspecting the body we'd treat that as a hard failure
+            // and the restore flow would report e.g. "5 of 50 failed" for
+            // images whose binaries just weren't uploaded yet (a common
+            // case during cross-device restore). Surface those as nil so
+            // the caller can `continue` past them, same as a real 404.
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               (json["statusCode"] as? String) == "404" {
+                return nil
+            }
             let body = String(data: data, encoding: .utf8) ?? ""
             logger.error("Download failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
             throw Error.httpFailure(status: http.statusCode)

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -37,14 +37,11 @@ final class SupabaseImageStorageService {
     /// Reads are always allowed. Public so the sync-status UI can label the
     /// Images channel as "disabled (DEBUG)" instead of falsely claiming
     /// successful uploads from simulator runs.
-    // ⚠️ TEMPORARY BYPASS FOR REAL-DEVICE TESTING — DO NOT COMMIT
-    // Restore the #if DEBUG block below after the device build is on hardware.
+    #if DEBUG
+    static let uploadsDisabled = true
+    #else
     static let uploadsDisabled = false
-    // #if DEBUG
-    // static let uploadsDisabled = true
-    // #else
-    // static let uploadsDisabled = false
-    // #endif
+    #endif
 
     init(
         url: String = SupabaseSyncConfig.url,

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -100,8 +100,9 @@ final class SupabaseImageStorageService {
         guard let http = response as? HTTPURLResponse else {
             throw Error.networkFailure
         }
+        let effective = Self.effectiveStatusCode(httpStatus: http.statusCode, body: responseData)
 
-        if http.statusCode == 409 {
+        if effective == 409 {
             // Object already exists at this path — treat as success since
             // image IDs are UUIDs (uniqueness is on us; collision means we
             // already uploaded the same image earlier).
@@ -109,10 +110,10 @@ final class SupabaseImageStorageService {
             return
         }
 
-        guard (200..<300).contains(http.statusCode) else {
+        guard (200..<300).contains(effective) else {
             let body = String(data: responseData, encoding: .utf8) ?? ""
-            logger.error("Upload failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
-            throw Error.httpFailure(status: http.statusCode)
+            logger.error("Upload failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: effective)
         }
     }
 
@@ -137,27 +138,39 @@ final class SupabaseImageStorageService {
         guard let http = response as? HTTPURLResponse else {
             throw Error.networkFailure
         }
-        if http.statusCode == 404 {
+        let effective = Self.effectiveStatusCode(httpStatus: http.statusCode, body: data)
+        if effective == 404 {
             return nil
         }
-        guard (200..<300).contains(http.statusCode) else {
-            // Supabase Storage doesn't always honor the outer HTTP status —
-            // a missing object can come back as HTTP 400 with a JSON body
-            // that says `{"statusCode":"404","error":"not_found",...}`.
-            // Without inspecting the body we'd treat that as a hard failure
-            // and the restore flow would report e.g. "5 of 50 failed" for
-            // images whose binaries just weren't uploaded yet (a common
-            // case during cross-device restore). Surface those as nil so
-            // the caller can `continue` past them, same as a real 404.
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               (json["statusCode"] as? String) == "404" {
-                return nil
-            }
+        guard (200..<300).contains(effective) else {
             let body = String(data: data, encoding: .utf8) ?? ""
-            logger.error("Download failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
-            throw Error.httpFailure(status: http.statusCode)
+            logger.error("Download failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: effective)
         }
         return data
+    }
+
+    /// Supabase Storage's REST endpoint wraps real status codes inside the
+    /// response body and returns HTTP 400 at the transport layer:
+    ///
+    ///     HTTP 400 + body `{"statusCode":"404", ...}`  → not found
+    ///     HTTP 400 + body `{"statusCode":"409", ...}`  → duplicate
+    ///     HTTP 400 + body `{"statusCode":"413", ...}`  → payload too large
+    ///
+    /// Without unwrapping the body, every error looks like a generic 400 and
+    /// callers can't branch on the real semantics (treat 404 as nil-continue,
+    /// treat 409 as already-uploaded success, surface 413 to the user, etc.).
+    /// This helper decodes the wrapped status when the outer code is non-2xx.
+    /// Returns the outer code unchanged on 2xx responses, or when the body
+    /// isn't the expected shape.
+    private static func effectiveStatusCode(httpStatus: Int, body: Data) -> Int {
+        if (200..<300).contains(httpStatus) { return httpStatus }
+        if let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+           let raw = json["statusCode"] as? String,
+           let parsed = Int(raw) {
+            return parsed
+        }
+        return httpStatus
     }
 
     /// Delete one or more images. Best-effort — partial failures log and

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -37,11 +37,14 @@ final class SupabaseImageStorageService {
     /// Reads are always allowed. Public so the sync-status UI can label the
     /// Images channel as "disabled (DEBUG)" instead of falsely claiming
     /// successful uploads from simulator runs.
-    #if DEBUG
-    static let uploadsDisabled = true
-    #else
+    // ⚠️ TEMPORARY BYPASS FOR REAL-DEVICE TESTING — DO NOT COMMIT
+    // Restore the #if DEBUG block below after the device build is on hardware.
     static let uploadsDisabled = false
-    #endif
+    // #if DEBUG
+    // static let uploadsDisabled = true
+    // #else
+    // static let uploadsDisabled = false
+    // #endif
 
     init(
         url: String = SupabaseSyncConfig.url,
@@ -64,7 +67,15 @@ final class SupabaseImageStorageService {
     /// Upload an image's bytes. Caller is responsible for compression; we
     /// just pipe the bytes through. Throws `Error.uploadsDisabled` in DEBUG
     /// so callers can no-op without surprising error logs.
-    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws {
+    ///
+    /// Returns `true` when the bytes were actually written this call, `false`
+    /// when the object was already present in the cloud at this exact path
+    /// (a 409 dedup outcome — Supabase wraps that as HTTP 400 + body 409,
+    /// see `effectiveStatusCode`). Callers want this distinction so the
+    /// `Scan: N uploaded, M dedup'd` accounting reflects reality instead of
+    /// claiming N new uploads when nothing actually went over the wire.
+    @discardableResult
+    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws -> Bool {
         if Self.uploadsDisabled {
             throw Error.uploadsDisabled
         }
@@ -107,7 +118,7 @@ final class SupabaseImageStorageService {
             // image IDs are UUIDs (uniqueness is on us; collision means we
             // already uploaded the same image earlier).
             logger.info("Image already uploaded, skipping: \(path, privacy: .private)")
-            return
+            return false
         }
 
         guard (200..<300).contains(effective) else {
@@ -115,6 +126,7 @@ final class SupabaseImageStorageService {
             logger.error("Upload failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
             throw Error.httpFailure(status: effective)
         }
+        return true
     }
 
     /// Download an image's bytes. Returns nil if the object doesn't exist

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -180,6 +180,14 @@ final class SupabaseSyncService: ObservableObject {
     /// `ContentView` at attach time; nil-tolerant so the service still works
     /// in tests / standalone contexts without reporter plumbing.
     weak var statusReporter: SyncStatusReporter?
+
+    /// Cached store references so `userDidEnableUploads()` can run a fresh
+    /// `fullSync` without re-attaching the Combine pipeline. Set in `attach`,
+    /// nilled implicitly by weak semantics if the stores go away.
+    private weak var attachedEventStore: EventStore?
+    private weak var attachedEventTypeStore: EventTypeTemplateStore?
+    private weak var attachedSkillStore: SkillInsightStore?
+
     private var cancellables = Set<AnyCancellable>()
     private let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -208,16 +216,42 @@ final class SupabaseSyncService: ObservableObject {
         self.rest = SupabaseREST(url: url, apiKey: apiKey)
     }
 
-    /// In DEBUG builds we disable all upload paths (fullSync + the per-store
-    /// Combine sinks) so simulator/dev runs can sign in with a real account
-    /// without polluting the production Supabase tables. Read paths
-    /// (`fetchAllRawRows`) stay live so dry-run preview and restore still work.
-    /// Release builds always sync normally.
+    /// DEBUG safety net: compile-time block that prevents any simulator or
+    /// dev-built binary from writing to the production Supabase project.
+    /// Independent of the user-controlled `syncUploadsEnabled` toggle — DEBUG
+    /// blocks regardless of what the user picked, so accidental builds can
+    /// never pollute prod. Read paths (`fetchAllRawRows`) stay live in both
+    /// modes so dry-run preview and restore still work.
     #if DEBUG
-    private static let uploadsDisabled = true
+    static let debugBlocksUploads = true
     #else
-    private static let uploadsDisabled = false
+    static let debugBlocksUploads = false
     #endif
+
+    /// Runtime gate: are uploads currently allowed for this device?
+    /// `debugBlocksUploads` (compile-time) AND `syncUploadsEnabled` (user
+    /// toggle, defaults OFF on a fresh install). Read on every sync entry
+    /// point so flipping the toggle takes effect on the very next debounce
+    /// without needing to re-attach the Combine pipeline.
+    nonisolated var canUpload: Bool {
+        if Self.debugBlocksUploads { return false }
+        return UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
+    }
+
+    /// Called by the settings UI when the user flips the upload toggle from
+    /// OFF → ON. Triggers a fresh fullSync to catch up the cloud with all
+    /// the local changes that accumulated while uploads were paused.
+    func userDidEnableUploads() {
+        guard canUpload, !userId.isEmpty else { return }
+        guard let es = attachedEventStore,
+              let ets = attachedEventTypeStore,
+              let ss = attachedSkillStore else { return }
+        Task {
+            self.isFullSyncDone = false
+            await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
+            self.isFullSyncDone = true
+        }
+    }
 
     /// Start observing stores. Call once after stores are initialized.
     func attach(
@@ -227,23 +261,28 @@ final class SupabaseSyncService: ObservableObject {
         skillStore: SkillInsightStore
     ) {
         self.authService = authService
+        self.attachedEventStore = eventStore
+        self.attachedEventTypeStore = eventTypeStore
+        self.attachedSkillStore = skillStore
         let debounce = SupabaseSyncConfig.debounceSeconds
 
-        if Self.uploadsDisabled {
+        if Self.debugBlocksUploads {
             logger.notice("⚠️ DEBUG build — uploads disabled. Auth + read-only sync only. Restore (GET) still works.")
         }
 
         // ── Watch auth state: keep userId in lockstep with session in all
         //    builds (fetchAllRawRows needs it). Skip the upload-side fullSync
-        //    when uploads are disabled.
+        //    when uploads are disabled by either gate (DEBUG or user toggle).
         authService.$session
             .sink { [weak self, weak eventStore, weak eventTypeStore, weak skillStore] session in
                 guard let self else { return }
                 if let session {
                     self.userId = session.user.id
-                    if Self.uploadsDisabled {
+                    if !self.canUpload {
                         // Mark "ready" so any code gated on isFullSyncDone still
-                        // works as expected (no harm — there are no sinks to gate).
+                        // works as expected. No fullSync — that runs when the
+                        // toggle flips on (see `userDidEnableUploads`) or when
+                        // the next debounced sink fires with the toggle on.
                         self.isFullSyncDone = true
                         return
                     }
@@ -264,15 +303,17 @@ final class SupabaseSyncService: ObservableObject {
 
         // In DEBUG, skip wiring up any of the upload-side Combine sinks below.
         // The signed-in userId is still set above so `fetchAllRawRows()` works,
-        // but nothing on the device will ever be pushed to Supabase.
-        if Self.uploadsDisabled { return }
+        // but nothing on the device will ever be pushed to Supabase. In Release
+        // we wire the sinks unconditionally — each sink body checks `canUpload`
+        // so the user toggle takes effect dynamically.
+        if Self.debugBlocksUploads { return }
 
         // ── Todo events ──
         eventStore.$events
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] events in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEvents(events, kind: "todo") }
             }
             .store(in: &cancellables)
@@ -282,7 +323,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] events in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEvents(events, kind: "calendar") }
             }
             .store(in: &cancellables)
@@ -292,7 +333,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] logs in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncLogs(logs) }
             }
             .store(in: &cancellables)
@@ -302,7 +343,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] records in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncFeedback(records) }
             }
             .store(in: &cancellables)
@@ -312,7 +353,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] lists in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncTodoLists(lists) }
             }
             .store(in: &cancellables)
@@ -322,7 +363,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] templates in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEventTypes(templates) }
             }
             .store(in: &cancellables)
@@ -332,7 +373,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] insights in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncSkills(insights) }
             }
             .store(in: &cancellables)
@@ -345,7 +386,7 @@ final class SupabaseSyncService: ObservableObject {
             .publisher(for: UserDefaults.didChangeNotification)
             .debounce(for: .seconds(5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncSettings() }
             }
             .store(in: &cancellables)

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -209,6 +209,13 @@ final class SupabaseSyncService: ObservableObject {
 
     private var isFullSyncDone = false
 
+    /// Re-entry guard for `fullSync`. The sign-in path and
+    /// `userDidEnableUploads` can both kick off a fullSync; rapid toggle
+    /// flipping could otherwise spawn N parallel passes that idempotent-upsert
+    /// the same rows and stretch the `isFullSyncDone == false` window that
+    /// blocks debounced sinks. Set inside the Task, cleared in defer.
+    private var fullSyncInFlight = false
+
     init(
         url: String = SupabaseSyncConfig.url,
         apiKey: String = SupabaseSyncConfig.anonKey
@@ -240,13 +247,17 @@ final class SupabaseSyncService: ObservableObject {
 
     /// Called by the settings UI when the user flips the upload toggle from
     /// OFF → ON. Triggers a fresh fullSync to catch up the cloud with all
-    /// the local changes that accumulated while uploads were paused.
+    /// the local changes that accumulated while uploads were paused. If a
+    /// fullSync is already in flight (e.g. rapid OFF→ON→OFF→ON), this is a
+    /// no-op — the in-flight pass already covers the catch-up work.
     func userDidEnableUploads() {
-        guard canUpload, !userId.isEmpty else { return }
+        guard canUpload, !userId.isEmpty, !fullSyncInFlight else { return }
         guard let es = attachedEventStore,
               let ets = attachedEventTypeStore,
               let ss = attachedSkillStore else { return }
         Task {
+            self.fullSyncInFlight = true
+            defer { self.fullSyncInFlight = false }
             self.isFullSyncDone = false
             await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
             self.isFullSyncDone = true
@@ -286,8 +297,11 @@ final class SupabaseSyncService: ObservableObject {
                         self.isFullSyncDone = true
                         return
                     }
-                    if let es = eventStore, let ets = eventTypeStore, let ss = skillStore {
+                    if let es = eventStore, let ets = eventTypeStore, let ss = skillStore,
+                       !self.fullSyncInFlight {
                         Task {
+                            self.fullSyncInFlight = true
+                            defer { self.fullSyncInFlight = false }
                             self.isFullSyncDone = false
                             await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
                             self.isFullSyncDone = true

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -701,6 +701,16 @@ struct DataPrivacySettingsView: View {
                         )
                     }
                 }
+                // Without this hint the card looks broken when the toggle is
+                // off — three idle rows with no obvious reason. Surface the
+                // gate state directly so the user can connect cause and effect.
+                if !syncUploadsEnabled {
+                    Text("Uploads are off for this device. Flip the Sync toggle above to start pushing changes to the cloud.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             settingsCard(L(.manageData)) {

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -614,6 +614,8 @@ struct DataPrivacySettingsView: View {
     @EnvironmentObject private var restoreCoordinator: RestoreCoordinator
     @EnvironmentObject private var imageBackupCoordinator: ImageBackupCoordinator
     @EnvironmentObject private var syncStatusReporter: SyncStatusReporter
+    @EnvironmentObject private var syncService: SupabaseSyncService
+    @AppStorage(AppSettingsKeys.syncUploadsEnabled) private var syncUploadsEnabled = false
     @State private var isConfirmingSkillClear = false
     @State private var isConfirmingInferenceClear = false
     @State private var isConfirmingResetAll = false
@@ -628,6 +630,26 @@ struct DataPrivacySettingsView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            settingsCard("Sync", spacing: 14) {
+                Toggle(isOn: $syncUploadsEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Upload this device's data to the cloud")
+                            .font(.subheadline.weight(.medium))
+                        Text("When off, this device only reads (restore still works). Off by default so a fresh install never surprise-writes your cloud data. Independent per device — your other devices keep their own setting.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                #if DEBUG
+                Text("Debug build: uploads are blocked regardless of this toggle as an extra safety net. Use a Release build to actually exercise the cloud write path.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                #endif
             }
 
             settingsCard("Cloud Backup", spacing: 14) {
@@ -704,6 +726,15 @@ struct DataPrivacySettingsView: View {
             RestoreSheet(previewOnly: true)
                 .environmentObject(restoreCoordinator)
                 .environmentObject(imageBackupCoordinator)
+        }
+        .onChange(of: syncUploadsEnabled) { oldValue, newValue in
+            // OFF → ON: catch the cloud up with everything that accumulated
+            // while uploads were paused. Triggers a full structured-data
+            // sync and clears the image-suppression cache so previously
+            // skipped images get re-evaluated.
+            guard !oldValue, newValue else { return }
+            syncService.userDidEnableUploads()
+            imageBackupCoordinator.userDidEnableUploads()
         }
         .alert(L(.alertClearSkillInsights), isPresented: $isConfirmingSkillClear) {
             Button(L(.cancel), role: .cancel) {}

--- a/done-mcp/supabase/migrations/008_event_images_bucket_size.sql
+++ b/done-mcp/supabase/migrations/008_event_images_bucket_size.sql
@@ -1,0 +1,44 @@
+-- Bump the `event-images` bucket file-size cap from 5 MB → 100 MB.
+--
+-- Why:
+-- Real-device testing surfaced a real-world failure mode: some legacy or
+-- pre-resize-pipeline image assets exceed the original 5 MB ceiling that
+-- migration 007 set as a "defensive safety net". The ceiling was sized
+-- against the compressed JPEG ceiling produced by `AgenticIntakeAssetStore`
+-- (2048px, q=0.82, typically 200–500 KB), but a handful of legacy assets
+-- (pre-compression, or HEIC originals that didn't run through the convert
+-- path, or panoramas) come in larger than expected. Those images currently
+-- fail upload with HTTP 413 "Payload too large", which then cascades to
+-- restore-side "object not found" errors on every other device.
+--
+-- 100 MB comfortably accommodates:
+--   - iPhone HEIC / RAW photos (typically 3–10 MB)
+--   - JPEG panoramas (often 20–40 MB)
+--   - the worst-case original-quality `UIImage.jpegData(compressionQuality:)`
+--     bypass path if compression ever regresses
+--
+-- It also intentionally keeps a finite limit: an unlimited bucket would
+-- silently absorb a GB-scale upload if a future code path accidentally
+-- routed a video file or screenshot recording into image storage. 100 MB
+-- is large enough to never block a legitimate photo, small enough to
+-- catch obvious misuse.
+--
+-- Reversible: a follow-up migration can lower the limit back to 5 MB if
+-- we ever decide the storage cost is meaningful. Existing rows above the
+-- new (lower) limit would remain accessible; only new uploads would be
+-- constrained.
+--
+-- Storage cost rough math (single user):
+--   50 images × ~5 MB avg ≈ 250 MB. Supabase Pro tier includes 100 GB
+--   storage, so this is ~0.25% of a single user's storage budget. At
+--   10k users with similar usage we'd consume ~2.5 TB and pay roughly
+--   $50/mo on the storage-overage line — still cheap relative to the
+--   restore-correctness benefit.
+--
+-- Follow-up (not in this migration): expose a per-app warning when a
+-- single upload exceeds, say, 25 MB, so the user knows it's eating into
+-- their device backup quota even though it's allowed. Tracked separately.
+
+update storage.buckets
+set file_size_limit = 100 * 1024 * 1024  -- 100 MB
+where id = 'event-images';


### PR DESCRIPTION
Replaces #31 (auto-closed when #27 merged and its base branch was deleted). Same branch, same 8 commits, now against \`main\`.

## Phase A — per-device upload toggle

Runtime, per-device gate so users (and dev builds) can opt into Supabase uploads. Default OFF; restore reads still work regardless.

\`\`\`
canUpload = !debugBlocksUploads && UserDefaults.bool(\"syncUploadsEnabled\")
\`\`\`

DEBUG safety net stays as belt-and-suspenders (compile-time block on simulator / dev builds even when the toggle is ON). The toggle is the user-facing primary control.

- \`daf8b8e\` — service-layer gate. \`SupabaseSyncService\` renames \`uploadsDisabled\` → \`debugBlocksUploads\`, adds computed \`canUpload\`, wires every sink body to check it. New \`userDidEnableUploads()\` runs a fresh fullSync on OFF→ON. \`ImageBackupCoordinator\` mirrors with its own \`userDidEnableUploads()\` that clears the suppression cache.
- \`c2435e8\` — UI toggle in Data & Privacy. \`.onChange\` on OFF→ON calls into both services. \`#if DEBUG\` caption explains the override.
- \`7faf0ec\` — addresses subagent review: overlap guards (\`fullSyncInFlight\`, \`scanInFlight\`) for rapid toggle flipping, defensive doc that \`syncUploadsEnabled\` must stay per-device (not in \`SyncedSettings.allKeys\`), and a contextual hint in the Sync Status card explaining the OFF state.

## Real-device bug fixes

Four discrete issues surfaced during real-device testing of the cloud-storage layer. Each was its own root cause; bundled here because they all came out of the same testing pass.

- \`27fce38\` — Migration 008 raises the \`event-images\` bucket size cap from 5 MB → 100 MB. The original 5 MB was a defensive ceiling sized for \`AgenticIntakeAssetStore\`'s compressed JPEG output (typically 200–500 KB), but a handful of legacy / panorama / HEIC assets exceeded it and were hitting HTTP 413, which cascaded into restore-side \"object not found\" failures on every other device. **Already applied to remote DB.**
- \`1ad8687\` — Treat Supabase Storage's HTTP 400 + body \`statusCode: \"404\"\` as object-not-found. The download path had been throwing on these as if they were hard errors; a cross-device restore would report \"5 of 50 failed\" for binaries that were simply absent.
- \`de32656\` — Same body-vs-HTTP discrepancy hits the upload path. Supabase returns HTTP 400 + body \`statusCode: \"409\"\` for duplicate writes. The existing \`http.statusCode == 409\` check never matched. Extracted \`effectiveStatusCode(httpStatus:body:)\` helper so upload and download share the unwrapping logic.
- \`25b3dff\` — \`upload()\` now returns \`Bool\` (true = bytes went over the wire, false = already-in-cloud dedup). Coordinator tracks \`newlyUploaded\` and \`alreadyInCloud\` separately. The Sync Status detail string and the log line now reflect what actually happened.

## Review fix (caught in /review pass)

- \`5517600\` — Critical: the DEBUG bypass marker (\"DO NOT COMMIT\") was applied to \`SupabaseImageStorageService.uploadsDisabled\` during a real-device test cycle and not reverted before the original push. The partner constant in \`SupabaseSyncService.debugBlocksUploads\` had been reverted correctly; this file was missed. Restored the original \`#if DEBUG\` block so dev builds can't silently write to prod.

## Manual verification done

- ⚠️ DEBUG safety net is on, user toggle OFF → no uploads happen, restore preview still fetches
- Toggle ON in Release build (bypass build for real-device test) → fullSync uploads 858 events + 208 logs + 864 skill_insights + 50 images
- After Migration 008 + Fix C + Fix D: scan reports honest dedup counts; 5 oversized images that previously hit 413 now upload successfully

## Out of scope (followups filed)

- **#29** — configurable per-user image size threshold + warn at save when an image is unusually large
- **#30** — persist diff-sync row hashes across launches so a second launch with no edits doesn't show \"N changed\" for every table
- **#28** — service_role → user-JWT migration (separate security debt; not regressed by this PR)

## Test plan

- [ ] Fresh install on simulator → confirm toggle defaults OFF, Sync Status card shows \"Uploads are off\" hint, no Combine sinks fire on edits
- [ ] Restore preview from simulator → reads cloud data, downloads images, no \"X of Y failed\" lines for already-in-cloud binaries
- [ ] Toggle ON in Release build → confirm fullSync runs, image scan reports honest \"N new, M already in cloud\" counts
- [ ] Toggle OFF→ON→OFF→ON in quick succession → no overlapping fullSync (overlap guards)
- [ ] Confirm \`syncUploadsEnabled\` is NOT in \`SyncedSettings.allKeys\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)