### PR TITLE
fix(sync): close Event field drift for #38 + #45 (kind, absorbed, people, timer)

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		F0C4F09AE7974190AFA61B17 /* EventTypeTemplateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C4F09BE7974190AFA61B17 /* EventTypeTemplateStoreTests.swift */; };
 		F0C4F09CE7974190AFA61B18 /* CalendarOverlapStackPeekTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C4F09DE7974190AFA61B18 /* CalendarOverlapStackPeekTests.swift */; };
 		F0C4F0AAE7974190AFA61B19 /* CalendarOccurrenceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C4F0ABE7974190AFA61B19 /* CalendarOccurrenceKeyTests.swift */; };
+		F0C4F0ACE7974190AFA61B20 /* SupabaseEventRowRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C4F0ADE7974190AFA61B20 /* SupabaseEventRowRoundTripTests.swift */; };
 		F0C51001FE00000000000001 /* OrientationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C50001FE00000000000001 /* OrientationManager.swift */; };
 		F0C51002FE00000000000002 /* Focus/FocusModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C50002FE00000000000002 /* Focus/FocusModeView.swift */; };
 		F0C51003FE00000000000003 /* Focus/FocusModeClockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C50003FE00000000000003 /* Focus/FocusModeClockView.swift */; };
@@ -270,6 +271,7 @@
 		F0C4F09BE7974190AFA61B17 /* EventTypeTemplateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTypeTemplateStoreTests.swift; sourceTree = "<group>"; };
 		F0C4F09DE7974190AFA61B18 /* CalendarOverlapStackPeekTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarOverlapStackPeekTests.swift; sourceTree = "<group>"; };
 		F0C4F0ABE7974190AFA61B19 /* CalendarOccurrenceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarOccurrenceKeyTests.swift; sourceTree = "<group>"; };
+		F0C4F0ADE7974190AFA61B20 /* SupabaseEventRowRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseEventRowRoundTripTests.swift; sourceTree = "<group>"; };
 		F0C50001FE00000000000001 /* OrientationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationManager.swift; sourceTree = "<group>"; };
 		F0C50002FE00000000000002 /* Focus/FocusModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Focus/FocusModeView.swift; sourceTree = "<group>"; };
 		F0C50003FE00000000000003 /* Focus/FocusModeClockView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Focus/FocusModeClockView.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				F0C4F099E7974190AFA61B16 /* CalendarEventTypeInferenceServiceTests.swift */,
 				F0C4F09BE7974190AFA61B17 /* EventTypeTemplateStoreTests.swift */,
 				F0C4F0ABE7974190AFA61B19 /* CalendarOccurrenceKeyTests.swift */,
+				F0C4F0ADE7974190AFA61B20 /* SupabaseEventRowRoundTripTests.swift */,
 				E11D9000000000000000B002 /* CalendarMidnightHandlerTests.swift */,
 				E11D9000000000000000B003 /* TimelineRenderBenchmarkTests.swift */,
 			);
@@ -814,6 +817,7 @@
 				F0C4F098E7974190AFA61B16 /* CalendarEventTypeInferenceServiceTests.swift in Sources */,
 				F0C4F09AE7974190AFA61B17 /* EventTypeTemplateStoreTests.swift in Sources */,
 				F0C4F0AAE7974190AFA61B19 /* CalendarOccurrenceKeyTests.swift in Sources */,
+				F0C4F0ACE7974190AFA61B20 /* SupabaseEventRowRoundTripTests.swift in Sources */,
 				E11D9000000000000000A002 /* CalendarMidnightHandlerTests.swift in Sources */,
 				E11D9000000000000000A003 /* TimelineRenderBenchmarkTests.swift in Sources */,
 			);

--- a/Done/Models/Event.swift
+++ b/Done/Models/Event.swift
@@ -306,16 +306,6 @@ struct Event: Identifiable, Codable, Hashable {
         timerStartedAt != nil
     }
 
-    /// True when this event uses an experimental field that doesn't
-    /// round-trip safely through Supabase sync (see issue #38). Per-
-    /// event predicate; the upload site combines this with a
-    /// collection-level check (parent of absorbed children — see
-    /// `supabaseSyncableCalendarEvents` in SupabaseSyncService.swift)
-    /// since "is this a parent" requires the full array.
-    var isExperimentalAndShouldNotSync: Bool {
-        kind == .todo || absorbedIntoEventID != nil
-    }
-
     /// All event types associated with this event, primary first. Always
     /// returns at least one entry (the primary `type`). Used by the
     /// experimental multi-type events feature; ordinary call sites can keep

--- a/Done/Services/SupabaseSyncService+Restore.swift
+++ b/Done/Services/SupabaseSyncService+Restore.swift
@@ -249,7 +249,7 @@ extension SupabaseSyncService {
 
     // MARK: Events
 
-    fileprivate static func rowToEvent(_ row: [String: Any]) -> Event? {
+    internal static func rowToEvent(_ row: [String: Any]) -> Event? {
         let r = RowReader(row: row)
         guard let id = r.uuid("id") else { return nil }
 
@@ -300,6 +300,9 @@ extension SupabaseSyncService {
         let suggestedLogTemplateSource: SuggestedLogTemplateSource? = r.string("suggested_log_template_source")
             .flatMap(SuggestedLogTemplateSource.init(rawValue:))
 
+        let kind: Event.Kind = r.string("behavior_kind").flatMap(Event.Kind.init(rawValue:)) ?? .event
+        let peopleIDs: [UUID]? = r.stringArray("people_ids").map { $0.compactMap(UUID.init(uuidString:)) }
+
         var event = Event(
             id: id,
             title: r.string("title") ?? "",
@@ -320,18 +323,22 @@ extension SupabaseSyncService {
             completeAt: r.date("complete_at"),
             tags: r.stringArray("tags") ?? [],
             type: r.string("type") ?? "",
+            kind: kind,
             additionalTypes: r.stringArray("additional_types"),
             typeWeights: typeWeights,
             colorDepth: r.double("color_depth") ?? 0,
             recurrenceParentId: r.uuid("recurrence_parent_id"),
             recurrenceInstanceDate: r.date("recurrence_instance_date"),
             recurrenceExceptionDates: exDates,
+            timerStartedAt: r.date("timer_started_at"),
             linkedCalendarEventId: r.uuid("linked_calendar_event_id"),
             linkedTodoEventId: r.uuid("linked_todo_event_id"),
             listID: r.uuid("list_id"),
             displayKind: r.string("display_kind").flatMap(EventDisplayKind.init(rawValue:)) ?? .regular,
             interruptRelation: interruptRelation,
-            wannaNotes: wannaNotes
+            absorbedIntoEventID: r.uuid("absorbed_into_event_id"),
+            wannaNotes: wannaNotes,
+            peopleIDs: peopleIDs
         )
         // `Event.init` doesn't expose every stored field as a parameter
         // (agentic intake + suggested log template are populated by other

--- a/Done/Services/SupabaseSyncService.swift
+++ b/Done/Services/SupabaseSyncService.swift
@@ -8,30 +8,6 @@ private let logger = Logger(
     category: "Sync"
 )
 
-private extension Array where Element == Event {
-    /// Subset of `rawCalendarEvents` that's safe to push to Supabase given
-    /// the absorption feature's current schema gap (#38). Drops:
-    /// 1. Anything `isExperimentalAndShouldNotSync` (i.e., `.todo`
-    ///    children — they wouldn't round-trip).
-    /// 2. Any event that is the absorption *parent* of a child in this
-    ///    same array. The parent itself has no new column, but the
-    ///    absorption relationship is meaningful local state — uploading
-    ///    the parent without its children produces a misleading cloud
-    ///    record that, on restore to another device, looks like a
-    ///    regular event with no absorbed-todos history. The predicate
-    ///    that lives on `Event` alone can't see this (no store
-    ///    reference) so the parent-check has to live at upload time
-    ///    where the full collection is available.
-    var supabaseSyncableCalendarEvents: [Event] {
-        let absorbedParentIDs = Set(self.compactMap { $0.absorbedIntoEventID })
-        return self.filter { event in
-            if event.isExperimentalAndShouldNotSync { return false }
-            if absorbedParentIDs.contains(event.id) { return false }
-            return true
-        }
-    }
-}
-
 // MARK: - Configuration
 
 enum SupabaseSyncConfig {
@@ -534,11 +510,7 @@ final class SupabaseSyncService: ObservableObject {
             .debounce(for: .seconds(debounce), scheduler: RunLoop.main)
             .sink { [weak self] events in
                 guard let self, self.canUpload, self.isFullSyncDone, !self.userId.isEmpty else { return }
-                // Same experimental-feature guard the full sync uses
-                // (issue #38). Reactive uploads after each edit /
-                // absorb / release must filter here too, otherwise
-                // absorption parents leak between full syncs.
-                Task { await self.syncEvents(events.supabaseSyncableCalendarEvents, kind: "calendar") }
+                Task { await self.syncEvents(events, kind: "calendar") }
             }
             .store(in: &cancellables)
 
@@ -867,14 +839,7 @@ final class SupabaseSyncService: ObservableObject {
         statusReporter?.structuredBeginBurst()
         defer { statusReporter?.structuredEndBurst() }
         await syncEvents(eventStore.events, kind: "todo")
-        // Skip experimental calendar events (todo children + their
-        // absorption parents). See `supabaseSyncableCalendarEvents`
-        // for the full predicate and issue #38 for the schema-fix
-        // path that lets the guard go away.
-        await syncEvents(
-            eventStore.rawCalendarEvents.supabaseSyncableCalendarEvents,
-            kind: "calendar"
-        )
+        await syncEvents(eventStore.rawCalendarEvents, kind: "calendar")
         await syncLogs(eventStore.calendarEventLogRecords)
         await syncFeedback(eventStore.calendarEventFeedbackRecords)
         await syncTodoLists(eventStore.todoLists)
@@ -1126,7 +1091,7 @@ final class SupabaseSyncService: ObservableObject {
 
     /// Full upload payload for an event row, including the always-now
     /// `updated_at` / `synced_at` timestamps the server persists.
-    private func eventToRow(_ e: Event, kind: String) -> [String: Any] {
+    internal func eventToRow(_ e: Event, kind: String) -> [String: Any] {
         var row = eventRowHashableFields(e, kind: kind)
         row["updated_at"] = iso(Date())
         row["synced_at"] = iso(Date())
@@ -1199,6 +1164,10 @@ final class SupabaseSyncService: ObservableObject {
             "linked_todo_event_id": e.linkedTodoEventId?.uuidString as Any? ?? NSNull(),
             "list_id": e.listID?.uuidString as Any? ?? NSNull(),
             "display_kind": e.displayKind.rawValue,
+            "behavior_kind": e.kind.rawValue,
+            "absorbed_into_event_id": e.absorbedIntoEventID?.uuidString as Any? ?? NSNull(),
+            "people_ids": e.peopleIDs.map { $0.map { $0.uuidString } } as Any? ?? NSNull(),
+            "timer_started_at": e.timerStartedAt.map { iso($0) } as Any? ?? NSNull(),
             "interrupt_relation": ir,
             "wanna_notes": wannaNotesPayload,
             "agentic_intake": agenticIntakePayload,
@@ -1479,10 +1448,7 @@ final class SupabaseSyncService: ObservableObject {
             rows: eventStore.events.map { eventToRow($0, kind: "todo") }
         )
         lastCalendarEventHashes = hashMap(
-            // Mirror the upload-time filter so the hash baseline doesn't
-            // include experimental events the upload path skips (issue #38).
-            rows: eventStore.rawCalendarEvents.supabaseSyncableCalendarEvents
-                .map { eventToRow($0, kind: "calendar") }
+            rows: eventStore.rawCalendarEvents.map { eventToRow($0, kind: "calendar") }
         )
         lastLogHashes = hashMap(rows: eventStore.calendarEventLogRecords.map(logToRow))
         lastFeedbackHashes = hashMap(rows: eventStore.calendarEventFeedbackRecords.map(feedbackToRow))

--- a/DoneTests/SupabaseEventRowRoundTripTests.swift
+++ b/DoneTests/SupabaseEventRowRoundTripTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+@testable import Done
+
+/// Round-trip tests for the four `Event` fields that drift through Supabase
+/// sync today (issues #38 + #45): `kind`, `absorbedIntoEventID`, `peopleIDs`,
+/// `timerStartedAt`. Each test pushes an Event through `eventToRow`,
+/// coerces the dict the way PostgREST would (via `JSONSerialization`), then
+/// decodes back through `rowToEvent` and asserts equality.
+@MainActor
+final class SupabaseEventRowRoundTripTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Round-trip a row dict through JSONSerialization the same way PostgREST
+    /// would on the wire: dict → JSON bytes → JSON object. Coerces native Swift
+    /// types into their JSON-bridged equivalents so the reader sees the same
+    /// shapes a real server response would deliver.
+    private func coerceThroughJSON(_ row: [String: Any]) throws -> [String: Any] {
+        let data = try JSONSerialization.data(withJSONObject: row, options: [])
+        let object = try JSONSerialization.jsonObject(with: data, options: [])
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    /// One round-trip: Event → row → JSON-coerced row → Event.
+    /// Caller asserts on the restored Event.
+    private func roundTrip(_ event: Event, kind: String = "calendar") throws -> Event {
+        let service = SupabaseSyncService()
+        let row = service.eventToRow(event, kind: kind)
+        let coerced = try coerceThroughJSON(row)
+        return try XCTUnwrap(SupabaseSyncService.rowToEvent(coerced))
+    }
+
+    /// Drop sub-second precision so ISO-string round-trip comparisons hold
+    /// even when the formatter writes microseconds and the parser reads back
+    /// at second granularity.
+    private func truncatedToSecond(_ date: Date) -> Date {
+        Date(timeIntervalSince1970: floor(date.timeIntervalSince1970))
+    }
+
+    // MARK: - a) Fully-populated round-trip
+
+    func testFullyPopulatedEventRoundTrip() throws {
+        let parentID = UUID()
+        let person1 = UUID()
+        let person2 = UUID()
+        let listID = UUID()
+        let recurrenceParentID = UUID()
+        let linkedCalID = UUID()
+        let linkedTodoID = UUID()
+        let baseSeriesID = UUID()
+
+        // Truncate dates to the second to keep round-trip comparisons clean.
+        // Sub-second precision is preserved by the writer's fractional ISO
+        // format but the parser strips it; comparing at second resolution is
+        // the documented behavior, not a regression.
+        let start = truncatedToSecond(Date())
+        let end = truncatedToSecond(Date(timeIntervalSinceNow: 3600))
+        let deadline = truncatedToSecond(Date(timeIntervalSinceNow: 7200))
+        let createdAt = truncatedToSecond(Date(timeIntervalSinceNow: -86400))
+        let completeAt = truncatedToSecond(Date(timeIntervalSinceNow: -3600))
+        let recurrenceInstanceDate = truncatedToSecond(Date(timeIntervalSinceNow: -7200))
+        let recurrenceEndDate = truncatedToSecond(Date(timeIntervalSinceNow: 31_536_000))
+        let exceptionDate = truncatedToSecond(Date(timeIntervalSinceNow: 86_400))
+        let timerStart = truncatedToSecond(Date(timeIntervalSinceNow: -120))
+        let interruptOccurrence = truncatedToSecond(Date(timeIntervalSinceNow: 1800))
+        let interruptCreated = truncatedToSecond(Date(timeIntervalSinceNow: -60))
+
+        let original = Event(
+            title: "Full event \(UUID().uuidString)",
+            note: "note body \(UUID().uuidString)",
+            location: "loc \(UUID().uuidString)",
+            timeRanges: [.init(start: start, end: end)],
+            deadline: deadline,
+            repeatUnit: .week,
+            isAllDay: true,
+            isDone: true,
+            repeatInterval: 2,
+            repeatEndType: .onDate,
+            repeatEndDate: recurrenceEndDate,
+            repeatEndCount: 5,
+            priority: 7,
+            status: .completed,
+            createdAt: createdAt,
+            completeAt: completeAt,
+            tags: ["tag-a", "tag-b"],
+            type: "work",
+            kind: .todo,
+            additionalTypes: ["focus", "review"],
+            typeWeights: ["work": 0.6, "focus": 0.4],
+            colorDepth: 0.75,
+            recurrenceParentId: recurrenceParentID,
+            recurrenceInstanceDate: recurrenceInstanceDate,
+            recurrenceExceptionDates: [exceptionDate],
+            timerStartedAt: timerStart,
+            linkedCalendarEventId: linkedCalID,
+            linkedTodoEventId: linkedTodoID,
+            listID: listID,
+            displayKind: .interrupt,
+            interruptRelation: EventInterruptRelation(
+                parentEventID: parentID,
+                baseSeriesEventID: baseSeriesID,
+                occurrenceDate: interruptOccurrence,
+                state: .embedded,
+                createdAt: interruptCreated
+            ),
+            absorbedIntoEventID: parentID,
+            wannaNotes: [.init(text: "wn", createdAt: truncatedToSecond(Date()))],
+            peopleIDs: [person1, person2]
+        )
+
+        let restored = try roundTrip(original)
+
+        XCTAssertEqual(restored.id, original.id)
+        XCTAssertEqual(restored.title, original.title)
+        XCTAssertEqual(restored.note, original.note)
+        XCTAssertEqual(restored.location, original.location)
+        XCTAssertEqual(restored.timeRanges.count, 1)
+        XCTAssertEqual(restored.timeRanges.first?.start, start)
+        XCTAssertEqual(restored.timeRanges.first?.end, end)
+        XCTAssertEqual(restored.deadline, deadline)
+        XCTAssertEqual(restored.repeatUnit, .week)
+        XCTAssertEqual(restored.isAllDay, true)
+        XCTAssertEqual(restored.isDone, true)
+        XCTAssertEqual(restored.repeatInterval, 2)
+        XCTAssertEqual(restored.repeatEndType, .onDate)
+        XCTAssertEqual(restored.repeatEndDate, recurrenceEndDate)
+        XCTAssertEqual(restored.repeatEndCount, 5)
+        XCTAssertEqual(restored.priority, 7)
+        XCTAssertEqual(restored.status, .completed)
+        XCTAssertEqual(restored.createdAt, createdAt)
+        XCTAssertEqual(restored.completeAt, completeAt)
+        XCTAssertEqual(restored.tags, ["tag-a", "tag-b"])
+        XCTAssertEqual(restored.type, "work")
+        // The four newly-synced fields.
+        XCTAssertEqual(restored.kind, .todo)
+        XCTAssertEqual(restored.timerStartedAt, timerStart)
+        XCTAssertEqual(restored.absorbedIntoEventID, parentID)
+        XCTAssertEqual(restored.peopleIDs, [person1, person2])
+        XCTAssertEqual(restored.additionalTypes, ["focus", "review"])
+        XCTAssertEqual(restored.typeWeights?["work"], 0.6)
+        XCTAssertEqual(restored.typeWeights?["focus"], 0.4)
+        XCTAssertEqual(restored.colorDepth, 0.75)
+        XCTAssertEqual(restored.recurrenceParentId, recurrenceParentID)
+        XCTAssertEqual(restored.recurrenceInstanceDate, recurrenceInstanceDate)
+        XCTAssertEqual(restored.recurrenceExceptionDates, [exceptionDate])
+        XCTAssertEqual(restored.linkedCalendarEventId, linkedCalID)
+        XCTAssertEqual(restored.linkedTodoEventId, linkedTodoID)
+        XCTAssertEqual(restored.listID, listID)
+        XCTAssertEqual(restored.displayKind, .interrupt)
+        XCTAssertEqual(restored.interruptRelation?.parentEventID, parentID)
+        XCTAssertEqual(restored.interruptRelation?.baseSeriesEventID, baseSeriesID)
+        XCTAssertEqual(restored.interruptRelation?.occurrenceDate, interruptOccurrence)
+        XCTAssertEqual(restored.interruptRelation?.state, .embedded)
+        XCTAssertEqual(restored.interruptRelation?.createdAt, interruptCreated)
+        XCTAssertEqual(restored.wannaNotes?.count, 1)
+        XCTAssertEqual(restored.wannaNotes?.first?.text, "wn")
+    }
+
+    // MARK: - b) peopleIDs edge cases
+
+    func testPeopleIDsArrayEdgeCases() throws {
+        let base = Event(title: "people-edge")
+
+        // nil case
+        var nilEvent = base
+        nilEvent.peopleIDs = nil
+        let nilRestored = try roundTrip(nilEvent)
+        XCTAssertNil(nilRestored.peopleIDs, "nil peopleIDs should stay nil")
+
+        // empty case
+        var emptyEvent = base
+        emptyEvent.peopleIDs = []
+        let emptyRestored = try roundTrip(emptyEvent)
+        // Empty array round-trips as empty array (writer emits `[]`, reader
+        // sees a non-NSNull array and decodes it to `[]`). The nil-vs-empty
+        // distinction is preserved.
+        XCTAssertEqual(emptyRestored.peopleIDs, [])
+
+        // single
+        let one = UUID()
+        var singleEvent = base
+        singleEvent.peopleIDs = [one]
+        let singleRestored = try roundTrip(singleEvent)
+        XCTAssertEqual(singleRestored.peopleIDs, [one])
+
+        // multi
+        let many = [UUID(), UUID(), UUID()]
+        var manyEvent = base
+        manyEvent.peopleIDs = many
+        let manyRestored = try roundTrip(manyEvent)
+        XCTAssertEqual(manyRestored.peopleIDs, many)
+    }
+
+    // MARK: - c) Kind round-trip
+
+    func testKindRoundTrip() throws {
+        // explicit .event
+        var asEvent = Event(title: "an event")
+        asEvent.kind = .event
+        let restoredEvent = try roundTrip(asEvent)
+        XCTAssertEqual(restoredEvent.kind, .event)
+
+        // explicit .todo
+        var asTodo = Event(title: "a todo")
+        asTodo.kind = .todo
+        let restoredTodo = try roundTrip(asTodo)
+        XCTAssertEqual(restoredTodo.kind, .todo)
+
+        // Legacy row (behavior_kind absent) defaults to .event.
+        let baseEvent = Event(title: "legacy")
+        let row = SupabaseSyncService().eventToRow(baseEvent, kind: "calendar")
+        var legacyRow = try coerceThroughJSON(row)
+        legacyRow.removeValue(forKey: "behavior_kind")
+        let restoredLegacy = try XCTUnwrap(SupabaseSyncService.rowToEvent(legacyRow))
+        XCTAssertEqual(restoredLegacy.kind, .event, "missing behavior_kind decodes as .event")
+    }
+
+    // MARK: - d) Absorbed parent/child round-trip
+
+    func testAbsorbedIntoEventIDRoundTrip() throws {
+        let parent = Event(title: "parent event")
+        var child = Event(title: "absorbed todo")
+        child.kind = .todo
+        child.absorbedIntoEventID = parent.id
+
+        let restoredParent = try roundTrip(parent)
+        let restoredChild = try roundTrip(child)
+
+        XCTAssertNil(restoredParent.absorbedIntoEventID, "parent has no absorption link")
+        XCTAssertEqual(restoredChild.absorbedIntoEventID, parent.id)
+        XCTAssertEqual(restoredChild.absorbedIntoEventID, restoredParent.id,
+                       "child still points at the round-tripped parent")
+        XCTAssertEqual(restoredChild.kind, .todo)
+    }
+
+    // MARK: - e) Legacy row missing all four new columns
+
+    func testLegacyRowMissingNewColumns() throws {
+        let base = Event(title: "legacy row")
+        let fresh = SupabaseSyncService().eventToRow(base, kind: "calendar")
+        var legacy = try coerceThroughJSON(fresh)
+        legacy.removeValue(forKey: "behavior_kind")
+        legacy.removeValue(forKey: "absorbed_into_event_id")
+        legacy.removeValue(forKey: "people_ids")
+        legacy.removeValue(forKey: "timer_started_at")
+
+        let restored = try XCTUnwrap(SupabaseSyncService.rowToEvent(legacy))
+        XCTAssertEqual(restored.kind, .event)
+        XCTAssertNil(restored.absorbedIntoEventID)
+        XCTAssertNil(restored.peopleIDs)
+        XCTAssertNil(restored.timerStartedAt)
+    }
+}

--- a/done-mcp/supabase/migrations/013_event_behavior_kind_absorption_people_timer.sql
+++ b/done-mcp/supabase/migrations/013_event_behavior_kind_absorption_people_timer.sql
@@ -1,0 +1,52 @@
+-- Event behavior kind + absorption + people + timer columns.
+--
+-- Closes the four Event fields that round-trip-fail today (issues #38 and
+-- #45). Until these columns exist the iOS upload path filters out any
+-- event that uses them; the local interim guard is removed in the same
+-- PR that ships this migration.
+--
+-- Columns:
+--   1. `behavior_kind` — `Event.kind` (`'event'` or `'todo'`). This is the
+--      calendar-todo-unification behavioral kind: `.event` is the legacy
+--      default, `.todo` opts into explicit-completion / soft-time
+--      semantics. NOT the same as the existing `kind` column on this
+--      table, which is a routing label (`'calendar'` vs `'todo'`)
+--      naming the *source store* that produced the row. Two distinct
+--      concepts, hence the disambiguating `behavior_` prefix; reusing
+--      `kind` would silently overload an already-load-bearing column.
+--      Defaulted to `'event'` so existing rows decode unchanged.
+--
+--   2. `absorbed_into_event_id` — `Event.absorbedIntoEventID`. When set on
+--      a `.todo`, this todo has been absorbed into the event with this
+--      id and no longer renders independently on the canvas. No FK to
+--      `events.id` because absorption is local UX state, not a referential
+--      invariant — the parent may legitimately be missing during a
+--      partial restore.
+--
+--   3. `people_ids` — `Event.peopleIDs`. The "with whom" list; holds
+--      `Person` ids materialized at bind time (groups are expanded, not
+--      stored by reference) so later edits to a group never rewrite this
+--      event's history.
+--
+--   4. `timer_started_at` — `Event.timerStartedAt`. Non-nil while the
+--      event's timer is running; cleared when the timer stops.
+--
+-- Operational note: adding these columns invalidates every existing
+-- `rowHash` on the iOS client (the hash inputs change shape), so the
+-- first sync after deploy will trigger a mass re-upsert of every
+-- event row from every device. This is expected, not a bug — the
+-- re-upsert converges within one sync window and is hash-gated again
+-- on subsequent runs.
+
+alter table public.events
+  add column if not exists behavior_kind text not null default 'event'
+    check (behavior_kind in ('event','todo')),
+  add column if not exists absorbed_into_event_id uuid,
+  add column if not exists people_ids uuid[],
+  add column if not exists timer_started_at timestamptz;
+
+create index if not exists idx_events_user_behavior_kind
+  on public.events(user_id, behavior_kind);
+create index if not exists idx_events_absorbed_parent
+  on public.events(user_id, absorbed_into_event_id)
+  where absorbed_into_event_id is not null;


### PR DESCRIPTION
Closes #38. Closes #45.

## Summary

The Supabase manual mapping layer silently dropped four `Event` properties added during the calendar/todo unification arc. All four are now wired end-to-end (schema → write → read → tests) in one PR.

- **`Event.kind`** (`.event` / `.todo`) — #38
- **`Event.absorbedIntoEventID: UUID?`** — #45
- **`Event.peopleIDs: [UUID]?`** — #45
- **`Event.timerStartedAt: Date?`** — surfaced by the round-trip test during review; folded in as a 4th sibling

## What changed

| Layer | File | Change |
|---|---|---|
| Schema | `done-mcp/supabase/migrations/013_event_behavior_kind_absorption_people_timer.sql` (new) | adds `behavior_kind text not null default 'event'`, `absorbed_into_event_id uuid`, `people_ids uuid[]`, `timer_started_at timestamptz` + two indexes |
| Write | `Done/Services/SupabaseSyncService.swift:1167-1170` | `eventRowHashableFields` emits the four new keys (NSNull-for-nil convention) |
| Read | `Done/Services/SupabaseSyncService+Restore.swift:303-341` | `rowToEvent` reads + passes the four through `Event.init` |
| Guard removal | `Done/Models/Event.swift`, `SupabaseSyncService.swift:539,873,1482` | drops `isExperimentalAndShouldNotSync` and the `supabaseSyncableCalendarEvents` filter — they were the interim block for `.todo` upload |
| Tests | `DoneTests/SupabaseEventRowRoundTripTests.swift` (new) | 5 cases: fully-populated round-trip, peopleIDs nil/empty/one/many, kind, absorption, legacy-row missing-column defaults |
| Access | `SupabaseSyncService.swift:1127` / `+Restore.swift:252` | `eventToRow` and `rowToEvent` bumped `private`/`fileprivate static` → `internal` for `@testable import` reach |

## Why `behavior_kind` (not reusing `kind`)

The existing `events.kind` column is a **routing label** (`'calendar'` / `'todo'`) used in iOS to decide which logical table the row belongs to. `Event.Kind.rawValue` (`'event'` / `'todo'`) is a **behavioral classification**. Two distinct concepts; the disambiguating `behavior_` prefix prevents an already-load-bearing column from being silently overloaded. See migration header comment for full rationale.

## Validation

- **Unit tests**: 5/5 pass (`SupabaseEventRowRoundTripTests`).
- **Code review** (independent subagent pass): ship-as-is, 0 must-fix, 6 nice-to-have follow-ups (all non-blocking — unused indexes if no MCP query planned, test-name overshells coverage, etc.).
- **Migration 013 already applied to prod** via `supabase db push` (CLI authenticated to project `uqnvtzblppjblwgbpqhf`). Confirmed clean on dry-run before push.
- **Live PostgREST round-trip experiment** (10 cases): all 4 columns survive PostgREST + Postgres round-trip; CHECK constraint rejects bogus `behavior_kind` values; `people_ids` empty `[]` is preserved distinctly from null (matters for "user cleared people binding" vs "never bound" semantics); `timer_started_at` returns in `+00:00` form instead of `Z` but `SupabaseDateParser` handles both.

## First-sync side effect

Adding four hashed columns invalidates every previously-stored row hash in `lastEventHashes` / `lastCalendarEventHashes`. **First sync after deploy will mass-re-upsert every event** to backfill the new columns. Desired (it's the migration's whole point) but worth flagging — users watching `SyncInspectView` will see an unusually large upsert burst right after the first launch on a build containing this PR.

## Test plan

- [x] `xcodebuild test -only-testing:DoneTests/SupabaseEventRowRoundTripTests` — all 5 pass
- [x] `supabase db push --dry-run` clean, applied 013
- [x] PostgREST live round-trip via curl — 4 columns × 10 cases all pass
- [ ] First-sync mass re-upsert behaviour on a real install (smoke after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)