### PR TITLE
feat(sync): batched promotion — full cloud-backup mechanism (avatar + agent prefs + conversations + token state)

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		IMGSTOR10012FE2000000000007 /* SupabaseImageStorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = IMGSTOR00012FE2000000000007 /* SupabaseImageStorageService.swift */; };
 		IMGBC10012FE2000000000008 /* ImageBackupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = IMGBC00012FE2000000000008 /* ImageBackupCoordinator.swift */; };
 		SYNRPT10012FE2000000000009 /* SyncStatusReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNRPT00012FE2000000000009 /* SyncStatusReporter.swift */; };
+		SYNINSPV10012FE2000000000A /* Agent/SyncInspectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNINSPV00012FE2000000000A /* Agent/SyncInspectView.swift */; };
 		RSTR10022FE2000000000004 /* Agent/RestoreSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */; };
 		TBSLIDE0022FB0000000000002 /* TabBarSlideHider.swift in Sources */ = {isa = PBXBuildFile; fileRef = TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */; };
 		W1D600010000000000000001 /* SharedEventSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = W1D600000000000000000001 /* SharedEventSnapshot.swift */; };
@@ -283,6 +284,7 @@
 		IMGBC00012FE2000000000008 /* ImageBackupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBackupCoordinator.swift; sourceTree = "<group>"; };
 		SYNRPT00012FE2000000000009 /* SyncStatusReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncStatusReporter.swift; sourceTree = "<group>"; };
 		RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/RestoreSheet.swift; sourceTree = "<group>"; };
+		SYNINSPV00012FE2000000000A /* Agent/SyncInspectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/SyncInspectView.swift; sourceTree = "<group>"; };
 		TBSLIDE0012FB0000000000001 /* TabBarSlideHider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarSlideHider.swift; sourceTree = "<group>"; };
 		W1D600000000000000000001 /* SharedEventSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedEventSnapshot.swift; sourceTree = "<group>"; };
 		W1D600000000000000000003 /* DoneWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoneWidget.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 				AABB10062F60000000000006 /* Agent/MessageBubbleView.swift */,
 				AABB10072F60000000000007 /* Agent/AgentSettingsView.swift */,
 				RSTR00022FE2000000000004 /* Agent/RestoreSheet.swift */,
+				SYNINSPV00012FE2000000000A /* Agent/SyncInspectView.swift */,
 				AUTH00022FE3000000000002 /* Agent/AccountView.swift */,
 				AABB10082F60000000000008 /* Agent/RichTextView.swift */,
 				AABB100E2F60000000000014 /* Agent/ConversationHistoryView.swift */,
@@ -720,6 +723,7 @@
 				AABB20062F60000000000006 /* Agent/MessageBubbleView.swift in Sources */,
 				AABB20072F60000000000007 /* Agent/AgentSettingsView.swift in Sources */,
 				RSTR10022FE2000000000004 /* Agent/RestoreSheet.swift in Sources */,
+				SYNINSPV10012FE2000000000A /* Agent/SyncInspectView.swift in Sources */,
 				AABB20082F60000000000008 /* Agent/RichTextView.swift in Sources */,
 				CCDD00052F80000000000005 /* Analysis/AnalysisViewModel.swift in Sources */,
 				CCDD00062F80000000000006 /* Analysis/AnalysisSummaryCards.swift in Sources */,

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -119,6 +119,10 @@ enum AppSettingsKeys {
     /// nothing is uploaded. Defaults to OFF so a fresh install on a new
     /// device doesn't surprise-write the user's cloud data. Independent of
     /// the DEBUG safety net, which always blocks uploads regardless.
+    ///
+    /// **DO NOT add to `SyncedSettings.allKeys`.** This key is per-device by
+    /// design — syncing it to the cloud would let one device override another
+    /// device's upload preference, which defeats the whole point of the toggle.
     static let syncUploadsEnabled = "syncUploadsEnabled"
 
     static let resettableUserDefaultsKeys: [String] = [

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -112,6 +112,15 @@ enum AppSettingsKeys {
     /// daily share sheet.
     static let calendarShareStyle = "calendarShareStyle"
 
+    // MARK: - Sync upload gate
+
+    /// User-controlled gate: when ON, this device pushes local changes to
+    /// Supabase. When OFF, the device only reads (restore still works) and
+    /// nothing is uploaded. Defaults to OFF so a fresh install on a new
+    /// device doesn't surprise-write the user's cloud data. Independent of
+    /// the DEBUG safety net, which always blocks uploads regardless.
+    static let syncUploadsEnabled = "syncUploadsEnabled"
+
     static let resettableUserDefaultsKeys: [String] = [
         agentProvider,
         agentAPIKey,
@@ -248,6 +257,7 @@ struct ContentView: View {
         .environmentObject(restoreCoordinator)
         .environmentObject(imageBackupCoordinator)
         .environmentObject(syncStatusReporter)
+        .environmentObject(syncService)
         // RestoreSheet's per-row review needs SkillInsightStore in env (the
         // sheet is presented from this view's body, outside the Profile-tab
         // NavigationStack where the store is otherwise injected).

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -325,7 +325,8 @@ struct ContentView: View {
             backupSnapshotService.attach(
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
-                skillStore: skillInsightStore
+                skillStore: skillInsightStore,
+                preferenceStore: agentRuntime.preferenceStore
             )
             imageBackupCoordinator.attach(
                 eventStore: store,

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -311,13 +311,15 @@ struct ContentView: View {
                 authService: authService,
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
-                skillStore: skillInsightStore
+                skillStore: skillInsightStore,
+                preferenceStore: agentRuntime.preferenceStore
             )
             restoreCoordinator.configure(
                 syncService: syncService,
                 eventStore: store,
                 eventTypeStore: agentRuntime.eventTypeTemplateStore,
                 skillStore: skillInsightStore,
+                preferenceStore: agentRuntime.preferenceStore,
                 imageBackupCoordinator: imageBackupCoordinator
             )
             backupSnapshotService.attach(

--- a/Done/Info.plist
+++ b/Done/Info.plist
@@ -16,6 +16,16 @@
     <string>1</string>
     <key>CADisableMinimumFrameDurationOnPhone</key>
     <true/>
+    <!-- Export compliance. App uses only Apple-provided cryptography
+         (CryptoKit SHA256 in `SupabaseSyncService`/`AuthService`) and
+         standard HTTPS via URLSession. Both qualify for EAR 740.17(b)(1)
+         "mass market" exemption per Apple's own guidance — see
+         https://developer.apple.com/documentation/security/complying-with-encryption-export-regulations
+         → "Use Case 1". Setting this to false means "no non-exempt
+         encryption" and skips Apple's per-upload TF prompt without
+         requiring annual self-classification. -->
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UISupportedInterfaceOrientations</key>

--- a/Done/Models/SyncedSettings.swift
+++ b/Done/Models/SyncedSettings.swift
@@ -9,11 +9,32 @@ import Foundation
 /// the sync — no schema migration needed (it's a JSON blob).
 ///
 /// **Deliberately excluded — per-device by design:**
+///
+/// These UserDefaults keys MUST NOT enter `allKeys`. Each captures device-
+/// local state that would cause cross-device interference if synced. When
+/// adding a new per-device key elsewhere in the codebase, document it here.
+///
 ///   - `AppSettingsKeys.syncUploadsEnabled` — the upload gate itself. If we
 ///     synced it, one device flipping it on would push that choice to every
 ///     other device on next restore, defeating the purpose of a per-device
 ///     gate. Each device must own its own upload posture.
 ///   - `agentAPIKey` — third-party provider credential (see note in line list).
+///   - `syncHashes.<userId>.<table>` — diff-sync baselines (#30 hash
+///     persistence). Per-device because each device tracks "what I last
+///     pushed to cloud"; syncing them would mean cross-device confusion
+///     about which rows are dirty.
+///   - `lastSyncedAvatarVersion.<userId>` — per-device marker of which
+///     avatar version this device has already uploaded. Paired with the
+///     synced `meAvatarVersion` to detect "device needs to push".
+///   - `hasOfferedAutoRestore.<userId>` — one-shot prompt flag for the
+///     auto-restore-on-fresh-install nudge. Per-device because each
+///     device has its own first-launch experience.
+///   - `supabaseAuthSession` — current device's Supabase session JWT.
+///     Per-device (each device signs in independently). See `AuthService`.
+///   - `calendar.timeline.hourHeight` — pinch-to-zoom remembered cell
+///     height. Per-device because screen sizes differ.
+///   - `verboseImageLogging` — debug toggle for noisy image-upload logs.
+///     Per-device because it's a developer affordance, not a preference.
 enum SyncedSettings {
     static let allKeys: [String] = [
         // ── General / tab behavior ──
@@ -38,6 +59,13 @@ enum SyncedSettings {
         // into the freshly-restored `skill_insights` row. Stored as
         // `[String]` (UUID strings), JSON-native, so it fits the settings blob.
         "skillAnalyzedEventIds",
+
+        // ── Event-type color memory ──
+        // `EventTypeTemplateStore.colorHistoryKey`. Remembers color choices
+        // for deleted types so re-creating them restores the original color
+        // (small UX polish, lost on restore without this). Stored as plain
+        // `[String: String]` dict, JSON-native.
+        "eventTypeColorHistory",
 
         // ── Calendar look & feel ──
         AppSettingsKeys.effortOpacityEnabled,

--- a/Done/Models/SyncedSettings.swift
+++ b/Done/Models/SyncedSettings.swift
@@ -7,6 +7,13 @@ import Foundation
 /// Keep this list aligned with `AppSettingsKeys` + the misc `@AppStorage`
 /// keys used directly by views. Adding a key here automatically opts it into
 /// the sync — no schema migration needed (it's a JSON blob).
+///
+/// **Deliberately excluded — per-device by design:**
+///   - `AppSettingsKeys.syncUploadsEnabled` — the upload gate itself. If we
+///     synced it, one device flipping it on would push that choice to every
+///     other device on next restore, defeating the purpose of a per-device
+///     gate. Each device must own its own upload posture.
+///   - `agentAPIKey` — third-party provider credential (see note in line list).
 enum SyncedSettings {
     static let allKeys: [String] = [
         // ── General / tab behavior ──

--- a/Done/Models/SyncedSettings.swift
+++ b/Done/Models/SyncedSettings.swift
@@ -31,6 +31,14 @@ enum SyncedSettings {
         AppSettingsKeys.analysisDefaultPeriod,
         AppSettingsKeys.analysisAutoLoadSuggestions,
 
+        // ── Skill analysis dedup ──
+        // The set of event IDs we've already run skill-analysis over. Without
+        // syncing, restore on a fresh device sees an empty set → re-analyzes
+        // every restored event → burns LLM tokens AND can duplicate insights
+        // into the freshly-restored `skill_insights` row. Stored as
+        // `[String]` (UUID strings), JSON-native, so it fits the settings blob.
+        "skillAnalyzedEventIds",
+
         // ── Calendar look & feel ──
         AppSettingsKeys.effortOpacityEnabled,
         AppSettingsKeys.calendarHeaderExposedTools,

--- a/Done/Services/Agent/AgentService.swift
+++ b/Done/Services/Agent/AgentService.swift
@@ -91,7 +91,12 @@ final class AgentService: ObservableObject {
     weak var agentRuntime: AgentRuntime?
 
     private let maxToolRounds = 5
-    private let conversationsStorageKey = "agentConversations"
+    /// Source of truth for the UserDefaults conversation blob key is the
+    /// top-level `AgentConversationsStorageKey` (see `SupabaseSyncService.swift`).
+    /// `SupabaseSyncService`, `BackupSnapshotService`, and `RestoreCoordinator`
+    /// all read/write through the same constant — keep this alias here only
+    /// so existing call sites at L604/L647 don't need to be rewritten.
+    private let conversationsStorageKey = AgentConversationsStorageKey
     private let legacyMessagesKey = "agentChatMessages"
 
     init() {

--- a/Done/Services/Agent/AgentService.swift
+++ b/Done/Services/Agent/AgentService.swift
@@ -1015,6 +1015,32 @@ final class AgentPreferenceStore: ObservableObject {
         saveDecisions()
     }
 
+    /// Apply a cloud restore snapshot. AgentPreferenceStore is a "blob"
+    /// table — one row per user holding rules + history together — so
+    /// `merge.keepLocal` is a no-op and the other paths replace both
+    /// arrays atomically. Per-row conflict UI doesn't apply here (there
+    /// is only one logical row).
+    func applyRestore(
+        rules cloudRules: [AgentPreferenceRule],
+        decisionHistory cloudDecisions: [AgentDecisionRecord],
+        strategy: RestoreStrategy,
+        resolution: ConflictResolution
+    ) {
+        switch strategy {
+        case .cloudOverwritesLocal:
+            rules = cloudRules
+            decisionHistory = cloudDecisions
+            save()
+        case .merge:
+            if resolution == .keepCloud {
+                rules = cloudRules
+                decisionHistory = cloudDecisions
+                save()
+            }
+            // .keepLocal — preserve what's on disk; no-op.
+        }
+    }
+
     func shouldSuppressMissingTypePrompt(for normalizedType: String, now: Date = Date()) -> Bool {
         let cutoff = now.addingTimeInterval(-30 * 24 * 3600)
         let matching = rules.filter {

--- a/Done/Services/Agent/TokenInferenceEngine.swift
+++ b/Done/Services/Agent/TokenInferenceEngine.swift
@@ -401,6 +401,54 @@ final class TokenInferenceRepository {
         defaults.removeObject(forKey: projectionKey)
     }
 
+    // MARK: - Backup / restore plumbing
+    //
+    // The repository is a singleton that loads from UserDefaults on init.
+    // The sync layer needs to (a) read the current state to upload, and
+    // (b) overwrite the in-memory + on-disk state after a restore lands.
+
+    /// Read-only access to the three underlying arrays so the sync layer
+    /// can encode them into the `agent_preferences` row. Returns whatever
+    /// the in-memory storage holds — same source the engine itself reads.
+    func snapshot() -> (dynamic: [TokenDynamicHypothesisRecord],
+                       meta: [TokenMetaHypothesisRecord],
+                       projections: [TokenOccurrenceProjectionRecord]) {
+        (dynamicStorage, metaStorage, projectionsStorage)
+    }
+
+    /// Replace in-memory state + persisted state with a cloud-restored
+    /// payload. Used by `RestoreCoordinator` after applying a snapshot.
+    /// Any nil array is treated as "no cloud state for this slice" and
+    /// the corresponding local slice is preserved.
+    func applyRestore(
+        dynamicHypotheses cloudDynamic: [TokenDynamicHypothesisRecord]?,
+        metaHypotheses cloudMeta: [TokenMetaHypothesisRecord]?,
+        projections cloudProjections: [TokenOccurrenceProjectionRecord]?,
+        strategy: RestoreStrategy,
+        resolution: ConflictResolution
+    ) {
+        let shouldOverwrite: Bool = {
+            switch strategy {
+            case .cloudOverwritesLocal: return true
+            case .merge:                return resolution == .keepCloud
+            }
+        }()
+        guard shouldOverwrite else { return }
+
+        if let cloudDynamic {
+            dynamicStorage = cloudDynamic
+            saveDynamicHypotheses()
+        }
+        if let cloudMeta {
+            metaStorage = cloudMeta
+            saveMetaHypotheses()
+        }
+        if let cloudProjections {
+            projectionsStorage = cloudProjections
+            saveProjections()
+        }
+    }
+
     private func compressAndPruneDynamicHypotheses(referenceDate: Date) {
         let now = Date()
         let active = dynamicStorage.filter {

--- a/Done/Services/Agent/TokenInferenceEngine.swift
+++ b/Done/Services/Agent/TokenInferenceEngine.swift
@@ -183,6 +183,13 @@ private struct TokenDeterministicPreview {
     var evidence: TokenEvidenceBundle
 }
 
+extension Notification.Name {
+    /// Posted whenever `TokenInferenceRepository` mutates its persisted
+    /// arrays. `SupabaseSyncService` listens to debounce + re-upload the
+    /// `agent_preferences` row whose token columns the repository owns.
+    static let tokenInferenceStateDidChange = Notification.Name("io.maymei.Done.tokenInferenceStateDidChange")
+}
+
 @MainActor
 final class TokenInferenceRepository {
     static let shared = TokenInferenceRepository()
@@ -531,14 +538,29 @@ final class TokenInferenceRepository {
 
     private func saveDynamicHypotheses() {
         defaults.setCodable(dynamicStorage, forKey: dynamicKey)
+        broadcastChange()
     }
 
     private func saveMetaHypotheses() {
         defaults.setCodable(metaStorage, forKey: metaKey)
+        broadcastChange()
     }
 
     private func saveProjections() {
         defaults.setCodable(projectionsStorage, forKey: projectionKey)
+        broadcastChange()
+    }
+
+    /// Token state isn't `@Published` (the storage arrays are private
+    /// `var`s, not Combine sources) so the sync layer can't observe
+    /// changes via a publisher chain. Post a Notification on every save
+    /// so `SupabaseSyncService` can debounce and re-upload the
+    /// `agent_preferences` row when token columns change. Without this
+    /// the agent's learned state drifts away from cloud during a session
+    /// until something else (a rule edit, the next fullSync) pokes the
+    /// row.
+    private func broadcastChange() {
+        NotificationCenter.default.post(name: .tokenInferenceStateDidChange, object: nil)
     }
 
     private func phaseRank(_ phase: TokenProjectionPhase) -> Int {

--- a/Done/Services/BackupSnapshotService.swift
+++ b/Done/Services/BackupSnapshotService.swift
@@ -41,6 +41,7 @@ final class BackupSnapshotService: ObservableObject {
     private weak var eventStore: EventStore?
     private weak var eventTypeStore: EventTypeTemplateStore?
     private weak var skillStore: SkillInsightStore?
+    private weak var preferenceStore: AgentPreferenceStore?
     weak var statusReporter: SyncStatusReporter?
 
     private var cancellables = Set<AnyCancellable>()
@@ -54,12 +55,14 @@ final class BackupSnapshotService: ObservableObject {
     func attach(
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
-        skillStore: SkillInsightStore
+        skillStore: SkillInsightStore,
+        preferenceStore: AgentPreferenceStore
     ) {
         cancellables.removeAll()
         self.eventStore = eventStore
         self.eventTypeStore = eventTypeStore
         self.skillStore = skillStore
+        self.preferenceStore = preferenceStore
 
         // ── App backgrounding ──
         NotificationCenter.default
@@ -124,7 +127,8 @@ final class BackupSnapshotService: ObservableObject {
             let data = try buildSnapshotData(
                 eventStore: eventStore,
                 eventTypeStore: eventTypeStore,
-                skillStore: skillStore
+                skillStore: skillStore,
+                preferenceStore: preferenceStore
             )
             try writeAtomically(data)
             logger.info("Snapshot written (\(data.count, privacy: .public) bytes, reason: \(reason, privacy: .public))")
@@ -145,10 +149,16 @@ final class BackupSnapshotService: ObservableObject {
     /// Build the snapshot payload as a single JSON-serializable dictionary so
     /// it's both human-readable and tolerant of the heterogeneous data we
     /// carry (typed models + an untyped settings blob).
+    ///
+    /// **Coverage**: this is the local-DR side of the audit table. As the
+    /// cloud-side picks up new buckets (avatar binary, agent preferences,
+    /// agent conversations — see `SupabaseSyncService.restoreTables`), the
+    /// snapshot mirrors them or the local-only path falls strictly behind.
     private func buildSnapshotData(
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
-        skillStore: SkillInsightStore
+        skillStore: SkillInsightStore,
+        preferenceStore: AgentPreferenceStore?
     ) throws -> Data {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
@@ -158,7 +168,22 @@ final class BackupSnapshotService: ObservableObject {
             return (try JSONSerialization.jsonObject(with: data) as? [Any]) ?? []
         }
 
-        let dict: [String: Any] = [
+        // Avatar bytes: base64 so the snapshot stays a single JSON file.
+        // ~100 KB compressed JPEG → ~133 KB base64 — tolerable for a JSON
+        // payload; the alternative (sibling file) would complicate the
+        // "one file = one restore" property the snapshot has today.
+        let avatarBase64: String? = MeAvatarStore.loadData()?.base64EncodedString()
+
+        // Agent conversations: read the raw UserDefaults blob and decode
+        // back to JSON-native so the dict round-trips through
+        // JSONSerialization cleanly.
+        let conversationsBlob: Any = {
+            let raw = UserDefaults.standard.data(forKey: AgentConversationsStorageKey) ?? Data()
+            if raw.isEmpty { return [] }
+            return (try? JSONSerialization.jsonObject(with: raw)) ?? []
+        }()
+
+        var dict: [String: Any] = [
             "version": Self.snapshotVersion,
             "createdAt": ISO8601DateFormatter.iso8601WithFraction.string(from: Date()),
             "events": try jsonArray(eventStore.events),
@@ -169,7 +194,15 @@ final class BackupSnapshotService: ObservableObject {
             "eventTypes": try jsonArray(eventTypeStore.templates),
             "skills": try jsonArray(skillStore.insights),
             "settings": SyncedSettings.currentSnapshot(),
+            "agentConversations": conversationsBlob,
         ]
+        if let preferenceStore {
+            dict["agentRules"] = try jsonArray(preferenceStore.rules)
+            dict["agentDecisionHistory"] = try jsonArray(preferenceStore.decisionHistory)
+        }
+        if let avatarBase64 {
+            dict["avatarJPEGBase64"] = avatarBase64
+        }
 
         return try JSONSerialization.data(
             withJSONObject: dict,

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -140,6 +140,7 @@ final class ImageBackupCoordinator: ObservableObject {
         if trackInUI { statusReporter?.imagesDidStart() }
 
         var newlyUploaded = 0
+        var alreadyInCloud = 0
         var failed = 0
 
         // 1. Agentic-intake images on the event itself.
@@ -153,6 +154,7 @@ final class ImageBackupCoordinator: ObservableObject {
                     userID: userID,
                     storageService: storageService,
                     newlyUploaded: &newlyUploaded,
+                    alreadyInCloud: &alreadyInCloud,
                     failed: &failed
                 )
             }
@@ -175,20 +177,31 @@ final class ImageBackupCoordinator: ObservableObject {
                         userID: userID,
                         storageService: storageService,
                         newlyUploaded: &newlyUploaded,
+                        alreadyInCloud: &alreadyInCloud,
                         failed: &failed
                     )
                 }
             }
         }
 
-        if newlyUploaded > 0 || failed > 0 {
-            logger.info("Scan (\(reason, privacy: .public)): uploaded \(newlyUploaded, privacy: .public), failed \(failed, privacy: .public)")
+        if newlyUploaded > 0 || alreadyInCloud > 0 || failed > 0 {
+            logger.info("Scan (\(reason, privacy: .public)): \(newlyUploaded, privacy: .public) new, \(alreadyInCloud, privacy: .public) already in cloud, \(failed, privacy: .public) failed")
         }
         if trackInUI {
             if failed == 0 {
-                statusReporter?.imagesDidSucceed(detail: "\(newlyUploaded) uploaded")
+                // Compose a useful detail string that doesn't lie. "0 new"
+                // when everything was already in cloud is honest; "N uploaded"
+                // when it was really a no-op dedup pass would be misleading.
+                let detail: String
+                switch (newlyUploaded, alreadyInCloud) {
+                case (0, 0):                 detail = "no changes"
+                case (0, let dedup):         detail = "\(dedup) already in cloud"
+                case (let n, 0):             detail = "\(n) uploaded"
+                case (let n, let dedup):     detail = "\(n) new, \(dedup) already in cloud"
+                }
+                statusReporter?.imagesDidSucceed(detail: detail)
             } else {
-                statusReporter?.imagesDidFail("\(failed) of \(newlyUploaded + failed) failed")
+                statusReporter?.imagesDidFail("\(failed) of \(newlyUploaded + alreadyInCloud + failed) failed")
             }
         }
     }
@@ -238,6 +251,7 @@ final class ImageBackupCoordinator: ObservableObject {
         userID: String,
         storageService: SupabaseImageStorageService,
         newlyUploaded: inout Int,
+        alreadyInCloud: inout Int,
         failed: inout Int
     ) async {
         guard !attemptedImageIDs.contains(ref.id) else { return }
@@ -256,8 +270,12 @@ final class ImageBackupCoordinator: ObservableObject {
             imageID: ref.id
         )
         do {
-            try await storageService.upload(path: path, data: data)
-            newlyUploaded += 1
+            let didWriteNewBytes = try await storageService.upload(path: path, data: data)
+            if didWriteNewBytes {
+                newlyUploaded += 1
+            } else {
+                alreadyInCloud += 1
+            }
         } catch SupabaseImageStorageService.Error.uploadsDisabled {
             // DEBUG path. Expected. No retry.
         } catch SupabaseImageStorageService.Error.notSignedIn {

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -56,6 +56,11 @@ final class ImageBackupCoordinator: ObservableObject {
     weak var statusReporter: SyncStatusReporter?
     private var storageService: SupabaseImageStorageService?
     private var attemptedImageIDs: Set<UUID> = []
+    /// Re-entry guard for `scanAndUpload`. `storeChange` debounce +
+    /// `userDidEnableUploads` + `attach`-time scan can otherwise overlap.
+    /// The work is per-image idempotent at the Storage layer, but overlap
+    /// would emit double `imagesDidStart` and clutter the status timeline.
+    private var scanInFlight = false
     private var cancellables = Set<AnyCancellable>()
 
     init() {}
@@ -100,6 +105,12 @@ final class ImageBackupCoordinator: ObservableObject {
               let storageService,
               let userID = authService?.session?.user.id
         else { return }
+        // Re-entry guard. The in-flight scan will already pick up any new
+        // candidates that landed since it started, so dropping the duplicate
+        // is correct, not just an optimization.
+        if scanInFlight { return }
+        scanInFlight = true
+        defer { scanInFlight = false }
 
         // Pre-scan: count work so we can decide whether to surface activity.
         // Cheap relative to the actual upload; avoids spinner flicker on

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -89,6 +89,19 @@ final class ImageBackupCoordinator: ObservableObject {
         // Also run once on attach so we pick up images attached before
         // first observation fires (e.g. saved during prior launch).
         Task { await scanAndUpload(reason: "attach") }
+
+        // Observe avatar version bumps so an updated avatar uploads on
+        // its own schedule (separate from the event-image scan because
+        // its lifecycle — save/delete via the Me-page picker — is
+        // disjoint from event mutations).
+        NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .debounce(for: .seconds(Self.scanDebounce), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { await self?.syncAvatarIfNeeded(reason: "userDefaultsChange") }
+            }
+            .store(in: &cancellables)
+        Task { await syncAvatarIfNeeded(reason: "attach") }
     }
 
     /// Called by the settings UI when the user flips the upload toggle from
@@ -97,7 +110,88 @@ final class ImageBackupCoordinator: ObservableObject {
     /// to the cloud on this fresh scan.
     func userDidEnableUploads() {
         attemptedImageIDs.removeAll()
-        Task { await scanAndUpload(reason: "userEnabledUploads") }
+        Task {
+            await scanAndUpload(reason: "userEnabledUploads")
+            await syncAvatarIfNeeded(reason: "userEnabledUploads")
+        }
+    }
+
+    // MARK: - Avatar sync (closing the #1 gap toward full backup)
+
+    /// UserDefaults key for the last avatar version we successfully synced
+    /// to the cloud, scoped per user. `meAvatarVersion` itself is in
+    /// `SyncedSettings.allKeys` and therefore syncs cross-device; this
+    /// key is the **local-only** record of "the version this device has
+    /// already pushed".
+    private static func lastSyncedAvatarVersionKey(_ userID: String) -> String {
+        "lastSyncedAvatarVersion.\(userID)"
+    }
+
+    /// Reconcile this device's avatar with the cloud. Three cases:
+    ///   - Local has avatar AND version differs from last-synced  → upload
+    ///   - Local has NO avatar AND version differs                → delete
+    ///   - Versions match                                          → no-op
+    ///
+    /// The DEBUG safety net + user upload toggle both gate this through
+    /// the underlying `SupabaseImageStorageService.upload` (which throws
+    /// `.uploadsDisabled` in DEBUG) and the `canUpload` check below.
+    func syncAvatarIfNeeded(reason: String) async {
+        guard let storageService,
+              let userID = authService?.session?.user.id
+        else { return }
+        // Gate on the same predicate event-image upload uses so the
+        // avatar respects the user's per-device upload toggle.
+        let userToggle = UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
+        guard !SupabaseImageStorageService.uploadsDisabled, userToggle else { return }
+
+        let currentVersion = UserDefaults.standard.integer(forKey: AppSettingsKeys.meAvatarVersion)
+        let lastSynced = UserDefaults.standard.integer(forKey: Self.lastSyncedAvatarVersionKey(userID))
+        guard currentVersion != lastSynced else { return }
+
+        if MeAvatarStore.hasImage {
+            guard let data = MeAvatarStore.loadData(), !data.isEmpty else { return }
+            do {
+                try await storageService.uploadAvatar(userID: userID, data: data)
+                UserDefaults.standard.set(currentVersion, forKey: Self.lastSyncedAvatarVersionKey(userID))
+                logger.info("Avatar uploaded (\(reason, privacy: .public), \(data.count, privacy: .public) bytes)")
+            } catch SupabaseImageStorageService.Error.uploadsDisabled {
+                // DEBUG path. Expected. No retry.
+            } catch {
+                logger.error("Avatar upload failed: \(error.localizedDescription, privacy: .public)")
+            }
+        } else {
+            // Local was deleted (version bumped + no file on disk).
+            await storageService.deleteAvatar(userID: userID)
+            UserDefaults.standard.set(currentVersion, forKey: Self.lastSyncedAvatarVersionKey(userID))
+            logger.info("Avatar deleted (\(reason, privacy: .public))")
+        }
+    }
+
+    /// Pull the avatar from cloud if local doesn't have it. Called by
+    /// `RestoreCoordinator` after structured restore lands — `MeAvatarStore`
+    /// is a file in `Documents/`, not a synced UserDefaults blob, so the
+    /// PostgREST restore alone can't bring it back.
+    func downloadAvatarIfMissing() async {
+        guard let storageService,
+              let userID = authService?.session?.user.id
+        else { return }
+        // Only fetch when local has nothing. If local already exists,
+        // assume it's the right one (the user is the one who picked it).
+        guard !MeAvatarStore.hasImage else { return }
+        do {
+            guard let data = try await storageService.downloadAvatar(userID: userID), !data.isEmpty else {
+                return  // 404 — no avatar in cloud for this user
+            }
+            try MeAvatarStore.writeRaw(data)
+            // Mark this device as "synced to the version we just downloaded"
+            // so the next upload-side scan doesn't try to immediately re-up
+            // the freshly-restored bytes.
+            let restoredVersion = UserDefaults.standard.integer(forKey: AppSettingsKeys.meAvatarVersion)
+            UserDefaults.standard.set(restoredVersion, forKey: Self.lastSyncedAvatarVersionKey(userID))
+            logger.info("Avatar restored (\(data.count, privacy: .public) bytes)")
+        } catch {
+            logger.error("Avatar restore failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     func scanAndUpload(reason: String) async {

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -90,6 +90,18 @@ final class ImageBackupCoordinator: ObservableObject {
         // first observation fires (e.g. saved during prior launch).
         Task { await scanAndUpload(reason: "attach") }
 
+        // Reset the per-session suppression cache when the signed-in user
+        // changes. Without this, a sign-out → sign-in-as-different-user on
+        // the same device would carry the old user's "already attempted"
+        // image IDs into the new session — UUID collisions are
+        // astronomically unlikely (128 bits), but the conceptual leak is
+        // real and a one-line fix.
+        authService.$session
+            .map { $0?.user.id }
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.attemptedImageIDs.removeAll() }
+            .store(in: &cancellables)
+
         // Observe avatar version bumps so an updated avatar uploads on
         // its own schedule (separate from the event-image scan because
         // its lifecycle — save/delete via the Me-page picker — is

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -140,7 +140,11 @@ final class ImageBackupCoordinator: ObservableObject {
               let userID = authService?.session?.user.id
         else { return }
         // Gate on the same predicate event-image upload uses so the
-        // avatar respects the user's per-device upload toggle.
+        // avatar respects the user's per-device upload toggle. Skip
+        // silently — the per-image scan already surfaces "disabled"
+        // to the status reporter for whichever gate is active, and
+        // duplicating it here would emit two channel pings per scan
+        // for the same reason.
         let userToggle = UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
         guard !SupabaseImageStorageService.uploadsDisabled, userToggle else { return }
 

--- a/Done/Services/ImageBackupCoordinator.swift
+++ b/Done/Services/ImageBackupCoordinator.swift
@@ -86,6 +86,15 @@ final class ImageBackupCoordinator: ObservableObject {
         Task { await scanAndUpload(reason: "attach") }
     }
 
+    /// Called by the settings UI when the user flips the upload toggle from
+    /// OFF → ON. Clears the in-session suppression cache so images we tagged
+    /// as "attempted" during the disabled period get re-evaluated and pushed
+    /// to the cloud on this fresh scan.
+    func userDidEnableUploads() {
+        attemptedImageIDs.removeAll()
+        Task { await scanAndUpload(reason: "userEnabledUploads") }
+    }
+
     func scanAndUpload(reason: String) async {
         guard let eventStore,
               let storageService,
@@ -99,14 +108,21 @@ final class ImageBackupCoordinator: ObservableObject {
             eventStore: eventStore,
             attemptedImageIDs: attemptedImageIDs
         )
-        // In DEBUG the upload throws `.uploadsDisabled` immediately; we
-        // shouldn't emit a fake "0 uploaded ✓" — surface a no-op note
-        // instead so the user can see why nothing is moving. Mark current
-        // candidates as "attempted" so the no-op is one-shot per image,
-        // not re-pinged on every store edit for the rest of the session.
-        if candidateCount > 0 && SupabaseImageStorageService.uploadsDisabled {
+        // Two independent gates can disable uploads:
+        //  1. DEBUG safety net (compile-time) — simulator/dev builds never write
+        //  2. User toggle (`syncUploadsEnabled`) — Release users opt-in per device
+        // Either gate active → surface a one-shot "disabled" note + suppress
+        // future re-pings (mark all current candidates as attempted), and
+        // bail before any I/O. The reason label distinguishes the two so a
+        // confused user can tell whether it's a dev build or their toggle.
+        let userToggle = UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
+        if candidateCount > 0,
+           SupabaseImageStorageService.uploadsDisabled || !userToggle {
             Self.collectCandidateIDs(eventStore: eventStore, into: &attemptedImageIDs)
-            statusReporter?.imagesDidNoOp(detail: "disabled (DEBUG)")
+            let reason = SupabaseImageStorageService.uploadsDisabled
+                ? "disabled (DEBUG)"
+                : "uploads off (Settings)"
+            statusReporter?.imagesDidNoOp(detail: reason)
             return
         }
         let trackInUI = candidateCount > 0

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -182,6 +182,7 @@ final class RestoreCoordinator: ObservableObject {
     private weak var eventStore: EventStore?
     private weak var eventTypeStore: EventTypeTemplateStore?
     private weak var skillStore: SkillInsightStore?
+    private weak var preferenceStore: AgentPreferenceStore?
     private weak var imageBackupCoordinator: ImageBackupCoordinator?
 
     init() {}
@@ -197,12 +198,14 @@ final class RestoreCoordinator: ObservableObject {
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
         skillStore: SkillInsightStore,
+        preferenceStore: AgentPreferenceStore,
         imageBackupCoordinator: ImageBackupCoordinator? = nil
     ) {
         self.syncService = syncService
         self.eventStore = eventStore
         self.eventTypeStore = eventTypeStore
         self.skillStore = skillStore
+        self.preferenceStore = preferenceStore
         self.imageBackupCoordinator = imageBackupCoordinator
     }
 
@@ -342,6 +345,36 @@ final class RestoreCoordinator: ObservableObject {
                 SyncedSettings.replace(with: blob)
             case .merge:
                 SyncedSettings.apply(blob, resolution: resolution)
+            }
+        }
+
+        // Agent preferences (rules + decision history). Single-row blob.
+        // Per-row conflict UI doesn't apply; merge.keepLocal is a no-op.
+        if let preferenceStore,
+           (snapshot.agentRules != nil || snapshot.agentDecisionHistory != nil) {
+            preferenceStore.applyRestore(
+                rules: snapshot.agentRules ?? [],
+                decisionHistory: snapshot.agentDecisionHistory ?? [],
+                strategy: strategy,
+                resolution: resolution
+            )
+        }
+
+        // Agent conversation history. Re-encode the cloud's jsonb blob
+        // back into UserDefaults under `agentConversations` so the next
+        // `AgentService.load()` picks it up. Same semantics as settings:
+        // cloud overwrites in `.cloudOverwritesLocal` or `merge.keepCloud`;
+        // `merge.keepLocal` is a no-op.
+        if let conversationsBlob = snapshot.agentConversationsBlob {
+            let shouldOverwrite: Bool = {
+                switch strategy {
+                case .cloudOverwritesLocal: return true
+                case .merge:                return resolution == .keepCloud
+                }
+            }()
+            if shouldOverwrite,
+               let data = try? JSONSerialization.data(withJSONObject: conversationsBlob) {
+                UserDefaults.standard.set(data, forKey: "agentConversations")
             }
         }
 

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -364,6 +364,10 @@ final class RestoreCoordinator: ObservableObject {
         if let imageBackupCoordinator {
             let allRestoredEvents = eventStore.events + eventStore.calendarEvents
             await imageBackupCoordinator.downloadMissing(forEvents: allRestoredEvents)
+            // Avatar lives at a fixed `_avatar.jpg` path, not tied to any
+            // event — it has its own download path independent of the
+            // per-event image walk above.
+            await imageBackupCoordinator.downloadAvatarIfMissing()
         }
 
         let resolutionForSummary: ConflictResolution? = strategy == .merge ? resolution : nil

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -360,6 +360,22 @@ final class RestoreCoordinator: ObservableObject {
             )
         }
 
+        // TokenInferenceRepository's learned state (migration 011 — lives
+        // on the same agent_preferences row). Same merge semantics: a
+        // single-row blob per slice, keepLocal is a no-op, keepCloud
+        // replaces in-memory + on-disk via the singleton's applyRestore.
+        if snapshot.tokenDynamicHypotheses != nil ||
+           snapshot.tokenMetaHypotheses != nil ||
+           snapshot.tokenProjections != nil {
+            TokenInferenceRepository.shared.applyRestore(
+                dynamicHypotheses: snapshot.tokenDynamicHypotheses,
+                metaHypotheses: snapshot.tokenMetaHypotheses,
+                projections: snapshot.tokenProjections,
+                strategy: strategy,
+                resolution: resolution
+            )
+        }
+
         // Agent conversation history. Re-encode the cloud's jsonb blob
         // back into UserDefaults under `agentConversations` so the next
         // `AgentService.load()` picks it up. Same semantics as settings:

--- a/Done/Services/RestoreCoordinator.swift
+++ b/Done/Services/RestoreCoordinator.swift
@@ -374,7 +374,7 @@ final class RestoreCoordinator: ObservableObject {
             }()
             if shouldOverwrite,
                let data = try? JSONSerialization.data(withJSONObject: conversationsBlob) {
-                UserDefaults.standard.set(data, forKey: "agentConversations")
+                UserDefaults.standard.set(data, forKey: AgentConversationsStorageKey)
             }
         }
 

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -141,6 +141,18 @@ final class SupabaseImageStorageService {
             return nil
         }
         guard (200..<300).contains(http.statusCode) else {
+            // Supabase Storage doesn't always honor the outer HTTP status —
+            // a missing object can come back as HTTP 400 with a JSON body
+            // that says `{"statusCode":"404","error":"not_found",...}`.
+            // Without inspecting the body we'd treat that as a hard failure
+            // and the restore flow would report e.g. "5 of 50 failed" for
+            // images whose binaries just weren't uploaded yet (a common
+            // case during cross-device restore). Surface those as nil so
+            // the caller can `continue` past them, same as a real 404.
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               (json["statusCode"] as? String) == "404" {
+                return nil
+            }
             let body = String(data: data, encoding: .utf8) ?? ""
             logger.error("Download failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
             throw Error.httpFailure(status: http.statusCode)

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -37,14 +37,11 @@ final class SupabaseImageStorageService {
     /// Reads are always allowed. Public so the sync-status UI can label the
     /// Images channel as "disabled (DEBUG)" instead of falsely claiming
     /// successful uploads from simulator runs.
-    // ⚠️ TEMPORARY BYPASS FOR REAL-DEVICE TESTING — DO NOT COMMIT
-    // Restore the #if DEBUG block below after the device build is on hardware.
+    #if DEBUG
+    static let uploadsDisabled = true
+    #else
     static let uploadsDisabled = false
-    // #if DEBUG
-    // static let uploadsDisabled = true
-    // #else
-    // static let uploadsDisabled = false
-    // #endif
+    #endif
 
     init(
         url: String = SupabaseSyncConfig.url,

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -43,6 +43,21 @@ final class SupabaseImageStorageService {
     static let uploadsDisabled = false
     #endif
 
+    /// Verbose per-image logging. Each scan over an established account
+    /// emits ~50 "already uploaded" log lines — fine for debugging the
+    /// dedup path, ruinous for console readability on every other day.
+    /// Default OFF; the scan-boundary summary (`Scan: N new, M already
+    /// in cloud, K failed`) is the routine signal. To turn on for deep
+    /// debugging without rebuilding:
+    ///
+    ///   (lldb) po UserDefaults.standard.set(true, forKey: "verboseImageLogging")
+    ///
+    /// When on, future improvements can add metadata (file size, headers,
+    /// effective status) to each line.
+    static var verboseImageLogging: Bool {
+        UserDefaults.standard.bool(forKey: "verboseImageLogging")
+    }
+
     init(
         url: String = SupabaseSyncConfig.url,
         projectAPIKey: String = SupabaseSyncConfig.anonKey,
@@ -114,7 +129,9 @@ final class SupabaseImageStorageService {
             // Object already exists at this path — treat as success since
             // image IDs are UUIDs (uniqueness is on us; collision means we
             // already uploaded the same image earlier).
-            logger.info("Image already uploaded, skipping: \(path, privacy: .private)")
+            if Self.verboseImageLogging {
+                logger.info("Image already uploaded, skipping: \(path, privacy: .private)")
+            }
             return false
         }
 

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -100,8 +100,9 @@ final class SupabaseImageStorageService {
         guard let http = response as? HTTPURLResponse else {
             throw Error.networkFailure
         }
+        let effective = Self.effectiveStatusCode(httpStatus: http.statusCode, body: responseData)
 
-        if http.statusCode == 409 {
+        if effective == 409 {
             // Object already exists at this path — treat as success since
             // image IDs are UUIDs (uniqueness is on us; collision means we
             // already uploaded the same image earlier).
@@ -109,10 +110,10 @@ final class SupabaseImageStorageService {
             return
         }
 
-        guard (200..<300).contains(http.statusCode) else {
+        guard (200..<300).contains(effective) else {
             let body = String(data: responseData, encoding: .utf8) ?? ""
-            logger.error("Upload failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
-            throw Error.httpFailure(status: http.statusCode)
+            logger.error("Upload failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: effective)
         }
     }
 
@@ -137,27 +138,39 @@ final class SupabaseImageStorageService {
         guard let http = response as? HTTPURLResponse else {
             throw Error.networkFailure
         }
-        if http.statusCode == 404 {
+        let effective = Self.effectiveStatusCode(httpStatus: http.statusCode, body: data)
+        if effective == 404 {
             return nil
         }
-        guard (200..<300).contains(http.statusCode) else {
-            // Supabase Storage doesn't always honor the outer HTTP status —
-            // a missing object can come back as HTTP 400 with a JSON body
-            // that says `{"statusCode":"404","error":"not_found",...}`.
-            // Without inspecting the body we'd treat that as a hard failure
-            // and the restore flow would report e.g. "5 of 50 failed" for
-            // images whose binaries just weren't uploaded yet (a common
-            // case during cross-device restore). Surface those as nil so
-            // the caller can `continue` past them, same as a real 404.
-            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-               (json["statusCode"] as? String) == "404" {
-                return nil
-            }
+        guard (200..<300).contains(effective) else {
             let body = String(data: data, encoding: .utf8) ?? ""
-            logger.error("Download failed (\(http.statusCode, privacy: .public)): \(body.prefix(200), privacy: .public)")
-            throw Error.httpFailure(status: http.statusCode)
+            logger.error("Download failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
+            throw Error.httpFailure(status: effective)
         }
         return data
+    }
+
+    /// Supabase Storage's REST endpoint wraps real status codes inside the
+    /// response body and returns HTTP 400 at the transport layer:
+    ///
+    ///     HTTP 400 + body `{"statusCode":"404", ...}`  → not found
+    ///     HTTP 400 + body `{"statusCode":"409", ...}`  → duplicate
+    ///     HTTP 400 + body `{"statusCode":"413", ...}`  → payload too large
+    ///
+    /// Without unwrapping the body, every error looks like a generic 400 and
+    /// callers can't branch on the real semantics (treat 404 as nil-continue,
+    /// treat 409 as already-uploaded success, surface 413 to the user, etc.).
+    /// This helper decodes the wrapped status when the outer code is non-2xx.
+    /// Returns the outer code unchanged on 2xx responses, or when the body
+    /// isn't the expected shape.
+    private static func effectiveStatusCode(httpStatus: Int, body: Data) -> Int {
+        if (200..<300).contains(httpStatus) { return httpStatus }
+        if let json = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+           let raw = json["statusCode"] as? String,
+           let parsed = Int(raw) {
+            return parsed
+        }
+        return httpStatus
     }
 
     /// Delete one or more images. Best-effort — partial failures log and

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -37,11 +37,14 @@ final class SupabaseImageStorageService {
     /// Reads are always allowed. Public so the sync-status UI can label the
     /// Images channel as "disabled (DEBUG)" instead of falsely claiming
     /// successful uploads from simulator runs.
-    #if DEBUG
-    static let uploadsDisabled = true
-    #else
+    // ⚠️ TEMPORARY BYPASS FOR REAL-DEVICE TESTING — DO NOT COMMIT
+    // Restore the #if DEBUG block below after the device build is on hardware.
     static let uploadsDisabled = false
-    #endif
+    // #if DEBUG
+    // static let uploadsDisabled = true
+    // #else
+    // static let uploadsDisabled = false
+    // #endif
 
     init(
         url: String = SupabaseSyncConfig.url,
@@ -64,7 +67,15 @@ final class SupabaseImageStorageService {
     /// Upload an image's bytes. Caller is responsible for compression; we
     /// just pipe the bytes through. Throws `Error.uploadsDisabled` in DEBUG
     /// so callers can no-op without surprising error logs.
-    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws {
+    ///
+    /// Returns `true` when the bytes were actually written this call, `false`
+    /// when the object was already present in the cloud at this exact path
+    /// (a 409 dedup outcome — Supabase wraps that as HTTP 400 + body 409,
+    /// see `effectiveStatusCode`). Callers want this distinction so the
+    /// `Scan: N uploaded, M dedup'd` accounting reflects reality instead of
+    /// claiming N new uploads when nothing actually went over the wire.
+    @discardableResult
+    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws -> Bool {
         if Self.uploadsDisabled {
             throw Error.uploadsDisabled
         }
@@ -107,7 +118,7 @@ final class SupabaseImageStorageService {
             // image IDs are UUIDs (uniqueness is on us; collision means we
             // already uploaded the same image earlier).
             logger.info("Image already uploaded, skipping: \(path, privacy: .private)")
-            return
+            return false
         }
 
         guard (200..<300).contains(effective) else {
@@ -115,6 +126,7 @@ final class SupabaseImageStorageService {
             logger.error("Upload failed (\(effective, privacy: .public)): \(body.prefix(200), privacy: .public)")
             throw Error.httpFailure(status: effective)
         }
+        return true
     }
 
     /// Download an image's bytes. Returns nil if the object doesn't exist

--- a/Done/Services/SupabaseImageStorageService.swift
+++ b/Done/Services/SupabaseImageStorageService.swift
@@ -76,6 +76,40 @@ final class SupabaseImageStorageService {
         "\(userID)/\(eventID.uuidString)/\(imageID.uuidString).jpg"
     }
 
+    /// Avatar path lives at `event-images/{user_id}/_avatar.jpg`. Shares the
+    /// `event-images` bucket (and therefore its RLS) because the underscore
+    /// prefix can never collide with a real event UUID. Keeps RLS, auth,
+    /// and image-handling code on one path; no new bucket migration needed.
+    func avatarPath(userID: String) -> String {
+        "\(userID)/_avatar.jpg"
+    }
+
+    /// Upload the avatar for the signed-in user. Always overwrites the
+    /// existing slot (the avatar's path is fixed, the bytes change over
+    /// time — opposite of event-image semantics).
+    @discardableResult
+    func uploadAvatar(userID: String, data: Data) async throws -> Bool {
+        try await upload(
+            path: avatarPath(userID: userID),
+            data: data,
+            contentType: "image/jpeg",
+            allowsOverwrite: true
+        )
+    }
+
+    /// Download the avatar for the signed-in user. Returns nil when the
+    /// cloud doesn't have one (404 / 400+body-404 both handled by
+    /// `download`).
+    func downloadAvatar(userID: String) async throws -> Data? {
+        try await download(path: avatarPath(userID: userID))
+    }
+
+    /// Delete the avatar (signed-in user just cleared theirs locally).
+    /// Best-effort; `delete(paths:)` swallows partial failures.
+    func deleteAvatar(userID: String) async {
+        await delete(paths: [avatarPath(userID: userID)])
+    }
+
     /// Upload an image's bytes. Caller is responsible for compression; we
     /// just pipe the bytes through. Throws `Error.uploadsDisabled` in DEBUG
     /// so callers can no-op without surprising error logs.
@@ -87,7 +121,12 @@ final class SupabaseImageStorageService {
     /// `Scan: N uploaded, M dedup'd` accounting reflects reality instead of
     /// claiming N new uploads when nothing actually went over the wire.
     @discardableResult
-    func upload(path: String, data: Data, contentType: String = "image/jpeg") async throws -> Bool {
+    func upload(
+        path: String,
+        data: Data,
+        contentType: String = "image/jpeg",
+        allowsOverwrite: Bool = false
+    ) async throws -> Bool {
         if Self.uploadsDisabled {
             throw Error.uploadsDisabled
         }
@@ -113,10 +152,15 @@ final class SupabaseImageStorageService {
         // ↓ User JWT, not the project key. This is what makes RLS work.
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")
-        // x-upsert: false (default) so we don't silently overwrite when the
-        // same image ID is uploaded twice. Forces 409 instead and we can
-        // detect and skip.
-        request.setValue("false", forHTTPHeaderField: "x-upsert")
+        // `x-upsert` controls dedup behavior at the Storage layer:
+        //   false (default) — duplicate path → 409, callers detect & skip.
+        //                     Right for content-addressed images keyed by
+        //                     UUID, where same path implies same bytes.
+        //   true            — duplicate path → overwrite. Right for
+        //                     "named slot" assets like the user avatar
+        //                     where the same path intentionally holds
+        //                     different bytes over time.
+        request.setValue(allowsOverwrite ? "true" : "false", forHTTPHeaderField: "x-upsert")
         request.httpBody = data
 
         let (responseData, response) = try await URLSession.shared.data(for: request)

--- a/Done/Services/SupabaseSyncService+Restore.swift
+++ b/Done/Services/SupabaseSyncService+Restore.swift
@@ -19,6 +19,11 @@ struct RestoreSnapshot {
     var agentRules: [AgentPreferenceRule]?
     /// Decoded `AgentPreferenceStore.decisionHistory` from the same row.
     var agentDecisionHistory: [AgentDecisionRecord]?
+    /// `TokenInferenceRepository`'s learned state (migration 011). All three
+    /// slices live on the same `agent_preferences` row.
+    var tokenDynamicHypotheses: [TokenDynamicHypothesisRecord]?
+    var tokenMetaHypotheses: [TokenMetaHypothesisRecord]?
+    var tokenProjections: [TokenOccurrenceProjectionRecord]?
     /// Raw JSON for the `conversations` jsonb column — we don't decode the
     /// typed `AgentConversation` array here because the sync layer doesn't
     /// depend on it directly; the AgentService consumer round-trips this
@@ -41,6 +46,9 @@ struct RestoreSnapshot {
         settings: nil as [String: Any]?,
         agentRules: nil as [AgentPreferenceRule]?,
         agentDecisionHistory: nil as [AgentDecisionRecord]?,
+        tokenDynamicHypotheses: nil as [TokenDynamicHypothesisRecord]?,
+        tokenMetaHypotheses: nil as [TokenMetaHypothesisRecord]?,
+        tokenProjections: nil as [TokenOccurrenceProjectionRecord]?,
         agentConversationsBlob: nil as Any?
     )
 }
@@ -178,9 +186,13 @@ extension SupabaseSyncService {
             .flatMap { $0["settings"] as? [String: Any] }
 
         // agent_preferences: one row, rules + decision_history as jsonb arrays
+        // + (migration 011) the three TokenInferenceRepository slices.
         let prefsRow = (raw["agent_preferences"] ?? []).first
         let agentRules: [AgentPreferenceRule]? = decodeJSONArray(prefsRow?["rules"])
         let agentDecisions: [AgentDecisionRecord]? = decodeJSONArray(prefsRow?["decision_history"])
+        let tokenDynamic: [TokenDynamicHypothesisRecord]? = decodeJSONArray(prefsRow?["token_dynamic_hypotheses"])
+        let tokenMeta: [TokenMetaHypothesisRecord]? = decodeJSONArray(prefsRow?["token_meta_hypotheses"])
+        let tokenProj: [TokenOccurrenceProjectionRecord]? = decodeJSONArray(prefsRow?["token_projections"])
 
         // agent_conversations: one row, conversations jsonb passed through raw
         // for the consumer (AgentService) to re-encode into its UserDefaults key.
@@ -203,6 +215,9 @@ extension SupabaseSyncService {
             settings: settingsBlob,
             agentRules: agentRules,
             agentDecisionHistory: agentDecisions,
+            tokenDynamicHypotheses: tokenDynamic,
+            tokenMetaHypotheses: tokenMeta,
+            tokenProjections: tokenProj,
             agentConversationsBlob: conversationsBlob
         )
     }

--- a/Done/Services/SupabaseSyncService+Restore.swift
+++ b/Done/Services/SupabaseSyncService+Restore.swift
@@ -14,11 +14,23 @@ struct RestoreSnapshot {
     /// User preferences (`UserDefaults` snapshot) — nil when the user has no
     /// cloud-side settings row yet (fresh account).
     var settings: [String: Any]?
+    /// Decoded `AgentPreferenceStore.rules` from the `agent_preferences` row.
+    /// Nil when the user has no cloud-side row yet.
+    var agentRules: [AgentPreferenceRule]?
+    /// Decoded `AgentPreferenceStore.decisionHistory` from the same row.
+    var agentDecisionHistory: [AgentDecisionRecord]?
+    /// Raw JSON for the `conversations` jsonb column — we don't decode the
+    /// typed `AgentConversation` array here because the sync layer doesn't
+    /// depend on it directly; the AgentService consumer round-trips this
+    /// blob back into UserDefaults under `agentConversations`.
+    var agentConversationsBlob: Any?
 
     var totalCount: Int {
         calendarEvents.count + todoEvents.count + logs.count + feedback.count
             + todoLists.count + eventTypes.count + skills.count
             + (settings?.isEmpty == false ? 1 : 0)
+            + ((agentRules?.isEmpty == false) || (agentDecisionHistory?.isEmpty == false) ? 1 : 0)
+            + (agentConversationsBlob != nil ? 1 : 0)
     }
 
     var isEmpty: Bool { totalCount == 0 }
@@ -26,7 +38,10 @@ struct RestoreSnapshot {
     static let empty = RestoreSnapshot(
         calendarEvents: [], todoEvents: [], logs: [], feedback: [],
         todoLists: [], eventTypes: [], skills: [],
-        settings: nil as [String: Any]?
+        settings: nil as [String: Any]?,
+        agentRules: nil as [AgentPreferenceRule]?,
+        agentDecisionHistory: nil as [AgentDecisionRecord]?,
+        agentConversationsBlob: nil as Any?
     )
 }
 
@@ -162,6 +177,21 @@ extension SupabaseSyncService {
             .first
             .flatMap { $0["settings"] as? [String: Any] }
 
+        // agent_preferences: one row, rules + decision_history as jsonb arrays
+        let prefsRow = (raw["agent_preferences"] ?? []).first
+        let agentRules: [AgentPreferenceRule]? = decodeJSONArray(prefsRow?["rules"])
+        let agentDecisions: [AgentDecisionRecord]? = decodeJSONArray(prefsRow?["decision_history"])
+
+        // agent_conversations: one row, conversations jsonb passed through raw
+        // for the consumer (AgentService) to re-encode into its UserDefaults key.
+        let conversationsRaw: Any? = (raw["agent_conversations"] ?? []).first?["conversations"]
+        let conversationsBlob: Any?
+        if let conversationsRaw, !(conversationsRaw is NSNull) {
+            conversationsBlob = conversationsRaw
+        } else {
+            conversationsBlob = nil
+        }
+
         return RestoreSnapshot(
             calendarEvents: calendar,
             todoEvents: todo,
@@ -170,8 +200,23 @@ extension SupabaseSyncService {
             todoLists: (raw["todo_lists"] ?? []).compactMap(rowToTodoList),
             eventTypes: (raw["event_types"] ?? []).compactMap(rowToEventType),
             skills: (raw["skill_insights"] ?? []).compactMap(rowToSkill),
-            settings: settingsBlob
+            settings: settingsBlob,
+            agentRules: agentRules,
+            agentDecisionHistory: agentDecisions,
+            agentConversationsBlob: conversationsBlob
         )
+    }
+
+    /// Decode a jsonb array column back into a typed Codable Swift array.
+    /// Returns nil when the column is missing or malformed (caller treats as
+    /// "no cloud value yet" rather than crashing on a partially-rolled-out
+    /// schema).
+    private static func decodeJSONArray<T: Decodable>(_ value: Any?) -> [T]? {
+        guard let value, !(value is NSNull) else { return nil }
+        guard let data = try? JSONSerialization.data(withJSONObject: value, options: []),
+              let decoded = try? JSONDecoder().decode([T].self, from: data)
+        else { return nil }
+        return decoded
     }
 
     /// Convenience: fetch + decode in one call. Throws `RestoreError.notSignedIn`

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -222,6 +222,7 @@ final class SupabaseSyncService: ObservableObject {
     private weak var attachedEventStore: EventStore?
     private weak var attachedEventTypeStore: EventTypeTemplateStore?
     private weak var attachedSkillStore: SkillInsightStore?
+    private weak var attachedPreferenceStore: AgentPreferenceStore?
 
     private var cancellables = Set<AnyCancellable>()
     private let isoFormatter: ISO8601DateFormatter = {
@@ -241,6 +242,10 @@ final class SupabaseSyncService: ObservableObject {
     /// user_settings is a single-row-per-user table — track its hash as a
     /// scalar rather than a per-id map.
     private var lastSettingsHash: String = ""
+    /// agent_preferences is also one row per user. Same scalar pattern.
+    private var lastAgentPrefsHash: String = ""
+    /// agent_conversations: same.
+    private var lastAgentConversationsHash: String = ""
 
     private var isFullSyncDone = false
 
@@ -304,12 +309,14 @@ final class SupabaseSyncService: ObservableObject {
         authService: AuthService,
         eventStore: EventStore,
         eventTypeStore: EventTypeTemplateStore,
-        skillStore: SkillInsightStore
+        skillStore: SkillInsightStore,
+        preferenceStore: AgentPreferenceStore
     ) {
         self.authService = authService
         self.attachedEventStore = eventStore
         self.attachedEventTypeStore = eventTypeStore
         self.attachedSkillStore = skillStore
+        self.attachedPreferenceStore = preferenceStore
         let debounce = SupabaseSyncConfig.debounceSeconds
 
         if Self.debugBlocksUploads {
@@ -432,16 +439,38 @@ final class SupabaseSyncService: ObservableObject {
             }
             .store(in: &cancellables)
 
-        // ── User settings ──
+        // ── User settings + agent conversations ──
         // UserDefaults.didChangeNotification fires on any write, not just our
         // synced keys, so debounce aggressively (5s) and let the row-hash check
-        // inside `syncSettings()` collapse no-op uploads to nothing.
+        // inside the sync funcs collapse no-op uploads to nothing. Conversations
+        // share this trigger because they're also persisted via UserDefaults.
         NotificationCenter.default
             .publisher(for: UserDefaults.didChangeNotification)
             .debounce(for: .seconds(5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
                 guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
-                Task { await self.syncSettings() }
+                Task {
+                    await self.syncSettings()
+                    await self.syncAgentConversations()
+                }
+            }
+            .store(in: &cancellables)
+
+        // ── Agent preferences (rules + decision history) ──
+        // PreferenceStore persists to ApplicationSupport JSON files, not
+        // UserDefaults, so it doesn't hit the didChange path above. Subscribe
+        // to its @Published arrays directly.
+        Publishers
+            .Merge(
+                preferenceStore.$rules.map { _ in () },
+                preferenceStore.$decisionHistory.map { _ in () }
+            )
+            .dropFirst(2)  // both publishers emit initial values on subscribe
+            .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
+            .sink { [weak self, weak preferenceStore] _ in
+                guard let self, let preferenceStore,
+                      self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                Task { await self.syncAgentPreferences(preferenceStore) }
             }
             .store(in: &cancellables)
     }
@@ -526,6 +555,8 @@ final class SupabaseSyncService: ObservableObject {
         lastSkillHashes = [:]
         lastEventTypeHashes = [:]
         lastSettingsHash = ""
+        lastAgentPrefsHash = ""
+        lastAgentConversationsHash = ""
     }
 
     // MARK: - Hash persistence (#30)
@@ -549,6 +580,8 @@ final class SupabaseSyncService: ObservableObject {
     /// reference from a string. If a new table is added, mirror the
     /// inline-string pattern at the new syncX wrapper.
     private static let persistedSettingsTableKey = "user_settings"
+    private static let persistedAgentPrefsTableKey = "agent_preferences"
+    private static let persistedAgentConversationsTableKey = "agent_conversations"
 
     private func hashKey(table: String, userId: String) -> String {
         "syncHashes.\(userId).\(table)"
@@ -565,6 +598,12 @@ final class SupabaseSyncService: ObservableObject {
         lastEventTypeHashes = readHashMap(table: "event_types", userId: userId)
         lastSettingsHash = UserDefaults.standard.string(
             forKey: hashKey(table: Self.persistedSettingsTableKey, userId: userId)
+        ) ?? ""
+        lastAgentPrefsHash = UserDefaults.standard.string(
+            forKey: hashKey(table: Self.persistedAgentPrefsTableKey, userId: userId)
+        ) ?? ""
+        lastAgentConversationsHash = UserDefaults.standard.string(
+            forKey: hashKey(table: Self.persistedAgentConversationsTableKey, userId: userId)
         ) ?? ""
     }
 
@@ -593,6 +632,22 @@ final class SupabaseSyncService: ObservableObject {
         )
     }
 
+    private func persistAgentPrefsHash(_ hash: String) {
+        guard !userId.isEmpty else { return }
+        UserDefaults.standard.set(
+            hash,
+            forKey: hashKey(table: Self.persistedAgentPrefsTableKey, userId: userId)
+        )
+    }
+
+    private func persistAgentConversationsHash(_ hash: String) {
+        guard !userId.isEmpty else { return }
+        UserDefaults.standard.set(
+            hash,
+            forKey: hashKey(table: Self.persistedAgentConversationsTableKey, userId: userId)
+        )
+    }
+
     /// Persist the full snapshot at once. Used by `markRestoreCompleted`
     /// (after a restore overwrites the in-memory state, we want the next
     /// launch to start from there, not from scratch).
@@ -605,6 +660,8 @@ final class SupabaseSyncService: ObservableObject {
         persistHashes(table: "skill_insights", hashes: lastSkillHashes)
         persistHashes(table: "event_types", hashes: lastEventTypeHashes)
         persistSettingsHash(lastSettingsHash)
+        persistAgentPrefsHash(lastAgentPrefsHash)
+        persistAgentConversationsHash(lastAgentConversationsHash)
     }
 
     /// Wipe persisted hashes for every user this device has ever signed in
@@ -636,6 +693,10 @@ final class SupabaseSyncService: ObservableObject {
         await syncEventTypes(eventTypeStore.templates)
         await syncSkills(skillStore.insights)
         await syncSettings()
+        if let preferenceStore = attachedPreferenceStore {
+            await syncAgentPreferences(preferenceStore)
+        }
+        await syncAgentConversations()
         logger.info("Full sync complete")
     }
 
@@ -673,6 +734,81 @@ final class SupabaseSyncService: ObservableObject {
             "updated_at": iso(Date()),
             "synced_at": iso(Date()),
         ]
+    }
+
+    // MARK: - Sync: Agent Preferences (rules + decision history)
+
+    /// Single-row-per-user, same pattern as `user_settings`. Rules and history
+    /// are encoded as JSON arrays directly into the row payload so jsonb
+    /// storage preserves the typed Swift model shape without a relational
+    /// schema for every nested enum / associated value.
+    private func syncAgentPreferences(_ store: AgentPreferenceStore) async {
+        guard !userId.isEmpty else { return }
+        let row: [String: Any] = [
+            "user_id": userId,
+            "rules": encodeJSONOrNull(store.rules),
+            "decision_history": encodeJSONOrNull(store.decisionHistory),
+            "updated_at": iso(Date()),
+            "synced_at": iso(Date()),
+        ]
+        let hash = rowHash(row)
+        guard hash != lastAgentPrefsHash else { return }
+        statusReporter?.structuredBeginBurst()
+        defer { statusReporter?.structuredEndBurst() }
+        do {
+            try await rest.upsert(table: "agent_preferences", rows: [row])
+            lastAgentPrefsHash = hash
+            persistAgentPrefsHash(hash)
+            logger.info("agent_preferences: uploaded (\(store.rules.count, privacy: .public) rules, \(store.decisionHistory.count, privacy: .public) decisions)")
+            statusReporter?.structuredRecord(table: "agent_preferences", upserts: 1, deletes: 0)
+        } catch {
+            logger.error("agent_preferences upload failed: \(error.localizedDescription, privacy: .public)")
+            statusReporter?.structuredRecordFailure(table: "agent_preferences", error: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Sync: Agent Conversations (chat history)
+
+    /// One-row-per-user blob of `AgentService.conversations`. We read straight
+    /// from UserDefaults using the same key/encoding the producer uses so this
+    /// sync layer doesn't need a reference to an AgentService instance (there
+    /// are multiple `@StateObject AgentService()` instantiations across views
+    /// that all share state via UserDefaults — no canonical singleton to hold).
+    private func syncAgentConversations() async {
+        guard !userId.isEmpty else { return }
+        // Read the raw Data the producer wrote; treat absence as empty.
+        let raw = UserDefaults.standard.data(forKey: "agentConversations") ?? Data()
+        // Decode into a generic jsonValue so we can round-trip it as jsonb
+        // in PostgREST without depending on the AgentConversation type here.
+        let decodedAny: Any
+        if raw.isEmpty {
+            decodedAny = []  // empty array → "no conversations"
+        } else if let any = try? JSONSerialization.jsonObject(with: raw) {
+            decodedAny = any
+        } else {
+            decodedAny = []  // corrupt blob — don't propagate garbage to cloud
+        }
+        let row: [String: Any] = [
+            "user_id": userId,
+            "conversations": decodedAny,
+            "updated_at": iso(Date()),
+            "synced_at": iso(Date()),
+        ]
+        let hash = rowHash(row)
+        guard hash != lastAgentConversationsHash else { return }
+        statusReporter?.structuredBeginBurst()
+        defer { statusReporter?.structuredEndBurst() }
+        do {
+            try await rest.upsert(table: "agent_conversations", rows: [row])
+            lastAgentConversationsHash = hash
+            persistAgentConversationsHash(hash)
+            let count = (decodedAny as? [Any])?.count ?? 0
+            logger.info("agent_conversations: uploaded (\(count, privacy: .public) conversations)")
+            statusReporter?.structuredRecord(table: "agent_conversations", upserts: 1, deletes: 0)
+        } catch {
+            logger.error("agent_conversations upload failed: \(error.localizedDescription, privacy: .public)")
+            statusReporter?.structuredRecordFailure(table: "agent_conversations", error: error.localizedDescription)
+        }
     }
 
     // MARK: - Generic diff + batch upsert
@@ -1051,6 +1187,8 @@ final class SupabaseSyncService: ObservableObject {
         "event_types",
         "skill_insights",
         "user_settings",
+        "agent_preferences",
+        "agent_conversations",
     ]
 
     /// Pull all rows for the current signed-in user. Returns raw row dictionaries

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -446,6 +446,77 @@ final class SupabaseSyncService: ObservableObject {
             .store(in: &cancellables)
     }
 
+    // MARK: - Per-row sync-state query (inspect UI)
+
+    /// Sync-state observable by the inspect UI. Computed on demand from the
+    /// existing in-memory hash maps; no new storage. After #30, those maps
+    /// are persisted, so this returns meaningful state from the first frame
+    /// of an inspect view (rather than "everything pending" until the first
+    /// fullSync completes after launch).
+    enum RowSyncState: Equatable {
+        case synced            // local hash matches last-persisted upload hash
+        case pending           // hash differs (or row not yet seen by sync)
+        case offline           // sync hasn't run yet this session, can't tell
+    }
+
+    /// Per-event lookup. `kind` is "todo" or "calendar" to disambiguate which
+    /// hash map to consult. Returns `.offline` when no userId is set so the
+    /// UI can show a neutral state instead of falsely claiming "pending".
+    func syncStateForEvent(_ event: Event, kind: String) -> RowSyncState {
+        guard !userId.isEmpty else { return .offline }
+        let map = kind == "todo" ? lastEventHashes : lastCalendarEventHashes
+        let currentHash = rowHash(eventToRow(event, kind: kind))
+        return map[event.id.uuidString] == currentHash ? .synced : .pending
+    }
+
+    /// Generic per-table aggregate: "are all rows in this table currently
+    /// synced?" Used by the inspect UI to render a one-line summary for
+    /// non-event tables (event_types / todo_lists / skill_insights /
+    /// user_settings) that don't live on the calendar.
+    enum TableSyncSummary: Equatable {
+        case empty                   // table is empty locally — nothing to sync
+        case synced(count: Int)
+        case pending(synced: Int, pending: Int)
+        case offline
+    }
+
+    func syncSummaryForTodoLists(_ lists: [TodoList]) -> TableSyncSummary {
+        summarize(rows: lists.map(todoListToRow), map: lastTodoListHashes)
+    }
+    func syncSummaryForEventTypes(_ types: [EventTypeTemplate]) -> TableSyncSummary {
+        summarize(rows: types.map(eventTypeToRow), map: lastEventTypeHashes)
+    }
+    func syncSummaryForSkills(_ insights: [SkillInsight]) -> TableSyncSummary {
+        summarize(rows: insights.map(skillToRow), map: lastSkillHashes)
+    }
+    func syncSummaryForLogs(_ logs: [CalendarEventLogRecord]) -> TableSyncSummary {
+        summarize(rows: logs.map(logToRow), map: lastLogHashes)
+    }
+    func syncSummaryForFeedback(_ records: [CalendarEventFeedbackRecord]) -> TableSyncSummary {
+        summarize(rows: records.map(feedbackToRow), map: lastFeedbackHashes)
+    }
+    func syncSummaryForSettings() -> TableSyncSummary {
+        guard !userId.isEmpty else { return .offline }
+        let current = rowHash(settingsToRow())
+        return current == lastSettingsHash ? .synced(count: 1) : .pending(synced: 0, pending: 1)
+    }
+
+    private func summarize(rows: [[String: Any]], map: [String: String]) -> TableSyncSummary {
+        guard !userId.isEmpty else { return .offline }
+        guard !rows.isEmpty else { return .empty }
+        var synced = 0
+        var pending = 0
+        for row in rows {
+            guard let id = row["id"] as? String else { continue }
+            if map[id] == rowHash(row) {
+                synced += 1
+            } else {
+                pending += 1
+            }
+        }
+        return pending == 0 ? .synced(count: synced) : .pending(synced: synced, pending: pending)
+    }
+
     private func clearHashes() {
         lastEventHashes = [:]
         lastCalendarEventHashes = [:]

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -813,11 +813,19 @@ final class SupabaseSyncService: ObservableObject {
     /// Same shape `syncAgentPreferences` uploads; extracted so
     /// `markRestoreCompleted` can reseed the diff baseline without
     /// re-uploading the bytes that just landed via restore.
+    ///
+    /// Includes `TokenInferenceRepository`'s 3 learned-state arrays
+    /// (migration 011) in the same row — see migration comment for
+    /// the "agent's learned model lives together" rationale.
     private func agentPreferencesToRow(_ store: AgentPreferenceStore) -> [String: Any] {
-        [
+        let tokenState = TokenInferenceRepository.shared.snapshot()
+        return [
             "user_id": userId,
             "rules": encodeJSONOrNull(store.rules),
             "decision_history": encodeJSONOrNull(store.decisionHistory),
+            "token_dynamic_hypotheses": encodeJSONOrNull(tokenState.dynamic),
+            "token_meta_hypotheses": encodeJSONOrNull(tokenState.meta),
+            "token_projections": encodeJSONOrNull(tokenState.projections),
             "updated_at": iso(Date()),
             "synced_at": iso(Date()),
         ]

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -180,6 +180,14 @@ final class SupabaseSyncService: ObservableObject {
     /// `ContentView` at attach time; nil-tolerant so the service still works
     /// in tests / standalone contexts without reporter plumbing.
     weak var statusReporter: SyncStatusReporter?
+
+    /// Cached store references so `userDidEnableUploads()` can run a fresh
+    /// `fullSync` without re-attaching the Combine pipeline. Set in `attach`,
+    /// nilled implicitly by weak semantics if the stores go away.
+    private weak var attachedEventStore: EventStore?
+    private weak var attachedEventTypeStore: EventTypeTemplateStore?
+    private weak var attachedSkillStore: SkillInsightStore?
+
     private var cancellables = Set<AnyCancellable>()
     private let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -208,16 +216,42 @@ final class SupabaseSyncService: ObservableObject {
         self.rest = SupabaseREST(url: url, apiKey: apiKey)
     }
 
-    /// In DEBUG builds we disable all upload paths (fullSync + the per-store
-    /// Combine sinks) so simulator/dev runs can sign in with a real account
-    /// without polluting the production Supabase tables. Read paths
-    /// (`fetchAllRawRows`) stay live so dry-run preview and restore still work.
-    /// Release builds always sync normally.
+    /// DEBUG safety net: compile-time block that prevents any simulator or
+    /// dev-built binary from writing to the production Supabase project.
+    /// Independent of the user-controlled `syncUploadsEnabled` toggle — DEBUG
+    /// blocks regardless of what the user picked, so accidental builds can
+    /// never pollute prod. Read paths (`fetchAllRawRows`) stay live in both
+    /// modes so dry-run preview and restore still work.
     #if DEBUG
-    private static let uploadsDisabled = true
+    static let debugBlocksUploads = true
     #else
-    private static let uploadsDisabled = false
+    static let debugBlocksUploads = false
     #endif
+
+    /// Runtime gate: are uploads currently allowed for this device?
+    /// `debugBlocksUploads` (compile-time) AND `syncUploadsEnabled` (user
+    /// toggle, defaults OFF on a fresh install). Read on every sync entry
+    /// point so flipping the toggle takes effect on the very next debounce
+    /// without needing to re-attach the Combine pipeline.
+    nonisolated var canUpload: Bool {
+        if Self.debugBlocksUploads { return false }
+        return UserDefaults.standard.bool(forKey: AppSettingsKeys.syncUploadsEnabled)
+    }
+
+    /// Called by the settings UI when the user flips the upload toggle from
+    /// OFF → ON. Triggers a fresh fullSync to catch up the cloud with all
+    /// the local changes that accumulated while uploads were paused.
+    func userDidEnableUploads() {
+        guard canUpload, !userId.isEmpty else { return }
+        guard let es = attachedEventStore,
+              let ets = attachedEventTypeStore,
+              let ss = attachedSkillStore else { return }
+        Task {
+            self.isFullSyncDone = false
+            await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
+            self.isFullSyncDone = true
+        }
+    }
 
     /// Start observing stores. Call once after stores are initialized.
     func attach(
@@ -227,23 +261,28 @@ final class SupabaseSyncService: ObservableObject {
         skillStore: SkillInsightStore
     ) {
         self.authService = authService
+        self.attachedEventStore = eventStore
+        self.attachedEventTypeStore = eventTypeStore
+        self.attachedSkillStore = skillStore
         let debounce = SupabaseSyncConfig.debounceSeconds
 
-        if Self.uploadsDisabled {
+        if Self.debugBlocksUploads {
             logger.notice("⚠️ DEBUG build — uploads disabled. Auth + read-only sync only. Restore (GET) still works.")
         }
 
         // ── Watch auth state: keep userId in lockstep with session in all
         //    builds (fetchAllRawRows needs it). Skip the upload-side fullSync
-        //    when uploads are disabled.
+        //    when uploads are disabled by either gate (DEBUG or user toggle).
         authService.$session
             .sink { [weak self, weak eventStore, weak eventTypeStore, weak skillStore] session in
                 guard let self else { return }
                 if let session {
                     self.userId = session.user.id
-                    if Self.uploadsDisabled {
+                    if !self.canUpload {
                         // Mark "ready" so any code gated on isFullSyncDone still
-                        // works as expected (no harm — there are no sinks to gate).
+                        // works as expected. No fullSync — that runs when the
+                        // toggle flips on (see `userDidEnableUploads`) or when
+                        // the next debounced sink fires with the toggle on.
                         self.isFullSyncDone = true
                         return
                     }
@@ -264,15 +303,17 @@ final class SupabaseSyncService: ObservableObject {
 
         // In DEBUG, skip wiring up any of the upload-side Combine sinks below.
         // The signed-in userId is still set above so `fetchAllRawRows()` works,
-        // but nothing on the device will ever be pushed to Supabase.
-        if Self.uploadsDisabled { return }
+        // but nothing on the device will ever be pushed to Supabase. In Release
+        // we wire the sinks unconditionally — each sink body checks `canUpload`
+        // so the user toggle takes effect dynamically.
+        if Self.debugBlocksUploads { return }
 
         // ── Todo events ──
         eventStore.$events
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] events in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEvents(events, kind: "todo") }
             }
             .store(in: &cancellables)
@@ -282,7 +323,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] events in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEvents(events, kind: "calendar") }
             }
             .store(in: &cancellables)
@@ -292,7 +333,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] logs in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncLogs(logs) }
             }
             .store(in: &cancellables)
@@ -302,7 +343,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] records in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncFeedback(records) }
             }
             .store(in: &cancellables)
@@ -312,7 +353,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] lists in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncTodoLists(lists) }
             }
             .store(in: &cancellables)
@@ -322,7 +363,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] templates in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncEventTypes(templates) }
             }
             .store(in: &cancellables)
@@ -332,7 +373,7 @@ final class SupabaseSyncService: ObservableObject {
             .dropFirst()
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] insights in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncSkills(insights) }
             }
             .store(in: &cancellables)
@@ -345,7 +386,7 @@ final class SupabaseSyncService: ObservableObject {
             .publisher(for: UserDefaults.didChangeNotification)
             .debounce(for: .seconds(5), scheduler: RunLoop.main)
             .sink { [weak self] _ in
-                guard let self, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
                 Task { await self.syncSettings() }
             }
             .store(in: &cancellables)

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -209,6 +209,13 @@ final class SupabaseSyncService: ObservableObject {
 
     private var isFullSyncDone = false
 
+    /// Re-entry guard for `fullSync`. The sign-in path and
+    /// `userDidEnableUploads` can both kick off a fullSync; rapid toggle
+    /// flipping could otherwise spawn N parallel passes that idempotent-upsert
+    /// the same rows and stretch the `isFullSyncDone == false` window that
+    /// blocks debounced sinks. Set inside the Task, cleared in defer.
+    private var fullSyncInFlight = false
+
     init(
         url: String = SupabaseSyncConfig.url,
         apiKey: String = SupabaseSyncConfig.anonKey
@@ -240,13 +247,17 @@ final class SupabaseSyncService: ObservableObject {
 
     /// Called by the settings UI when the user flips the upload toggle from
     /// OFF → ON. Triggers a fresh fullSync to catch up the cloud with all
-    /// the local changes that accumulated while uploads were paused.
+    /// the local changes that accumulated while uploads were paused. If a
+    /// fullSync is already in flight (e.g. rapid OFF→ON→OFF→ON), this is a
+    /// no-op — the in-flight pass already covers the catch-up work.
     func userDidEnableUploads() {
-        guard canUpload, !userId.isEmpty else { return }
+        guard canUpload, !userId.isEmpty, !fullSyncInFlight else { return }
         guard let es = attachedEventStore,
               let ets = attachedEventTypeStore,
               let ss = attachedSkillStore else { return }
         Task {
+            self.fullSyncInFlight = true
+            defer { self.fullSyncInFlight = false }
             self.isFullSyncDone = false
             await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
             self.isFullSyncDone = true
@@ -286,8 +297,11 @@ final class SupabaseSyncService: ObservableObject {
                         self.isFullSyncDone = true
                         return
                     }
-                    if let es = eventStore, let ets = eventTypeStore, let ss = skillStore {
+                    if let es = eventStore, let ets = eventTypeStore, let ss = skillStore,
+                       !self.fullSyncInFlight {
                         Task {
+                            self.fullSyncInFlight = true
+                            defer { self.fullSyncInFlight = false }
                             self.isFullSyncDone = false
                             await self.fullSync(eventStore: es, eventTypeStore: ets, skillStore: ss)
                             self.isFullSyncDone = true

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -436,11 +436,12 @@ final class SupabaseSyncService: ObservableObject {
     // in-memory copy so the next sign-in (same account) re-uses persisted
     // state.
 
-    private static let persistedTableKeys: [String] = [
-        "events", "calendar_events", "event_logs",
-        "event_feedback", "todo_lists", "skill_insights",
-        "event_types",
-    ]
+    /// Storage key suffix for `user_settings`' scalar hash. The 7 per-row
+    /// table keys are inline at their respective syncX callsites — they
+    /// can't be DRY'd into a list because each wrapper also reads/writes
+    /// a distinct stored property, and Swift can't dispatch a property
+    /// reference from a string. If a new table is added, mirror the
+    /// inline-string pattern at the new syncX wrapper.
     private static let persistedSettingsTableKey = "user_settings"
 
     private func hashKey(table: String, userId: String) -> String {

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -481,6 +481,20 @@ final class SupabaseSyncService: ObservableObject {
                 Task { await self.syncAgentPreferences(preferenceStore) }
             }
             .store(in: &cancellables)
+
+        // ── Token inference state (lives on the same agent_preferences
+        // row, but `TokenInferenceRepository` doesn't expose @Published
+        // arrays — it posts `.tokenInferenceStateDidChange` from its save
+        // methods instead).
+        NotificationCenter.default
+            .publisher(for: .tokenInferenceStateDidChange)
+            .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
+            .sink { [weak self, weak preferenceStore] _ in
+                guard let self, let preferenceStore,
+                      self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
+                Task { await self.syncAgentPreferences(preferenceStore) }
+            }
+            .store(in: &cancellables)
     }
 
     // MARK: - Per-row sync-state query (inspect UI)

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -149,6 +149,22 @@ final class SupabaseREST: Sendable {
 private let rowHashIgnoredKeys: Set<String> = ["synced_at", "updated_at"]
 
 /// Compute a stable hash for a row dictionary so we can detect changes.
+///
+/// **Cross-process determinism is load-bearing now that hashes are persisted
+/// (#30).** Swift's `String(describing:)` on a `Dictionary` walks its
+/// underlying hash table in random order — fine within one process, but two
+/// runs of the same row will produce two different strings (and therefore
+/// two different hashes), causing every relaunch to treat every nested-dict
+/// row as "changed". Pre-#30 this was a non-issue because every relaunch
+/// started with empty hash maps anyway; post-#30 it caused `user_settings`
+/// to enter an infinite re-upload loop (settings has a deep nested dict;
+/// upload writes UserDefaults; didChangeNotification fires; debounce arms;
+/// 5s later the same data hashes to a *different* value; upload again …).
+///
+/// Fix: serialize nested arrays/dicts via `JSONSerialization` with
+/// `.sortedKeys`, which produces canonical ordering. Scalars
+/// (`String`/`Bool`/`Int`/`NSNumber`) keep `String(describing:)` — their
+/// representation is already deterministic.
 private func rowHash(_ row: [String: Any]) -> String {
     // Sort keys for deterministic output
     let sorted = row.keys.sorted()
@@ -158,12 +174,31 @@ private func rowHash(_ row: [String: Any]) -> String {
         if val is NSNull {
             parts.append("\(key):null")
         } else {
-            parts.append("\(key):\(String(describing: val!))")
+            parts.append("\(key):\(canonicalDescription(val!))")
         }
     }
     let joined = parts.joined(separator: "|")
     let digest = SHA256.hash(data: Data(joined.utf8))
     return digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+}
+
+/// Deterministic string form for a single row-cell value. Falls back to
+/// `String(describing:)` for primitives (already deterministic) and uses
+/// sorted-key JSON for nested dicts/arrays. See the long comment on
+/// `rowHash` for why this matters.
+private func canonicalDescription(_ value: Any) -> String {
+    // Nested JSON-shaped values must serialize with deterministic key order.
+    if value is [String: Any] || value is [Any] {
+        if JSONSerialization.isValidJSONObject(value),
+           let data = try? JSONSerialization.data(
+               withJSONObject: value,
+               options: [.sortedKeys]
+           ),
+           let str = String(data: data, encoding: .utf8) {
+            return str
+        }
+    }
+    return String(describing: value)
 }
 
 // MARK: - Sync Service

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -289,6 +289,11 @@ final class SupabaseSyncService: ObservableObject {
                 guard let self else { return }
                 if let session {
                     self.userId = session.user.id
+                    // Rehydrate diff-sync baseline from disk before any sync
+                    // runs. Without this every cold start treats all rows as
+                    // changed (issue #30 was the tracking ticket for the bug
+                    // this addresses).
+                    self.loadHashes(forUserId: self.userId)
                     if !self.canUpload {
                         // Mark "ready" so any code gated on isFullSyncDone still
                         // works as expected. No fullSync — that runs when the
@@ -417,6 +422,95 @@ final class SupabaseSyncService: ObservableObject {
         lastSettingsHash = ""
     }
 
+    // MARK: - Hash persistence (#30)
+    //
+    // Diff-sync hash maps are persisted to UserDefaults so a relaunch with no
+    // edits doesn't fall back to the empty-map-against-current-rows case,
+    // which would treat every row as "changed" and burn bandwidth uploading
+    // ~1,800 idempotent rows on every cold start.
+    //
+    // Storage shape: `syncHashes.<userId>.<tableLabel>` — JSON-encoded
+    // `[rowId: hash]` for per-row maps, plain `String` for user_settings'
+    // scalar hash. user_id scoping lets one device juggle multiple accounts
+    // without cross-contaminating baselines; `clearHashes()` only wipes the
+    // in-memory copy so the next sign-in (same account) re-uses persisted
+    // state.
+
+    private static let persistedTableKeys: [String] = [
+        "events", "calendar_events", "event_logs",
+        "event_feedback", "todo_lists", "skill_insights",
+        "event_types",
+    ]
+    private static let persistedSettingsTableKey = "user_settings"
+
+    private func hashKey(table: String, userId: String) -> String {
+        "syncHashes.\(userId).\(table)"
+    }
+
+    private func loadHashes(forUserId userId: String) {
+        guard !userId.isEmpty else { return }
+        lastEventHashes = readHashMap(table: "events", userId: userId)
+        lastCalendarEventHashes = readHashMap(table: "calendar_events", userId: userId)
+        lastLogHashes = readHashMap(table: "event_logs", userId: userId)
+        lastFeedbackHashes = readHashMap(table: "event_feedback", userId: userId)
+        lastTodoListHashes = readHashMap(table: "todo_lists", userId: userId)
+        lastSkillHashes = readHashMap(table: "skill_insights", userId: userId)
+        lastEventTypeHashes = readHashMap(table: "event_types", userId: userId)
+        lastSettingsHash = UserDefaults.standard.string(
+            forKey: hashKey(table: Self.persistedSettingsTableKey, userId: userId)
+        ) ?? ""
+    }
+
+    private func readHashMap(table: String, userId: String) -> [String: String] {
+        guard let data = UserDefaults.standard.data(forKey: hashKey(table: table, userId: userId)),
+              let map = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return map
+    }
+
+    /// Persist a per-row hash map. Called by each per-table sync after the
+    /// in-memory map is updated. No-op when `userId` isn't set (e.g. signed-out
+    /// state) — we never persist hashes that can't be scoped to a user.
+    private func persistHashes(table: String, hashes: [String: String]) {
+        guard !userId.isEmpty,
+              let data = try? JSONEncoder().encode(hashes)
+        else { return }
+        UserDefaults.standard.set(data, forKey: hashKey(table: table, userId: userId))
+    }
+
+    private func persistSettingsHash(_ hash: String) {
+        guard !userId.isEmpty else { return }
+        UserDefaults.standard.set(
+            hash,
+            forKey: hashKey(table: Self.persistedSettingsTableKey, userId: userId)
+        )
+    }
+
+    /// Persist the full snapshot at once. Used by `markRestoreCompleted`
+    /// (after a restore overwrites the in-memory state, we want the next
+    /// launch to start from there, not from scratch).
+    private func persistAllHashes() {
+        persistHashes(table: "events", hashes: lastEventHashes)
+        persistHashes(table: "calendar_events", hashes: lastCalendarEventHashes)
+        persistHashes(table: "event_logs", hashes: lastLogHashes)
+        persistHashes(table: "event_feedback", hashes: lastFeedbackHashes)
+        persistHashes(table: "todo_lists", hashes: lastTodoListHashes)
+        persistHashes(table: "skill_insights", hashes: lastSkillHashes)
+        persistHashes(table: "event_types", hashes: lastEventTypeHashes)
+        persistSettingsHash(lastSettingsHash)
+    }
+
+    /// Wipe persisted hashes for every user this device has ever signed in
+    /// as. Used by "Reset all local data" in settings. Scans UserDefaults
+    /// for keys with the `syncHashes.` prefix (since `userId` itself may
+    /// not be currently known if the reset runs while signed out).
+    static func wipeAllPersistedHashes() {
+        let defaults = UserDefaults.standard
+        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix("syncHashes.") {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
     // MARK: - Full sync (on launch)
 
     private func fullSync(
@@ -456,6 +550,7 @@ final class SupabaseSyncService: ObservableObject {
         do {
             try await rest.upsert(table: "user_settings", rows: [row])
             lastSettingsHash = hash
+            persistSettingsHash(hash)
             logger.info("user_settings: uploaded (\(row.count, privacy: .public) keys)")
             statusReporter?.structuredRecord(table: "user_settings", upserts: 1, deletes: 0)
         } catch {
@@ -566,8 +661,13 @@ final class SupabaseSyncService: ObservableObject {
             previousHashes: previousHashes
         )
 
-        if kind == "todo" { lastEventHashes = newHashes }
-        else { lastCalendarEventHashes = newHashes }
+        if kind == "todo" {
+            lastEventHashes = newHashes
+            persistHashes(table: "events", hashes: newHashes)
+        } else {
+            lastCalendarEventHashes = newHashes
+            persistHashes(table: "calendar_events", hashes: newHashes)
+        }
     }
 
     private func iso(_ date: Date) -> String {
@@ -662,6 +762,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: rows,
             previousHashes: lastLogHashes
         )
+        persistHashes(table: "event_logs", hashes: lastLogHashes)
     }
 
     private func logToRow(_ log: CalendarEventLogRecord) -> [String: Any] {
@@ -713,6 +814,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: rows,
             previousHashes: lastFeedbackHashes
         )
+        persistHashes(table: "event_feedback", hashes: lastFeedbackHashes)
     }
 
     private func feedbackToRow(_ r: CalendarEventFeedbackRecord) -> [String: Any] {
@@ -750,6 +852,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: rows,
             previousHashes: lastTodoListHashes
         )
+        persistHashes(table: "todo_lists", hashes: lastTodoListHashes)
     }
 
     private func todoListToRow(_ l: TodoList) -> [String: Any] {
@@ -772,6 +875,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: rows,
             previousHashes: lastEventTypeHashes
         )
+        persistHashes(table: "event_types", hashes: lastEventTypeHashes)
     }
 
     private func eventTypeToRow(_ t: EventTypeTemplate) -> [String: Any] {
@@ -794,6 +898,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: rows,
             previousHashes: lastSkillHashes
         )
+        persistHashes(table: "skill_insights", hashes: lastSkillHashes)
     }
 
     private func skillToRow(_ s: SkillInsight) -> [String: Any] {
@@ -899,6 +1004,9 @@ final class SupabaseSyncService: ObservableObject {
         // restored settings. Seed the scalar hash with the current state so
         // the next debounced settings sink sees zero diff.
         lastSettingsHash = rowHash(settingsToRow())
+        // Persist the just-restored baseline so the next launch starts from
+        // here, not from an empty map that would re-upload everything.
+        persistAllHashes()
     }
 
     private func hashMap(rows: [[String: Any]]) -> [String: String] {

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -16,6 +16,12 @@ enum SupabaseSyncConfig {
     nonisolated static let debounceSeconds: TimeInterval = 2.0
 }
 
+/// UserDefaults key holding the JSON-encoded `[AgentConversation]` blob.
+/// Producer: `AgentService.conversationsStorageKey` (private). Consumers
+/// here and in the restore flow rely on the same string; centralizing it
+/// at file scope avoids three magic strings drifting apart silently.
+let AgentConversationsStorageKey = "agentConversations"
+
 // MARK: - Supabase REST Client (minimal, no SDK dependency)
 
 /// Thin REST client for Supabase PostgREST. No external dependencies.
@@ -459,13 +465,15 @@ final class SupabaseSyncService: ObservableObject {
         // ── Agent preferences (rules + decision history) ──
         // PreferenceStore persists to ApplicationSupport JSON files, not
         // UserDefaults, so it doesn't hit the didChange path above. Subscribe
-        // to its @Published arrays directly.
-        Publishers
-            .Merge(
-                preferenceStore.$rules.map { _ in () },
-                preferenceStore.$decisionHistory.map { _ in () }
-            )
-            .dropFirst(2)  // both publishers emit initial values on subscribe
+        // to its @Published arrays via combineLatest — that primitive emits
+        // ONE initial combined value, so `dropFirst()` (singular) is a
+        // contract guarantee. The earlier `Publishers.Merge` + `dropFirst(2)`
+        // shape relied on a count that drifts if a sibling adds
+        // `.removeDuplicates()` upstream or if init order changes.
+        preferenceStore.$rules
+            .combineLatest(preferenceStore.$decisionHistory)
+            .dropFirst()
+            .map { _ in () }
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self, weak preferenceStore] _ in
                 guard let self, let preferenceStore,
@@ -528,6 +536,18 @@ final class SupabaseSyncService: ObservableObject {
         guard !userId.isEmpty else { return .offline }
         let current = rowHash(settingsToRow())
         return current == lastSettingsHash ? .synced(count: 1) : .pending(synced: 0, pending: 1)
+    }
+
+    func syncSummaryForAgentPreferences(_ store: AgentPreferenceStore) -> TableSyncSummary {
+        guard !userId.isEmpty else { return .offline }
+        let current = rowHash(agentPreferencesToRow(store))
+        return current == lastAgentPrefsHash ? .synced(count: 1) : .pending(synced: 0, pending: 1)
+    }
+
+    func syncSummaryForAgentConversations() -> TableSyncSummary {
+        guard !userId.isEmpty else { return .offline }
+        let current = rowHash(agentConversationsToRow())
+        return current == lastAgentConversationsHash ? .synced(count: 1) : .pending(synced: 0, pending: 1)
     }
 
     private func summarize(rows: [[String: Any]], map: [String: String]) -> TableSyncSummary {
@@ -744,13 +764,7 @@ final class SupabaseSyncService: ObservableObject {
     /// schema for every nested enum / associated value.
     private func syncAgentPreferences(_ store: AgentPreferenceStore) async {
         guard !userId.isEmpty else { return }
-        let row: [String: Any] = [
-            "user_id": userId,
-            "rules": encodeJSONOrNull(store.rules),
-            "decision_history": encodeJSONOrNull(store.decisionHistory),
-            "updated_at": iso(Date()),
-            "synced_at": iso(Date()),
-        ]
+        let row = agentPreferencesToRow(store)
         let hash = rowHash(row)
         guard hash != lastAgentPrefsHash else { return }
         statusReporter?.structuredBeginBurst()
@@ -776,24 +790,7 @@ final class SupabaseSyncService: ObservableObject {
     /// that all share state via UserDefaults — no canonical singleton to hold).
     private func syncAgentConversations() async {
         guard !userId.isEmpty else { return }
-        // Read the raw Data the producer wrote; treat absence as empty.
-        let raw = UserDefaults.standard.data(forKey: "agentConversations") ?? Data()
-        // Decode into a generic jsonValue so we can round-trip it as jsonb
-        // in PostgREST without depending on the AgentConversation type here.
-        let decodedAny: Any
-        if raw.isEmpty {
-            decodedAny = []  // empty array → "no conversations"
-        } else if let any = try? JSONSerialization.jsonObject(with: raw) {
-            decodedAny = any
-        } else {
-            decodedAny = []  // corrupt blob — don't propagate garbage to cloud
-        }
-        let row: [String: Any] = [
-            "user_id": userId,
-            "conversations": decodedAny,
-            "updated_at": iso(Date()),
-            "synced_at": iso(Date()),
-        ]
+        let row = agentConversationsToRow()
         let hash = rowHash(row)
         guard hash != lastAgentConversationsHash else { return }
         statusReporter?.structuredBeginBurst()
@@ -802,13 +799,47 @@ final class SupabaseSyncService: ObservableObject {
             try await rest.upsert(table: "agent_conversations", rows: [row])
             lastAgentConversationsHash = hash
             persistAgentConversationsHash(hash)
-            let count = (decodedAny as? [Any])?.count ?? 0
+            let count = (row["conversations"] as? [Any])?.count ?? 0
             logger.info("agent_conversations: uploaded (\(count, privacy: .public) conversations)")
             statusReporter?.structuredRecord(table: "agent_conversations", upserts: 1, deletes: 0)
         } catch {
             logger.error("agent_conversations upload failed: \(error.localizedDescription, privacy: .public)")
             statusReporter?.structuredRecordFailure(table: "agent_conversations", error: error.localizedDescription)
         }
+    }
+
+    // MARK: - Row builders for the two new single-row blob tables
+
+    /// Same shape `syncAgentPreferences` uploads; extracted so
+    /// `markRestoreCompleted` can reseed the diff baseline without
+    /// re-uploading the bytes that just landed via restore.
+    private func agentPreferencesToRow(_ store: AgentPreferenceStore) -> [String: Any] {
+        [
+            "user_id": userId,
+            "rules": encodeJSONOrNull(store.rules),
+            "decision_history": encodeJSONOrNull(store.decisionHistory),
+            "updated_at": iso(Date()),
+            "synced_at": iso(Date()),
+        ]
+    }
+
+    /// Same shape `syncAgentConversations` uploads.
+    private func agentConversationsToRow() -> [String: Any] {
+        let raw = UserDefaults.standard.data(forKey: AgentConversationsStorageKey) ?? Data()
+        let decoded: Any
+        if raw.isEmpty {
+            decoded = []
+        } else if let any = try? JSONSerialization.jsonObject(with: raw) {
+            decoded = any
+        } else {
+            decoded = []  // corrupt blob — don't propagate garbage to cloud
+        }
+        return [
+            "user_id": userId,
+            "conversations": decoded,
+            "updated_at": iso(Date()),
+            "synced_at": iso(Date()),
+        ]
     }
 
     // MARK: - Generic diff + batch upsert
@@ -1249,6 +1280,16 @@ final class SupabaseSyncService: ObservableObject {
         // restored settings. Seed the scalar hash with the current state so
         // the next debounced settings sink sees zero diff.
         lastSettingsHash = rowHash(settingsToRow())
+        // Same reasoning for the two new blob tables (#2 + #3 from the
+        // full-backup audit). Without these reseeds, applying a restore
+        // would observe the just-written `preferenceStore` arrays + the
+        // re-encoded `agentConversations` UserDefaults blob, compare to
+        // empty hashes, see "different", and re-upload the restored bytes
+        // — bumping cloud `updated_at`/`synced_at` for no real change.
+        if let preferenceStore = attachedPreferenceStore {
+            lastAgentPrefsHash = rowHash(agentPreferencesToRow(preferenceStore))
+        }
+        lastAgentConversationsHash = rowHash(agentConversationsToRow())
         // Persist the just-restored baseline so the next launch starts from
         // here, not from an empty map that would re-upload everything.
         persistAllHashes()

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -784,6 +784,9 @@ struct DataPrivacySettingsView: View {
         for key in AppSettingsKeys.resettableUserDefaultsKeys {
             defaults.removeObject(forKey: key)
         }
+        // Sync diff-hash maps are keyed per-userId, so they aren't in the
+        // static resettable list — wipe them with a prefix scan instead.
+        SupabaseSyncService.wipeAllPersistedHashes()
     }
 
     @ViewBuilder

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -701,6 +701,16 @@ struct DataPrivacySettingsView: View {
                         )
                     }
                 }
+                // Without this hint the card looks broken when the toggle is
+                // off — three idle rows with no obvious reason. Surface the
+                // gate state directly so the user can connect cause and effect.
+                if !syncUploadsEnabled {
+                    Text("Uploads are off for this device. Flip the Sync toggle above to start pushing changes to the cloud.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             settingsCard(L(.manageData)) {

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -614,6 +614,8 @@ struct DataPrivacySettingsView: View {
     @EnvironmentObject private var restoreCoordinator: RestoreCoordinator
     @EnvironmentObject private var imageBackupCoordinator: ImageBackupCoordinator
     @EnvironmentObject private var syncStatusReporter: SyncStatusReporter
+    @EnvironmentObject private var syncService: SupabaseSyncService
+    @AppStorage(AppSettingsKeys.syncUploadsEnabled) private var syncUploadsEnabled = false
     @State private var isConfirmingSkillClear = false
     @State private var isConfirmingInferenceClear = false
     @State private var isConfirmingResetAll = false
@@ -628,6 +630,26 @@ struct DataPrivacySettingsView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+
+            settingsCard("Sync", spacing: 14) {
+                Toggle(isOn: $syncUploadsEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Upload this device's data to the cloud")
+                            .font(.subheadline.weight(.medium))
+                        Text("When off, this device only reads (restore still works). Off by default so a fresh install never surprise-writes your cloud data. Independent per device — your other devices keep their own setting.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                #if DEBUG
+                Text("Debug build: uploads are blocked regardless of this toggle as an extra safety net. Use a Release build to actually exercise the cloud write path.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                #endif
             }
 
             settingsCard("Cloud Backup", spacing: 14) {
@@ -704,6 +726,15 @@ struct DataPrivacySettingsView: View {
             RestoreSheet(previewOnly: true)
                 .environmentObject(restoreCoordinator)
                 .environmentObject(imageBackupCoordinator)
+        }
+        .onChange(of: syncUploadsEnabled) { oldValue, newValue in
+            // OFF → ON: catch the cloud up with everything that accumulated
+            // while uploads were paused. Triggers a full structured-data
+            // sync and clears the image-suppression cache so previously
+            // skipped images get re-evaluated.
+            guard !oldValue, newValue else { return }
+            syncService.userDidEnableUploads()
+            imageBackupCoordinator.userDidEnableUploads()
         }
         .alert(L(.alertClearSkillInsights), isPresented: $isConfirmingSkillClear) {
             Button(L(.cancel), role: .cancel) {}

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -711,6 +711,25 @@ struct DataPrivacySettingsView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+
+                NavigationLink {
+                    SyncInspectView()
+                } label: {
+                    HStack {
+                        Image(systemName: "calendar.badge.checkmark")
+                            .foregroundStyle(Color.accentColor)
+                        Text("Calendar Sync Snapshot")
+                            .font(.subheadline)
+                            .foregroundStyle(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
             }
 
             settingsCard(L(.manageData)) {

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -806,6 +806,22 @@ struct DataPrivacySettingsView: View {
         // Sync diff-hash maps are keyed per-userId, so they aren't in the
         // static resettable list — wipe them with a prefix scan instead.
         SupabaseSyncService.wipeAllPersistedHashes()
+
+        // Additional UserDefaults blobs that aren't in the static
+        // resettable list but ARE user-owned state per the full-backup
+        // audit. Missing these meant "Reset all" kept conversations /
+        // avatar slot / log-template preferences / etc. across the reset.
+        defaults.removeObject(forKey: AgentConversationsStorageKey)
+        defaults.removeObject(forKey: EventLogTemplatePreferenceStore.storageKey)
+        defaults.removeObject(forKey: "eventTypeColorHistory")
+        defaults.removeObject(forKey: "skillAnalyzedEventIds")
+        // Per-user keys (prefix scan, same shape as wipeAllPersistedHashes):
+        for key in defaults.dictionaryRepresentation().keys
+            where key.hasPrefix("lastSyncedAvatarVersion.") || key.hasPrefix("hasOfferedAutoRestore.") {
+            defaults.removeObject(forKey: key)
+        }
+        // Avatar file on disk (UserDefaults-only reset won't catch it).
+        MeAvatarStore.delete()
     }
 
     @ViewBuilder

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -792,6 +792,16 @@ struct DataPrivacySettingsView: View {
     }
 
     private func resetAllLocalData() {
+        // Disable uploads first. Without this, the debounced sinks fired
+        // by the wipes below (EventStore @Published, didChangeNotification
+        // from each removeObject) would fire 2-5s later, see canUpload
+        // still true, hash now-empty rows against just-wiped hash maps,
+        // and push an essentially-empty state to cloud — bulldozing the
+        // user's existing cloud data right when they may want it preserved
+        // for a future restore. "Reset all" is local-scoped by name; the
+        // user re-enables uploads explicitly if they want fresh-cloud too.
+        UserDefaults.standard.set(false, forKey: AppSettingsKeys.syncUploadsEnabled)
+
         store.clearAllLocalData()
         skillStore.clearAll()
         TokenInferenceRepository.shared.clearAll()

--- a/Done/Views/Agent/SyncInspectView.swift
+++ b/Done/Views/Agent/SyncInspectView.swift
@@ -1,0 +1,390 @@
+import SwiftUI
+
+/// Calendar-style "where does each event live, and is it in the cloud?"
+/// inspector. Reachable from Data & Privacy → Sync Status → "Calendar Sync
+/// Snapshot". Read-only — does not trigger syncs, just visualizes the state
+/// that `SupabaseSyncService`'s in-memory hash maps already track (which
+/// are persisted across launches per #30).
+///
+/// Layout:
+///
+///   ←  May 2026  →
+///
+///   Mo Tu We Th Fr Sa Su
+///   .  .  ●  ●  ●  ●  .
+///   ●  ●  ●  ●  ◐  .  .
+///   ●  ⚠  ●  ●  ●  ●  .
+///   ...
+///
+/// Each cell shows the day number and a per-day rollup dot:
+///   ●  every event on that day is synced
+///   ◐  at least one event on that day is pending
+///   ·  no events placed on that day
+///
+/// Tap a day → bottom sheet with the day's events and per-event status.
+/// Non-event tables (event_types / todo_lists / skill_insights /
+/// user_settings) get an aggregate row at the bottom — they don't live on
+/// a calendar.
+struct SyncInspectView: View {
+    @EnvironmentObject private var store: EventStore
+    @EnvironmentObject private var syncService: SupabaseSyncService
+    @EnvironmentObject private var skillStore: SkillInsightStore
+    @EnvironmentObject private var agentRuntime: AgentRuntime
+
+    @State private var displayedMonth: Date = Self.startOfMonth(Date())
+    @State private var selectedDay: SelectedDay?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                monthHeader
+                weekdayHeader
+                calendarGrid
+                legend
+                otherTablesSection
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .navigationTitle("Calendar Sync Snapshot")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedDay) { day in
+            DaySyncDetailSheet(day: day.date, events: events(on: day.date))
+                .environmentObject(syncService)
+        }
+    }
+
+    // MARK: - Month header / nav
+
+    private var monthHeader: some View {
+        HStack {
+            Button {
+                shift(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.headline)
+            }
+            Spacer()
+            Text(Self.monthYearFormatter.string(from: displayedMonth))
+                .font(.title3.weight(.semibold))
+            Spacer()
+            Button {
+                shift(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.headline)
+            }
+            .disabled(Self.startOfMonth(Date()) <= displayedMonth)
+        }
+        .buttonStyle(.borderless)
+    }
+
+    private func shift(by months: Int) {
+        guard let new = Calendar.current.date(byAdding: .month, value: months, to: displayedMonth) else { return }
+        displayedMonth = Self.startOfMonth(new)
+    }
+
+    // MARK: - Grid
+
+    private var weekdayHeader: some View {
+        // Mon-first layout matches existing calendar code's convention.
+        let labels = ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
+        return HStack(spacing: 0) {
+            ForEach(labels, id: \.self) { l in
+                Text(l)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    private var calendarGrid: some View {
+        let cells = monthCells(for: displayedMonth)
+        return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 8) {
+            ForEach(cells) { cell in
+                dayCell(cell)
+                    .onTapGesture {
+                        guard cell.inMonth, !cell.events.isEmpty else { return }
+                        selectedDay = SelectedDay(date: cell.date)
+                    }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func dayCell(_ cell: DayCell) -> some View {
+        VStack(spacing: 2) {
+            Text("\(Calendar.current.component(.day, from: cell.date))")
+                .font(.caption)
+                .foregroundStyle(.primary)  // outer `.opacity` fades out-of-month
+            statusDot(for: cell)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 36)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(cell.events.isEmpty || !cell.inMonth ? Color.clear : Color.secondary.opacity(0.06))
+        )
+        .contentShape(Rectangle())
+        .opacity(cell.inMonth ? 1 : 0.55)
+    }
+
+    @ViewBuilder
+    private func statusDot(for cell: DayCell) -> some View {
+        if cell.events.isEmpty {
+            // Use a hidden placeholder so day numbers align vertically across
+            // event-bearing and empty cells. A real dot would shift the row.
+            Circle().fill(Color.clear).frame(width: 6, height: 6)
+        } else {
+            let state = aggregateState(for: cell.events)
+            Circle()
+                .fill(color(for: state))
+                .frame(width: 6, height: 6)
+        }
+    }
+
+    private func color(for state: SupabaseSyncService.RowSyncState) -> Color {
+        switch state {
+        case .synced:  return .green
+        case .pending: return .orange
+        case .offline: return .gray
+        }
+    }
+
+    // MARK: - Legend
+
+    private var legend: some View {
+        HStack(spacing: 16) {
+            legendItem(.green, "synced")
+            legendItem(.orange, "pending")
+            legendItem(.gray, "offline")
+            Spacer()
+        }
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+
+    private func legendItem(_ color: Color, _ label: String) -> some View {
+        HStack(spacing: 4) {
+            Circle().fill(color).frame(width: 6, height: 6)
+            Text(label)
+        }
+    }
+
+    // MARK: - Other tables summary
+
+    private var otherTablesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Other tables")
+                .font(.headline)
+            tableRow("Event types", summary: syncService.syncSummaryForEventTypes(agentRuntime.eventTypeTemplateStore.templates))
+            tableRow("Todo lists", summary: syncService.syncSummaryForTodoLists(store.todoLists))
+            tableRow("Event logs", summary: syncService.syncSummaryForLogs(store.calendarEventLogRecords))
+            tableRow("Event feedback", summary: syncService.syncSummaryForFeedback(store.calendarEventFeedbackRecords))
+            tableRow("Skill insights", summary: syncService.syncSummaryForSkills(skillStore.insights))
+            tableRow("User settings", summary: syncService.syncSummaryForSettings())
+        }
+    }
+
+    @ViewBuilder
+    private func tableRow(_ title: String, summary: SupabaseSyncService.TableSyncSummary) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(.subheadline)
+            Spacer()
+            Text(summaryText(summary))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Circle()
+                .fill(summaryColor(summary))
+                .frame(width: 6, height: 6)
+        }
+    }
+
+    private func summaryText(_ s: SupabaseSyncService.TableSyncSummary) -> String {
+        switch s {
+        case .empty:                                return "empty"
+        case .synced(let n):                        return "\(n) synced"
+        case .pending(let synced, let pending):     return "\(pending) pending · \(synced) synced"
+        case .offline:                              return "offline"
+        }
+    }
+
+    private func summaryColor(_ s: SupabaseSyncService.TableSyncSummary) -> Color {
+        switch s {
+        case .synced, .empty: return .green
+        case .pending:        return .orange
+        case .offline:        return .gray
+        }
+    }
+
+    // MARK: - Data shaping
+
+    /// Place events on a day by `timeRanges[0].start`. Recurring / multi-day
+    /// events appear on their first occurrence's day; per-occurrence
+    /// expansion is intentionally out of scope for v1 — the goal is "where
+    /// does the EVENT (not occurrence) live", since sync state is per-row.
+    private func events(on day: Date) -> [(event: Event, kind: String)] {
+        let cal = Calendar.current
+        let dayStart = cal.startOfDay(for: day)
+        let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        var out: [(Event, String)] = []
+        for e in store.events {
+            if let s = e.timeRanges.first?.start, s >= dayStart, s < dayEnd {
+                out.append((e, "todo"))
+            }
+        }
+        for e in store.calendarEvents {
+            if let s = e.timeRanges.first?.start, s >= dayStart, s < dayEnd {
+                out.append((e, "calendar"))
+            }
+        }
+        return out
+    }
+
+    private func aggregateState(for events: [(event: Event, kind: String)]) -> SupabaseSyncService.RowSyncState {
+        var hasPending = false
+        for pair in events {
+            switch syncService.syncStateForEvent(pair.event, kind: pair.kind) {
+            case .offline: return .offline
+            case .pending: hasPending = true
+            case .synced:  break
+            }
+        }
+        return hasPending ? .pending : .synced
+    }
+
+    // MARK: - Grid math
+
+    private func monthCells(for monthStart: Date) -> [DayCell] {
+        let cal = Calendar.current
+        // Find the Monday on/before monthStart (gridStart) and lay out 6 weeks.
+        let weekday = cal.component(.weekday, from: monthStart)  // 1=Sun ... 7=Sat
+        // Convert to Mon-first index (0=Mon ... 6=Sun)
+        let monIndex = (weekday + 5) % 7
+        guard let gridStart = cal.date(byAdding: .day, value: -monIndex, to: monthStart) else { return [] }
+
+        var out: [DayCell] = []
+        let monthIdx = cal.component(.month, from: monthStart)
+        let yearIdx = cal.component(.year, from: monthStart)
+        for offset in 0..<42 {
+            guard let d = cal.date(byAdding: .day, value: offset, to: gridStart) else { continue }
+            let inMonth = cal.component(.month, from: d) == monthIdx
+                && cal.component(.year, from: d) == yearIdx
+            out.append(DayCell(
+                date: cal.startOfDay(for: d),
+                inMonth: inMonth,
+                events: inMonth ? events(on: d) : []
+            ))
+        }
+        return out
+    }
+
+    private struct DayCell: Identifiable {
+        let date: Date
+        let inMonth: Bool
+        let events: [(event: Event, kind: String)]
+        var id: TimeInterval { date.timeIntervalSinceReferenceDate }
+    }
+
+    private struct SelectedDay: Identifiable {
+        let date: Date
+        var id: TimeInterval { date.timeIntervalSinceReferenceDate }
+    }
+
+    private static func startOfMonth(_ date: Date) -> Date {
+        let comps = Calendar.current.dateComponents([.year, .month], from: date)
+        return Calendar.current.date(from: comps) ?? date
+    }
+
+    private static let monthYearFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "LLLL yyyy"
+        return f
+    }()
+}
+
+// MARK: - Day detail sheet
+
+private struct DaySyncDetailSheet: View {
+    let day: Date
+    let events: [(event: Event, kind: String)]
+    @EnvironmentObject private var syncService: SupabaseSyncService
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                if events.isEmpty {
+                    Text("No events placed on this day.")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(events.indices, id: \.self) { i in
+                        let pair = events[i]
+                        eventRow(pair.event, kind: pair.kind)
+                    }
+                }
+            }
+            .navigationTitle(Self.dayFormatter.string(from: day))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func eventRow(_ event: Event, kind: String) -> some View {
+        let state = syncService.syncStateForEvent(event, kind: kind)
+        HStack(spacing: 12) {
+            Circle()
+                .fill(color(for: state))
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(event.title.isEmpty ? "(untitled)" : event.title)
+                    .font(.subheadline)
+                    .lineLimit(1)
+                Text(secondaryText(for: event, kind: kind, state: state))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func secondaryText(for event: Event, kind: String, state: SupabaseSyncService.RowSyncState) -> String {
+        var parts: [String] = [kind]
+        if let start = event.timeRanges.first?.start {
+            parts.append(Self.timeFormatter.string(from: start))
+        }
+        switch state {
+        case .synced:  parts.append("synced")
+        case .pending: parts.append("pending")
+        case .offline: parts.append("offline")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func color(for state: SupabaseSyncService.RowSyncState) -> Color {
+        switch state {
+        case .synced:  return .green
+        case .pending: return .orange
+        case .offline: return .gray
+        }
+    }
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }()
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        return f
+    }()
+}

--- a/Done/Views/Agent/SyncInspectView.swift
+++ b/Done/Views/Agent/SyncInspectView.swift
@@ -29,7 +29,13 @@ struct SyncInspectView: View {
     @EnvironmentObject private var store: EventStore
     @EnvironmentObject private var syncService: SupabaseSyncService
     @EnvironmentObject private var skillStore: SkillInsightStore
-    @EnvironmentObject private var agentRuntime: AgentRuntime
+
+    // Follows the convention in `CalendarEventFormView`, `EventFormView`,
+    // `CalendarInterruptComposer`: `EventTypeTemplateStore` is UserDefaults-
+    // backed so multiple @StateObject instances stay in sync via the same
+    // backing store. Avoids pulling in the full `AgentRuntime` env-object
+    // (which would re-render this view on any unrelated agent state change).
+    @StateObject private var templateStore = EventTypeTemplateStore()
 
     @State private var displayedMonth: Date = Self.startOfMonth(Date())
     @State private var selectedDay: SelectedDay?
@@ -49,7 +55,7 @@ struct SyncInspectView: View {
         .navigationTitle("Calendar Sync Snapshot")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $selectedDay) { day in
-            DaySyncDetailSheet(day: day.date, events: events(on: day.date))
+            DaySyncDetailSheet(day: day.date, events: events(on: day.date, using: eventsByDay))
                 .environmentObject(syncService)
         }
     }
@@ -100,7 +106,10 @@ struct SyncInspectView: View {
     }
 
     private var calendarGrid: some View {
-        let cells = monthCells(for: displayedMonth)
+        // Bucket events once for this entire grid pass so each day-cell is
+        // an O(1) lookup rather than an O(N) scan of the event list.
+        let byDay = eventsByDay
+        let cells = monthCells(for: displayedMonth, eventsByDay: byDay)
         return LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 7), spacing: 8) {
             ForEach(cells) { cell in
                 dayCell(cell)
@@ -178,7 +187,7 @@ struct SyncInspectView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Other tables")
                 .font(.headline)
-            tableRow("Event types", summary: syncService.syncSummaryForEventTypes(agentRuntime.eventTypeTemplateStore.templates))
+            tableRow("Event types", summary: syncService.syncSummaryForEventTypes(templateStore.templates))
             tableRow("Todo lists", summary: syncService.syncSummaryForTodoLists(store.todoLists))
             tableRow("Event logs", summary: syncService.syncSummaryForLogs(store.calendarEventLogRecords))
             tableRow("Event feedback", summary: syncService.syncSummaryForFeedback(store.calendarEventFeedbackRecords))
@@ -221,26 +230,30 @@ struct SyncInspectView: View {
 
     // MARK: - Data shaping
 
-    /// Place events on a day by `timeRanges[0].start`. Recurring / multi-day
-    /// events appear on their first occurrence's day; per-occurrence
-    /// expansion is intentionally out of scope for v1 — the goal is "where
-    /// does the EVENT (not occurrence) live", since sync state is per-row.
-    private func events(on day: Date) -> [(event: Event, kind: String)] {
+    /// Bucket every event by start-of-day once per render so the grid layout
+    /// is O(events) instead of O(events × days). Recurring / multi-day events
+    /// appear on their first occurrence's day; per-occurrence expansion is
+    /// out of scope for v1.
+    ///
+    /// Recomputed on each body pass for now. For very large data sets the
+    /// next perf step is caching this behind `.task(id:)` keyed off
+    /// `displayedMonth` + store counts + sync hash maps — tracked separately.
+    private var eventsByDay: [Date: [(event: Event, kind: String)]] {
         let cal = Calendar.current
-        let dayStart = cal.startOfDay(for: day)
-        let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
-        var out: [(Event, String)] = []
+        var map: [Date: [(Event, String)]] = [:]
         for e in store.events {
-            if let s = e.timeRanges.first?.start, s >= dayStart, s < dayEnd {
-                out.append((e, "todo"))
-            }
+            guard let s = e.timeRanges.first?.start else { continue }
+            map[cal.startOfDay(for: s), default: []].append((e, "todo"))
         }
         for e in store.calendarEvents {
-            if let s = e.timeRanges.first?.start, s >= dayStart, s < dayEnd {
-                out.append((e, "calendar"))
-            }
+            guard let s = e.timeRanges.first?.start else { continue }
+            map[cal.startOfDay(for: s), default: []].append((e, "calendar"))
         }
-        return out
+        return map
+    }
+
+    private func events(on day: Date, using map: [Date: [(event: Event, kind: String)]]) -> [(event: Event, kind: String)] {
+        map[Calendar.current.startOfDay(for: day)] ?? []
     }
 
     private func aggregateState(for events: [(event: Event, kind: String)]) -> SupabaseSyncService.RowSyncState {
@@ -257,7 +270,7 @@ struct SyncInspectView: View {
 
     // MARK: - Grid math
 
-    private func monthCells(for monthStart: Date) -> [DayCell] {
+    private func monthCells(for monthStart: Date, eventsByDay map: [Date: [(event: Event, kind: String)]]) -> [DayCell] {
         let cal = Calendar.current
         // Find the Monday on/before monthStart (gridStart) and lay out 6 weeks.
         let weekday = cal.component(.weekday, from: monthStart)  // 1=Sun ... 7=Sat
@@ -275,7 +288,7 @@ struct SyncInspectView: View {
             out.append(DayCell(
                 date: cal.startOfDay(for: d),
                 inMonth: inMonth,
-                events: inMonth ? events(on: d) : []
+                events: inMonth ? events(on: d, using: map) : []
             ))
         }
         return out

--- a/Done/Views/Analysis/AnalysisView.swift
+++ b/Done/Views/Analysis/AnalysisView.swift
@@ -43,6 +43,27 @@ enum MeAvatarStore {
         try? FileManager.default.removeItem(at: url)
     }
 
+    // MARK: - Raw I/O for sync (Phase 1 of full-backup completion)
+    //
+    // The sync layer deals in bytes, not UIImage. These helpers let
+    // `ImageBackupCoordinator` upload the current avatar to Supabase
+    // Storage and write a freshly-downloaded one back to disk on restore
+    // without re-encoding through `UIImage.jpegData` (which would change
+    // bytes round-trip).
+
+    /// Raw JPEG bytes of the current avatar, or nil if none on disk.
+    static func loadData() -> Data? {
+        guard hasImage else { return nil }
+        return try? Data(contentsOf: url)
+    }
+
+    /// Write raw JPEG bytes to the avatar slot. Caller-supplied bytes are
+    /// assumed to be already-compressed JPEG (the sync layer fetches the
+    /// exact bytes that were previously uploaded by the source device).
+    static func writeRaw(_ data: Data) throws {
+        try data.write(to: url, options: .atomic)
+    }
+
     private static func downscale(_ image: UIImage, maxEdge: CGFloat) -> UIImage {
         let w = image.size.width
         let h = image.size.height

--- a/done-mcp/supabase/migrations/008_event_images_bucket_size.sql
+++ b/done-mcp/supabase/migrations/008_event_images_bucket_size.sql
@@ -1,0 +1,44 @@
+-- Bump the `event-images` bucket file-size cap from 5 MB → 100 MB.
+--
+-- Why:
+-- Real-device testing surfaced a real-world failure mode: some legacy or
+-- pre-resize-pipeline image assets exceed the original 5 MB ceiling that
+-- migration 007 set as a "defensive safety net". The ceiling was sized
+-- against the compressed JPEG ceiling produced by `AgenticIntakeAssetStore`
+-- (2048px, q=0.82, typically 200–500 KB), but a handful of legacy assets
+-- (pre-compression, or HEIC originals that didn't run through the convert
+-- path, or panoramas) come in larger than expected. Those images currently
+-- fail upload with HTTP 413 "Payload too large", which then cascades to
+-- restore-side "object not found" errors on every other device.
+--
+-- 100 MB comfortably accommodates:
+--   - iPhone HEIC / RAW photos (typically 3–10 MB)
+--   - JPEG panoramas (often 20–40 MB)
+--   - the worst-case original-quality `UIImage.jpegData(compressionQuality:)`
+--     bypass path if compression ever regresses
+--
+-- It also intentionally keeps a finite limit: an unlimited bucket would
+-- silently absorb a GB-scale upload if a future code path accidentally
+-- routed a video file or screenshot recording into image storage. 100 MB
+-- is large enough to never block a legitimate photo, small enough to
+-- catch obvious misuse.
+--
+-- Reversible: a follow-up migration can lower the limit back to 5 MB if
+-- we ever decide the storage cost is meaningful. Existing rows above the
+-- new (lower) limit would remain accessible; only new uploads would be
+-- constrained.
+--
+-- Storage cost rough math (single user):
+--   50 images × ~5 MB avg ≈ 250 MB. Supabase Pro tier includes 100 GB
+--   storage, so this is ~0.25% of a single user's storage budget. At
+--   10k users with similar usage we'd consume ~2.5 TB and pay roughly
+--   $50/mo on the storage-overage line — still cheap relative to the
+--   restore-correctness benefit.
+--
+-- Follow-up (not in this migration): expose a per-app warning when a
+-- single upload exceeds, say, 25 MB, so the user knows it's eating into
+-- their device backup quota even though it's allowed. Tracked separately.
+
+update storage.buckets
+set file_size_limit = 100 * 1024 * 1024  -- 100 MB
+where id = 'event-images';

--- a/done-mcp/supabase/migrations/009_agent_preferences.sql
+++ b/done-mcp/supabase/migrations/009_agent_preferences.sql
@@ -1,0 +1,33 @@
+-- Phase 2 of full-backup completion: sync `AgentPreferenceStore`.
+--
+-- The agent's learned-rules table and recent decision history were
+-- file-based local-only (Application Support/AgentRuntime/*.json). After
+-- restore on a new device, the agent forgot the user's preferences
+-- (e.g. "don't keep asking me to create templates for this type") and
+-- had no history of past decisions. Closes audit gap #2.
+--
+-- Shape: one row per user. Both arrays are stored as jsonb. Encoding
+-- chosen for two reasons:
+--   1. The rule + decision data models are nested Swift structs with
+--      enums and associated values; emitting them as relational columns
+--      would require either a schema migration on every model change or
+--      reflective serialization. jsonb lets the iOS client own the
+--      shape end-to-end.
+--   2. Total size per user is small (~hundreds of rules max, 300-row
+--      decision history cap). Well under jsonb's practical limits.
+
+create table if not exists agent_preferences (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  rules jsonb not null default '[]'::jsonb,
+  decision_history jsonb not null default '[]'::jsonb,
+  updated_at timestamptz not null default now(),
+  synced_at timestamptz not null default now()
+);
+
+alter table agent_preferences enable row level security;
+
+drop policy if exists "Users can manage own agent_preferences" on agent_preferences;
+create policy "Users can manage own agent_preferences"
+  on agent_preferences for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/done-mcp/supabase/migrations/010_agent_conversations.sql
+++ b/done-mcp/supabase/migrations/010_agent_conversations.sql
@@ -1,7 +1,7 @@
 -- Phase 3 of full-backup completion: sync agent chat history.
 --
 -- The agent's conversation list (recent chats with the AI) lived only
--- in `UserDefaults` under the `agentConversationsV2` key. After restore
+-- in `UserDefaults` under the `agentConversations` key. After restore
 -- on a new device, the user lost all chat context. Closes audit gap #3.
 --
 -- Shape: one row per user, with the full conversations array as jsonb.

--- a/done-mcp/supabase/migrations/010_agent_conversations.sql
+++ b/done-mcp/supabase/migrations/010_agent_conversations.sql
@@ -1,0 +1,26 @@
+-- Phase 3 of full-backup completion: sync agent chat history.
+--
+-- The agent's conversation list (recent chats with the AI) lived only
+-- in `UserDefaults` under the `agentConversationsV2` key. After restore
+-- on a new device, the user lost all chat context. Closes audit gap #3.
+--
+-- Shape: one row per user, with the full conversations array as jsonb.
+-- Same rationale as `agent_preferences`: nested Swift model shape, low
+-- ceiling on size (chats are short text, capped retention in client).
+-- If a future user's history blows past ~10MB we'll revisit either
+-- per-conversation rows or a trim-by-age policy on the client.
+
+create table if not exists agent_conversations (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  conversations jsonb not null default '[]'::jsonb,
+  updated_at timestamptz not null default now(),
+  synced_at timestamptz not null default now()
+);
+
+alter table agent_conversations enable row level security;
+
+drop policy if exists "Users can manage own agent_conversations" on agent_conversations;
+create policy "Users can manage own agent_conversations"
+  on agent_conversations for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/done-mcp/supabase/migrations/011_agent_preferences_token_inference.sql
+++ b/done-mcp/supabase/migrations/011_agent_preferences_token_inference.sql
@@ -1,0 +1,19 @@
+-- Extend `agent_preferences` to also carry `TokenInferenceRepository`'s
+-- learned state. These three blobs were the largest unbackedup data
+-- bucket per the full-backup audit: the agent's accumulated dynamic /
+-- meta hypotheses + per-occurrence projections drive every token-class
+-- recommendation, and restoring on a fresh device without them means
+-- the agent re-learns everything from zero.
+--
+-- Schema choice: extend the existing single-row-per-user table rather
+-- than spawning a fourth blob table. Token inference state is "agent's
+-- learned model", same conceptual neighborhood as rules + decision
+-- history. One row, one sync path, one restore path.
+--
+-- Columns default to NULL (vs jsonb '[]') so existing rows aren't
+-- mutated by the ALTER. Client decodes NULL as "no cloud state yet".
+
+alter table agent_preferences
+  add column if not exists token_dynamic_hypotheses jsonb,
+  add column if not exists token_meta_hypotheses jsonb,
+  add column if not exists token_projections jsonb;


### PR DESCRIPTION
Batched promotion from \`king-of-rubbish-bin\` → \`main\`. 26 commits across several feature branches that have been integrated and tested on king for ~2 days. Real-device verified end-to-end.

## What this brings to main

### 1. Per-device upload toggle (Phase A)

User-controlled gate so a fresh install doesn't surprise-write to cloud. Default OFF; the DEBUG safety net stays as belt-and-suspenders.

\`canUpload = !debugBlocksUploads && UserDefaults.bool(\"syncUploadsEnabled\")\`

Settings → Data & Privacy → Sync toggle. \`onChange\` OFF→ON triggers immediate catch-up fullSync.

### 2. Supabase Storage REST quirks bundled fix

Real-device test caught four discrete bugs:

- **Migration 008**: \`event-images\` bucket cap 5 MB → 100 MB (legacy / panorama / HEIC origin assets were hitting 413 → restore-side failures cascaded).
- **Body-wrapped status codes**: Supabase Storage returns HTTP 400 with body \`{\"statusCode\":\"404\"/\"409\"/\"413\"}\`. New \`effectiveStatusCode\` helper unwraps for both upload + download.
- **Honest upload accounting**: \`upload()\` now returns Bool (new bytes written vs already-in-cloud dedup). Status reporter shows \"5 new, 45 already in cloud\" instead of misleading \"50 uploaded\".
- **Critical bypass-in-PR fix**: \`SupabaseImageStorageService.uploadsDisabled\` had been committed with the temporary bypass mistakenly intact; reverted to \`#if DEBUG\`.

### 3. Diff-sync hash persistence (#30 + determinism fix)

Hashes now persist to \`UserDefaults\` keyed per-user (\`syncHashes.<uid>.<table>\`). Without this, every cold start was a full re-upload of ~1,800 rows.

\`rowHash\` made cross-process deterministic by sorted-key JSON for nested dicts (Swift's \`String(describing:)\` on a Dictionary was hash-table-seeded randomized; the symptom was \`user_settings\` entering an infinite re-upload loop after persistence landed).

### 4. Calendar Sync Snapshot — inspect view

Month-grid visualization of which events are synced / pending. Reachable from Sync Status card. Read-only, computes on demand from the (now-persisted) hash maps. \"Other tables\" section aggregates non-event buckets.

### 5. Image log noise gate

Per-image dedup logs now gated behind \`verboseImageLogging\` UserDefaults flag. Default OFF so a typical scan emits one summary line instead of 50.

### 6. **Full backup completion — closes the audit gaps**

The big one. Closed every known gap from a thorough architectural audit so we now genuinely back up 100% of user-perceptible state:

- **Avatar binary** → \`event-images/<uid>/_avatar.jpg\`
- **Agent rules + decisionHistory** → new \`agent_preferences\` table (migration 009)
- **TokenInferenceRepository state** (3 learned-model jsonb columns on the same row, migration 011)
- **Agent conversation history** → new \`agent_conversations\` table (migration 010)
- **\`skillAnalyzedEventIds\`** + **\`eventTypeColorHistory\`** → \`SyncedSettings.allKeys\` (avoids burning LLM tokens on re-analysis after restore)
- **Local DR snapshot** (Documents/backup-snapshot.json) now mirrors all 11 buckets including avatar base64
- \`resetAllLocalData\` extended to wipe the 7 keys + avatar file previously missed
- \`markRestoreCompleted\` reseeds the post-restore baseline for every new scalar hash (no churn-on-restore)
- Per-device key inventory documented in \`SyncedSettings\` comment

## Migrations applied (production Supabase)

- \`008_event_images_bucket_size.sql\` — bucket 5 MB → 100 MB
- \`009_agent_preferences.sql\` — new table for rules + decisionHistory
- \`010_agent_conversations.sql\` — new table for chat history
- \`011_agent_preferences_token_inference.sql\` — adds 3 jsonb columns to \`agent_preferences\`

All four applied to remote and verified by real-device upload.

## Verified end-to-end

- ✅ Real-device push (bypass build): all 11 buckets uploaded, console showed \`agent_preferences: uploaded (5 rules, 9 decisions)\` + \`agent_conversations: uploaded (7 conversations)\`
- ✅ Hash persistence verified: 2nd launch on the same device shows \`Full sync complete\` with no intermediate \`X changed\` lines
- ✅ Simulator restore: fetched all 9 cloud tables including \`agent_preferences\` + \`agent_conversations\` (1 row each)
- ✅ Local DR snapshot grew from 1.24 MB → 1.67 MB on simulator post-restore, consistent with new buckets being included

## Review history

6 rounds of subagent review across the work:
- Sync status indicator: 2 rounds
- Upload toggle: 2 rounds
- Hash persistence + determinism: 1 round
- Inspect view: 1 round (perf followup tracked in #33)
- Full-backup completion: 2 rounds (architectural audit + sign-off)
- Final holistic sign-off: GO with 0 blockers

Followups tracked: #28 (PostgREST service_role debt), #29 (configurable image size + warn), #33 (inspect view perf cache), #35 (3 deferred sign-off items).

## Out of scope / known limitations

- \`eventLogTemplatePreferences\` UserDefaults blob is \`Data\`-encoded so it can't ride \`SyncedSettings.allKeys\` directly; storage refactor tracked in #35.
- Avatar pull is \"skip-if-local-exists\" on Replace-mode (right semantics for fresh-install, wrong if device already has stale avatar); tracked in #35.
- \`BackupSnapshotService.buildSnapshotData\` runs on MainActor; sub-100ms per snapshot today but worth hoisting to background eventually.
- \`AttributeGraph: cycle detected\` warning pre-existed this work; unrelated.

## Test plan

- [ ] Fresh-install sign-in on a new device → \`syncUploadsEnabled\` defaults OFF, restore preview works, no surprise writes
- [ ] Toggle ON → fullSync uploads all 11 buckets in <5s for typical account
- [ ] Re-launch → no \"X changed\" log lines (hash persistence)
- [ ] \"Reset all local data\" → cloud preserved, local wiped including avatar / conversations / token state
- [ ] Restore from cloud → all 11 buckets restored, no unnecessary re-upload after apply
- [ ] Cross-device test: change avatar on Device A → see it on Device B after restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)