### PR TITLE
fix(calendar): cross-midnight drag + chip-less in-grid + single-day regressions (#53 A+B)

### DIFF
--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -699,9 +699,18 @@ func calendarResolvedVerticalScrollOffsetForBoundaryExtensionChange(
     hourHeight: CGFloat
 ) -> CGFloat? {
     let normalizedCurrentOffsetY = currentOffsetY.isFinite ? max(0, currentOffsetY) : 0
-    let leadingHoursIncreased = newState.leadingHours > previousState.leadingHours
+    let leadingHoursChanged = newState.leadingHours != previousState.leadingHours
 
-    guard leadingHoursIncreased else { return nil }
+    // Symmetric scroll compensation: previously gated on `leadingHoursIncreased`
+    // only (open extension during drag → compensate). The CLOSE direction
+    // (extension N → 0, dragEnd dismiss path) was left uncompensated, so the
+    // now-time indicator visibly slid 12h*hourHeight as `leading` animated to
+    // zero — the user-observed "now-time refresh" after the bounce was
+    // unhooked. Apply the same column-local-time-preserving adjustment in
+    // both directions; the underlying math
+    // (`calendarAdjustedVerticalScrollOffsetForLeadingTimelineExtension`) is
+    // already symmetric (`currentOffsetY + delta*hourHeight`). (#53 single-day)
+    guard leadingHoursChanged else { return nil }
 
     let leadingAdjustedOffsetY = calendarAdjustedVerticalScrollOffsetForLeadingTimelineExtension(
         currentOffsetY: normalizedCurrentOffsetY,
@@ -2548,7 +2557,16 @@ private extension CalendarPageView {
 
         // When the drag source clears (finger lifted) near max
         // pinch, the extension can't be scrolled away naturally
-        // (scroll range too small).  Dismiss directly with fade.
+        // (scroll range too small). Route the dismiss through
+        // `applyTimelineBoundaryExtensionState(.none)` so the scroll
+        // position is compensated alongside the leading/trailing
+        // collapse (matches what the open path does during drag, just
+        // running in reverse). The previous `clearTimelineBoundaryExtensionState`
+        // bypassed scroll compensation, so when the canvas height
+        // shrank from extended → base, ScrollView clamped contentOffset
+        // back into range out-of-sync with the leading-driven content
+        // shift — the user-observed "canvas slides up then snaps
+        // back" bounce. (#53 single-day regression)
         if newState.source == nil, retainedState.hasAnyExtension {
             let hourHeight = calendarState.timelineHourHeight
             let baseContentHeight = CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
@@ -2556,8 +2574,24 @@ private extension CalendarPageView {
             if scrollableRange < hourHeight * 2 {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [self] in
                     guard timelineRawBoundaryExtensionState.source == nil else { return }
-                    withAnimation(.easeOut(duration: 0.3)) {
-                        clearTimelineBoundaryExtensionState()
+                    // `applyTimelineBoundaryExtensionState` snaps scroll
+                    // instantly (`disablesAnimations = true` on the inner
+                    // scrollTo transaction) but the `leading` state change
+                    // is observed by TimelineView's
+                    // `.animation(boundaryExtensionAnimation, value: leading)`
+                    // modifier — and post-drag that animation is a spring
+                    // (~0.28s). The scroll snap + spring leading shift
+                    // get out-of-sync, so an event committed mid-collapse
+                    // jumps to its new window-y at t=0 (scroll snap) and
+                    // then slides back over the spring duration. Wrap the
+                    // apply in a `disablesAnimations` transaction so the
+                    // leading change propagates animation-free, in lockstep
+                    // with the scroll snap (and the event holds its
+                    // visual position). (#53 single-day follow-on)
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        applyTimelineBoundaryExtensionState(.none)
                     }
                 }
             }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2663,7 +2663,23 @@ private extension CalendarPageView {
             trailingVisible: visibility.trailingVisible
         )
         guard collapsedState != timelineBoundaryExtensionState else { return }
-        withAnimation(.easeOut(duration: 0.25)) {
+        // Mirror the drag-end dismiss path's `disablesAnimations` guard
+        // (see 2580-2591). `applyTimelineBoundaryExtensionState` now snaps
+        // scroll via `disablesAnimations = true` on the inner scrollTo
+        // transaction in BOTH directions (since
+        // `calendarResolvedVerticalScrollOffsetForBoundaryExtensionChange`
+        // became symmetric in #53). The outer
+        // `withAnimation(.easeOut(0.25))` here used to wrap a path that
+        // never compensated scroll, so leading and scroll could each have
+        // their own animations — but post-PR, scroll snaps while
+        // `leading` springs via TimelineView's `.animation(_:value:)`
+        // modifier (returns ~0.28s spring outside drag). The two get
+        // out-of-sync, content drifts ~0.28s. Suppress the leading
+        // spring with the same transaction so leading + scroll snap in
+        // lockstep, matching the drag-end dismiss flow.
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
             applyTimelineBoundaryExtensionState(collapsedState)
         }
     }

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -2125,8 +2125,27 @@ final class DayLayerHostView: UIView {
     ) {
         let event = occurrence.event
         let session = gestureController.activeEventSession
-        let isDraggedOccurrence = session?.occurrenceID == occurrence.id
-        let isMoveDragging = isDraggedOccurrence && session?.mode == .move
+        // `isStaticDraggedHere` — this layer is the STATIC source-day block
+        // of the dragged event (id matches verbatim). Drives the move-
+        // transform translation path (which must NOT also be applied to
+        // the synth-preview projection — its frame already encodes the
+        // live position via its clipped range).
+        let isStaticDraggedHere = session?.occurrenceID == occurrence.id
+        let isMoveDragging = isStaticDraggedHere && session?.mode == .move
+        // `isDraggedOccurrence` — this layer REPRESENTS the dragged event
+        // for visual purposes (dim, shadow, focus, drag-state animations).
+        // Covers BOTH the static block (above) and its `#preview` synth
+        // projection on any host (source or sibling). Without this the
+        // projection got focus-dimmed to 0.28 like every other non-dragged
+        // event on the column (#53A: "target event itself should keep its
+        // color, not gray out like others").
+        let previewSuffix = "#preview"
+        let isDraggedOccurrence: Bool = {
+            if isStaticDraggedHere { return true }
+            if let sid = session?.occurrenceID, occurrence.id == sid + previewSuffix { return true }
+            if let fid = foreignDragSession?.occurrenceID, occurrence.id == fid + previewSuffix { return true }
+            return false
+        }()
         let reduceMotion = calendarReduceMotionEnabled
         // Floating chip owns the visual during a move drag: hide the source
         // block instantly (opacity 0) and pin it in place (no move translation).
@@ -4676,34 +4695,36 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 hasPromotedManipulation = true
                 (gesture as? TracingLongPressGesture)?.isDragPromoted = true
                 disableScrollPanGesturesForDrag()
-                // Floating drag chip (move-only). Snapshot the rendered block,
-                // lift it into the window above all columns, and hide the source
-                // block (section G). If the snapshot can't be taken, fall through
-                // to the existing in-column finger-follow behavior.
-                if chipEnabled,
-                   currentMode == .move, dragChip == nil, let window = host.window,
+                // Snapshot the rendered source block at promotion. ALWAYS
+                // captured, even in chip-less mode — the autoscroll chip
+                // (#53A) spawns lazily on edge auto-scroll using these
+                // stored fields. In `chipEnabled` mode the chip is also
+                // spawned right here at promotion as the always-on visual.
+                if currentMode == .move,
                    let snap = host.snapshotDraggedOccurrence(session.occurrenceID) {
-                    let chip = UIImageView(image: snap.image)
-                    chip.frame = snap.windowRect
-                    chip.contentMode = .scaleToFill
-                    chip.layer.shadowColor = UIColor.black.cgColor
-                    chip.layer.shadowOpacity = 0.22
-                    chip.layer.shadowRadius = 8
-                    chip.layer.shadowOffset = CGSize(width: 0, height: 3)
-                    chip.alpha = 0.97
-                    chip.transform = CGAffineTransform(scaleX: 1.03, y: 1.03)
                     chipSourceSize = snap.windowRect.size
                     chipSourceImage = snap.image
                     chipGrabOffset = CGSize(
                         width: initialPointInWindow.x - snap.windowRect.midX,
                         height: initialPointInWindow.y - snap.windowRect.midY
                     )
-                    window.addSubview(chip)
-                    dragChip = chip
-                    isChipActive = true
-                    lastSnappedColumnCenterX = nil
-                    host.renderLiveDragFrame() // hide the source block immediately
-                    updateChipPosition()
+                    if chipEnabled, dragChip == nil, let window = host.window {
+                        let chip = UIImageView(image: snap.image)
+                        chip.frame = snap.windowRect
+                        chip.contentMode = .scaleToFill
+                        chip.layer.shadowColor = UIColor.black.cgColor
+                        chip.layer.shadowOpacity = 0.22
+                        chip.layer.shadowRadius = 8
+                        chip.layer.shadowOffset = CGSize(width: 0, height: 3)
+                        chip.alpha = 0.97
+                        chip.transform = CGAffineTransform(scaleX: 1.03, y: 1.03)
+                        window.addSubview(chip)
+                        dragChip = chip
+                        isChipActive = true
+                        lastSnappedColumnCenterX = nil
+                        host.renderLiveDragFrame()
+                        updateChipPosition()
+                    }
                 }
                 // Callback order matches the SwiftUI path (G-15):
                 // onManipulationPromotion (resets menu + sets focus, reading
@@ -4911,11 +4932,60 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
 
     // MARK: Floating cross-day drag chip (move-only)
 
+    /// #53A autoscroll chip: in chip-less mode, spawn a temporary chip the
+    /// moment edge auto-scroll (or in-edge dragging) suppresses horizontal
+    /// snap, and despawn the moment it stops. The chip is the SOLE visual
+    /// during autoscroll — the in-grid projection is intentionally cleared
+    /// (`updateInGridPreview` snap-suppressed guard) to avoid the per-tick
+    /// 15-min snap flicker. The chip follows the finger 1:1 (no snap), so
+    /// the user sees a smooth lift-off representation of what they're
+    /// dragging while the time grid scrolls under them.
+    private func ensureAutoscrollChipIfNeeded() {
+        // chipEnabled mode manages its own chip at promotion + drop — skip.
+        guard !chipEnabled else { return }
+        // Need a promotion + move drag + a captured source snapshot.
+        guard hasPromotedManipulation, currentMode == .move,
+              let host, let image = chipSourceImage,
+              chipSourceSize.width > 0, chipSourceSize.height > 0 else {
+            return
+        }
+        let needsChip = isHorizontalSnapSuppressed
+        if needsChip, dragChip == nil, let window = host.window {
+            let chip = UIImageView(image: image)
+            chip.bounds.size = chipSourceSize
+            chip.contentMode = .scaleToFill
+            chip.layer.shadowColor = UIColor.black.cgColor
+            chip.layer.shadowOpacity = 0.22
+            chip.layer.shadowRadius = 8
+            chip.layer.shadowOffset = CGSize(width: 0, height: 3)
+            chip.alpha = 0.97
+            chip.transform = CGAffineTransform(scaleX: 1.03, y: 1.03)
+            let f = lastLocationInWindow
+            chip.center = CGPoint(
+                x: f.x - chipGrabOffset.width,
+                y: f.y - chipGrabOffset.height
+            )
+            window.addSubview(chip)
+            dragChip = chip
+            isChipActive = true
+            NSLog("[#53A][autoscroll-chip] spawn")
+        } else if !needsChip, dragChip != nil {
+            dragChip?.removeFromSuperview()
+            dragChip = nil
+            isChipActive = false
+            lastSnappedColumnCenterX = nil
+            lastChipSnapFingerprint = nil
+            lastChipSnapSize = nil
+            NSLog("[#53A][autoscroll-chip] despawn")
+        }
+    }
+
     /// Position the floating chip each frame. Y follows the finger continuously
     /// (preserving the grab offset). X free-follows the finger while horizontal
     /// snap is suppressed (edge / auto-scroll), otherwise snaps to the center of
     /// the day-column under the finger.
     private func updateChipPosition() {
+        ensureAutoscrollChipIfNeeded()
         guard let chip = dragChip else { return }
         // The chip is the dragged event's ONE always-visible representation for
         // the whole drag — it must never be hidden, or the event vanishes when
@@ -5059,13 +5129,24 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             clearInGridPreview(); return
         }
         // Only move + resize participate in the in-grid preview path.
-        // (#53A: dropping the chip means in-grid is the sole visual — it
-        // must keep updating during edge auto-scroll too. The pre-chip-less
-        // gate `guard !isHorizontalSnapSuppressed` was there because the
-        // floating chip handled the free / auto-scroll visual; in chip-less
-        // mode that gate would BLANK the dragged event for every autoscroll
-        // tick. Each tick re-fans-out so the in-grid block tracks the
-        // scrolling time grid live.)
+        switch currentMode {
+        case .move:
+            // Hand off to the autoscroll chip (`ensureAutoscrollChipIfNeeded`)
+            // whenever horizontal snap is suppressed — edge zone or
+            // active edge-autoscroll. The chip follows the finger 1:1 with
+            // no snap; the in-grid would flicker per tick as each new
+            // 15-min slot snaps under finger. Clear all in-grid previews
+            // so the chip is the sole visual until autoscroll ends.
+            guard !isHorizontalSnapSuppressed else {
+                clearInGridPreview(); return
+            }
+        case .resizeTop, .resizeBottom:
+            // Resize stays in the source column; no horizontal-snap
+            // distinction. Resize doesn't drive an autoscroll chip — the
+            // resized block follows the live range via `liveAdjustedOccurrence`
+            // on the source and via the synth preview on siblings.
+            break
+        }
         // FIX 5: a dragged todo deliberately does NOT participate in overlap
         // (it's excluded from `overlapCandidates` via `draggedTodoOccurrenceID`),
         // so it must never squeeze peers. Pushing a `#preview` occurrence into

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -5214,29 +5214,27 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             ) ?? session.originalRange
         }
 
-        // 2) Per-day clipper. Shared id (`#preview`) across hosts so the
-        //    sibling-paint render branch + source `previewChipGeometryInWindow`
-        //    keep their existing keying. Returns nil when the live range
-        //    doesn't touch this day at all.
+        // 2) Per-day push decision. Shared id (`#preview`) across hosts so
+        //    the sibling-paint render branch + source
+        //    `previewChipGeometryInWindow` keep their existing keying.
+        //    Returns nil when the live range doesn't touch this day at all.
+        //
+        //    #53A follow-on: the preview carries the FULL live range, NOT
+        //    the day-clipped portion. This makes the in-block time text
+        //    show the unified event duration (e.g. "23:30 - 02:30") on
+        //    every column the cross-midnight event touches, instead of
+        //    each half showing its own partial slice and looking like two
+        //    separate events. `verticalFrame` clips visually via
+        //    `calendarTimelineYFraction`'s `min(max(0, raw), 1)` clamp +
+        //    `max(visibleStart, range.start)` / `min(visibleEnd, range.end)`
+        //    — same shape static cross-midnight blocks already follow
+        //    (their `occurrence.range` is also the full unclipped range).
         let previewID = session.occurrenceID + "#preview"
         func clippedPreview(forDay dayStart: Date) -> CalendarLayout.EventOccurrence? {
             let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
             guard liveRange.end > dayStart, liveRange.start < dayEnd else { return nil }
-            let clipped = calendarAdjustedOccurrenceRange(
-                occurrenceID: session.occurrenceID,
-                occurrenceRange: liveRange,
-                draggingOccurrenceID: session.occurrenceID,
-                draggingOriginalRange: session.originalRange,
-                dragMode: currentMode,
-                previewRange: liveRange,
-                dayStart: dayStart,
-                dayEnd: dayEnd
-            ) ?? Event.TimeRange(
-                start: max(liveRange.start, dayStart),
-                end: min(liveRange.end, dayEnd)
-            )
             return CalendarLayout.EventOccurrence(
-                id: previewID, event: session.event, range: clipped
+                id: previewID, event: session.event, range: liveRange
             )
         }
 

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -540,6 +540,43 @@ final class DayLayerHostView: UIView {
     /// duration. Empty when the dragged event is not an interrupt parent.
     private var draggedInterruptChildIDs: Set<String> = []
 
+    /// Cross-midnight sibling-paint signal (#53 sub-bug A). A cross-midnight
+    /// occurrence fans out into TWO `EventOccurrence`s sharing one event id,
+    /// rendered on TWO `DayLayerHostView`s — but only ONE host owns the live
+    /// `activeEventSession` (the column the finger first hit). The OTHER host
+    /// receives a `foreignDragSession` push from the gesture controller every
+    /// drag frame, so it can:
+    ///   (a) hide its static block twin (via `chipHidesSource` honoring the
+    ///       foreign session — resize too, not just move),
+    ///   (b) hide its embedded interrupt children (via
+    ///       `draggedInterruptChildIDs` computed off `effectiveDragEvent`),
+    ///   (c) paint the synthesized preview (the clipped, live-adjusted range
+    ///       portion that falls on THIS day) as a real block — gated on
+    ///       `activeEventSession == nil && foreignDragSession != nil` in
+    ///       `render` / `repaintVertical` / `cullViewport` (three render paths,
+    ///       per `[[project_calayer_timeline_render_paths]]`),
+    ///   (d) extend the synthesized-preview dedup so the still-present static
+    ///       same-id occurrence on the sibling day doesn't dedup the preview
+    ///       out before overlap ever sees it.
+    /// Mirrors the drag-create per-day mapping shape (`creationPreviewByDay`).
+    /// Cleared by the controller on day-leave / end / cancel.
+    struct ForeignDragSession: Equatable {
+        let occurrenceID: String
+        let event: Event
+        let mode: EventDragMode
+        static func == (lhs: ForeignDragSession, rhs: ForeignDragSession) -> Bool {
+            lhs.occurrenceID == rhs.occurrenceID
+                && lhs.event.id == rhs.event.id
+                && lhs.mode == rhs.mode
+        }
+    }
+    private(set) var foreignDragSession: ForeignDragSession?
+    func setForeignDragSession(_ session: ForeignDragSession?) {
+        guard foreignDragSession != session else { return }
+        foreignDragSession = session
+        renderLiveDragFrame()
+    }
+
     // MARK: Gestures (S4)
 
     /// Closures + shared scratchpad the gesture layer fires/mirrors into.
@@ -1279,8 +1316,14 @@ final class DayLayerHostView: UIView {
         // 没跟上" thrash) AND hide with the parent's chip. Recompute the set here
         // (the only place `interrupt` is in scope) into the host-level single
         // source of truth read below + by `applyInteractionState`.
-        draggedInterruptChildIDs = activeSession.map {
-            interrupt.embeddedChildIDs(ofParent: $0.event)
+        //
+        // Sibling host (cross-midnight, #53 A): `activeSession` is nil but
+        // `foreignDragSession` carries the dragged event, so use it as the
+        // fallback — embedded children of a cross-midnight interrupt parent
+        // must hide on BOTH hosts.
+        let effectiveDragEvent: Event? = activeSession?.event ?? foreignDragSession?.event
+        draggedInterruptChildIDs = effectiveDragEvent.map {
+            interrupt.embeddedChildIDs(ofParent: $0)
         } ?? []
         let draggedInterruptChildIDs = self.draggedInterruptChildIDs
         // Stack-peek mode excludes embedded interrupt children from overlap
@@ -1322,7 +1365,16 @@ final class DayLayerHostView: UIView {
             // but it's hidden + excluded from overlap, so the preview must
             // replace it (else same-day drag shows nothing: real hidden + preview
             // deduped away = the "event disappears when preview is active" bug).
+            //
+            // Sibling host (cross-midnight, #53 A): `activeEventSession` is nil
+            // on the sibling, so without the foreign fallback the host's
+            // still-present static occurrence (same event id, `id !=` nil)
+            // would match the predicate and dedup the preview out before
+            // overlap ever sees it. Accept the foreign-dragged occurrence id
+            // as the dragged id too so we only reject DIFFERENT real
+            // occurrences of the same event.
             let draggedID = gestureController.activeEventSession?.occurrenceID
+                ?? foreignDragSession?.occurrenceID
             guard !model.occurrences.contains(where: {
                 $0.event.id == preview.event.id && $0.id != draggedID
             }) else { return nil }
@@ -1530,6 +1582,32 @@ final class DayLayerHostView: UIView {
             applyInteractionState(layers, occurrence: occurrence, frame: frame, model: model)
 
             layers.container.zPosition = zPosition
+        }
+
+        // ── Sibling-paint branch (#53 sub-bug A) ─────────────────────────
+        // Cross-midnight: a sibling host (no local active session, but a
+        // foreign drag session pushed by the controller) renders the dragged
+        // event's synthesized preview as a real block at its overlap slot.
+        // The chip lives in window-space anchored to the source host's
+        // column; here on a sibling the synthesized preview IS the visible
+        // representation of the dragged event for this day (the static block
+        // is hidden via `chipHidesSource` honoring the foreign session).
+        //
+        // Source-host invariant preserved: this branch is gated on
+        // `activeSession == nil && foreignDragSession != nil`, so the source
+        // host (which owns the local session) still treats `synthesizedPreview`
+        // as reflow-only.
+        if activeSession == nil, foreignDragSession != nil,
+           let preview = synthesizedPreview {
+            let slot = slots[preview.id] ?? .default
+            if let painted = paintSiblingPreview(
+                slot: slot, preview: preview, model: model, interrupt: interrupt,
+                contentHeight: contentHeight,
+                visibleStart: visibleStart, visibleEnd: visibleEnd,
+                visibleRect: visibleRect, liveIDs: &liveIDs
+            ) {
+                rendered[preview.id] = painted
+            }
         }
 
         // Recycle subtrees for occurrences that left the day OR were culled out
@@ -1750,6 +1828,24 @@ final class DayLayerHostView: UIView {
             }
         }
 
+        // Sibling-paint (#53 sub-bug A): keep the painted sibling preview
+        // alive on scroll-settle culls between full renders, at the position
+        // the last full render placed it (the cull just re-keeps it; the next
+        // `renderLiveDragFrame` repositions). Gated identically to `render`
+        // / `repaintVertical` so all three paths agree.
+        if gestureController.activeEventSession == nil, foreignDragSession != nil,
+           let preview = dragPreviewOccurrence,
+           let slot = cachedPreviewSlot {
+            if let painted = paintSiblingPreview(
+                slot: slot, preview: preview, model: model, interrupt: interrupt,
+                contentHeight: contentHeight,
+                visibleStart: visibleStart, visibleEnd: visibleEnd,
+                visibleRect: visibleRect, liveIDs: &liveIDs
+            ) {
+                renderedFrames[preview.id] = painted
+            }
+        }
+
         // Never recycle the in-grid drag preview here: it is NOT in the cull
         // index (built from `model.occurrences`), so the candidate slice never
         // re-keeps it — but it must survive scroll-settle culls between full
@@ -1796,6 +1892,58 @@ final class DayLayerHostView: UIView {
         // headerHeight + fraction*contentHeight, then the +1.5 top gap.
         let blockY = model.headerHeight + yFraction * contentHeight + 1.5
         return (blockY, blockHeight)
+    }
+
+    /// Sibling-paint helper for cross-midnight drag (#53 sub-bug A). Paints the
+    /// `synthesizedPreview` occurrence as a real block at its slot on a SIBLING
+    /// host (gate: `foreignDragSession != nil && activeEventSession == nil`).
+    /// Shared by `render`, `repaintVertical`, and `cullViewport` so the painted
+    /// preview survives pinch and scroll-cull frames in lockstep
+    /// ([[project_calayer_timeline_render_paths]]).
+    ///
+    /// Returns the painted `RenderedEventFrame` so callers can fold it into
+    /// `renderedFrames` and the live-set. Returns nil when no preview/slot is
+    /// available; still returns a frame (without committing the layer subtree)
+    /// when the painted block falls outside the viewport so `renderedFrames`
+    /// stays complete for the gesture hit-test path.
+    private func paintSiblingPreview(
+        slot: CalendarLayout.EventOverlapSlot,
+        preview: CalendarLayout.EventOccurrence,
+        model: Model,
+        interrupt: InterruptContext,
+        contentHeight: CGFloat,
+        visibleStart: Date,
+        visibleEnd: Date,
+        visibleRect: CGRect?,
+        liveIDs: inout Set<String>
+    ) -> RenderedEventFrame? {
+        let eventAreaWidth = max(0, model.contentWidth - model.eventHorizontalInset * 2)
+        let overlapGap: CGFloat = slot.widthFraction < 1 ? 2 : 0
+        let blockWidth = max(0, eventAreaWidth * slot.widthFraction - overlapGap)
+        let blockX = model.eventHorizontalInset + eventAreaWidth * slot.xOffsetFraction
+        let vf = verticalFrame(
+            for: preview, model: model, contentHeight: contentHeight,
+            visibleStart: visibleStart, visibleEnd: visibleEnd
+        )
+        let frame = CGRect(x: blockX, y: vf.y, width: blockWidth, height: vf.height)
+        let rendered = RenderedEventFrame(
+            occurrence: preview, frame: frame,
+            slot: slot, isEmbeddedChild: false
+        )
+        // Outside the viewport: keep `renderedFrames` complete (struct-only)
+        // but don't commit a layer subtree.
+        guard isWithinViewport(frame, visibleRect: visibleRect) else { return rendered }
+        liveIDs.insert(preview.id)
+        let layers = acquireLayers(for: preview.id)
+        configure(
+            layers, frame: frame, occurrence: preview, model: model,
+            slot: slot, isEmbeddedChild: false, interrupt: interrupt,
+            visibleStart: visibleStart, visibleEnd: visibleEnd,
+            stackPeekStripWidth: cachedStackPeekStripWidth
+        )
+        applyInteractionState(layers, occurrence: preview, frame: frame, model: model)
+        layers.container.zPosition = CGFloat(slot.zIndex)
+        return rendered
     }
 
     // MARK: Live drag / interaction rendering (S4)
@@ -1890,11 +2038,30 @@ final class DayLayerHostView: UIView {
     /// and the `UIVisualEffectView` blur stay in lockstep. `draggedInterruptChildIDs`
     /// is recomputed once per `render(_:)` before either consumer runs.
     private func chipHidesSource(for occurrenceID: String) -> Bool {
-        guard gestureController.isChipActive,
-              let session = gestureController.activeEventSession,
-              session.mode == .move else { return false }
-        return session.occurrenceID == occurrenceID
-            || draggedInterruptChildIDs.contains(occurrenceID)
+        // Source host (LOCAL session): the floating move-chip stands in for
+        // the dragged block — hide the source block + its embedded interrupt
+        // children. Resize on the source host folds into the range via
+        // `liveAdjustedOccurrence`, so the static block keeps painting itself
+        // and we do NOT hide it here.
+        if gestureController.isChipActive,
+           let session = gestureController.activeEventSession,
+           session.mode == .move {
+            if session.occurrenceID == occurrenceID { return true }
+            if draggedInterruptChildIDs.contains(occurrenceID) { return true }
+            return false
+        }
+        // Sibling host (cross-midnight, #53 A): no local session, but the
+        // gesture controller pushed a `foreignDragSession` for the dragged
+        // event that also renders here. Hide the static block (the sibling
+        // preview will paint the live position) and its embedded interrupt
+        // children — for BOTH move and resize, because in either mode the
+        // sibling's static block is frozen at its original range and the
+        // sibling-painted preview is the only correct representation.
+        if let foreign = foreignDragSession {
+            if foreign.occurrenceID == occurrenceID { return true }
+            if draggedInterruptChildIDs.contains(occurrenceID) { return true }
+        }
+        return false
     }
 
     private func applyInteractionState(
@@ -2716,8 +2883,30 @@ final class DayLayerHostView: UIView {
             layers.container.zPosition = placement.zPosition
         }
 
+        // Sibling-paint (#53 sub-bug A): re-position the painted sibling
+        // preview at the new hourHeight so a pinch mid-cross-midnight drag
+        // does not freeze it. Uses the cached preview slot from the last full
+        // render (cheap path discipline — no overlap recompute here). Gated
+        // identically to the `render` branch so all three render paths agree.
+        if gestureController.activeEventSession == nil, foreignDragSession != nil,
+           let preview = dragPreviewOccurrence,
+           let slot = cachedPreviewSlot {
+            if let painted = paintSiblingPreview(
+                slot: slot, preview: preview, model: model, interrupt: interrupt,
+                contentHeight: contentHeight,
+                visibleStart: visibleStart, visibleEnd: visibleEnd,
+                visibleRect: visibleRect, liveIDs: &liveIDs
+            ) {
+                renderedFrames[preview.id] = painted
+            }
+        }
+
         // Recycle subtrees that pinched/scrolled out of the buffered viewport.
-        for (id, layers) in pool where !liveIDs.contains(id) {
+        // Never recycle the sibling-painted preview here: it lives outside the
+        // model's occurrence set (id suffix `#preview`), so `liveIDs` would
+        // drop it the moment the candidate-slice cull doesn't re-visit it.
+        let previewID = dragPreviewOccurrence?.id
+        for (id, layers) in pool where !liveIDs.contains(id) && id != previewID {
             recycleLayers(id: id, layers: layers)
         }
 
@@ -4159,9 +4348,21 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     private var chipSourceImage: UIImage?           // source-width snapshot, restored in free mode
     private var lastSnappedColumnCenterX: CGFloat?  // avoid re-springing every frame
     private(set) var isChipActive = false
-    // The host currently showing the in-grid drag preview (so we can clear it
-    // when the finger moves to a different day or the drag ends).
-    private weak var lastPreviewHost: DayLayerHostView?
+    // Weak handle so the fan-out list can survive host recycle without
+    // retain cycles.
+    private struct WeakHostRef {
+        weak var host: DayLayerHostView?
+    }
+    // The hosts currently showing an in-grid drag preview / foreign drag
+    // signal for the active session. ONE source-day target (the column under
+    // the finger) plus zero or more SIBLINGS that share a cross-midnight
+    // window with the dragged event (#53 sub-bug A — mirror of
+    // `creationPreviewByDay`'s per-day fan-out for drag-to-create at
+    // TimelineView.swift:2504-2533). Cleared on day-change / end / cancel,
+    // and re-built every drag frame so a column the live range LEAVES is
+    // cleared (not frozen on its last clip), and a column the live range
+    // newly ENTERS is painted.
+    private var lastPreviewHosts: [WeakHostRef] = []
 
     // Creation drag state (mirrors CreationDragGesture consumer @State).
     private var isCreating = false
@@ -4199,7 +4400,13 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     private func eventOccurrence(at pointInView: CGPoint) -> DayLayerHostView.RenderedEventFrame? {
         guard let host else { return nil }
         var best: (frame: DayLayerHostView.RenderedEventFrame, z: CGFloat)?
-        for (_, rf) in host.renderedFrames {
+        for (id, rf) in host.renderedFrames {
+            // Cross-midnight sibling-paint frames (id suffix `#preview`) are
+            // visual-only; gesture ownership stays with the source host's
+            // active session (#53 sub-bug A). Excluding them from hit-test
+            // means a touch over a sibling preview falls through to
+            // drag-create on empty canvas instead of starting a second drag.
+            if id.hasSuffix("#preview") { continue }
             let frame = rf.frame
             guard frame.contains(pointInView) else { continue }
             // Fall-through edge inset (smoothstep) — only blocks without
@@ -4676,13 +4883,8 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     /// the nearest one if the finger is past all columns), plus its center X and
     /// date. Walks the window subtree so it finds every visible day-column.
     private func dayColumnUnderFinger() -> (host: DayLayerHostView, windowCenterX: CGFloat, date: Date)? {
-        guard let host, let window = host.window else { return nil }
-        var hosts: [DayLayerHostView] = []
-        func walk(_ v: UIView) {
-            if let h = v as? DayLayerHostView { hosts.append(h) }
-            v.subviews.forEach(walk)
-        }
-        walk(window)
+        let hosts = allDayHosts()
+        guard !hosts.isEmpty else { return nil }
         let fingerX = lastLocationInWindow.x
         var best: (h: DayLayerHostView, rect: CGRect)?
         for h in hosts {
@@ -4695,18 +4897,58 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         return (chosen.h, chosen.rect.midX, date)
     }
 
-    // MARK: In-grid drag preview (move-only, snap mode)
+    /// All `DayLayerHostView` instances currently in the window subtree (the
+    /// visible day columns). Used by the cross-midnight sibling-paint fan-out
+    /// to push a `foreignDragSession` onto every sibling whose day window the
+    /// dragged event's range intersects (#53 sub-bug A).
+    private func allDayHosts() -> [DayLayerHostView] {
+        guard let host, let window = host.window else { return [] }
+        var hosts: [DayLayerHostView] = []
+        func walk(_ v: UIView) {
+            if let h = v as? DayLayerHostView { hosts.append(h) }
+            v.subviews.forEach(walk)
+        }
+        walk(window)
+        return hosts
+    }
+
+    // MARK: In-grid drag preview (move + cross-midnight sibling fan-out)
 
     /// While a move drag is settled (NOT auto-scrolling), push a real-time
     /// preview occurrence onto the day-column under the finger: the dragged
     /// event slots into THAT day's timeline at the dragged time (Y → time,
     /// day = the absolute target column), so neighbors reflow around it. The
     /// floating chip is hidden in this mode (see `updateChipPosition`).
+    ///
+    /// Cross-midnight (#53 sub-bug A): the live range can span multiple day
+    /// columns. We split the (move-shifted-and-clipped OR resize-folded) range
+    /// across every visible day-host it touches and push a `foreignDragSession`
+    /// + clipped preview to each NON-source host. Mirror of drag-create's
+    /// per-day mapping at `TimelineView.swift:updateCreationPreviewMapping`.
+    /// Rebuilt every drag frame so a column the live range LEAVES is cleared
+    /// (not frozen on its last clip), and a column the live range newly ENTERS
+    /// is painted.
     private func updateInGridPreview() {
-        guard let host, hasPromotedManipulation, currentMode == .move,
-              let session = eventSession, !isHorizontalSnapSuppressed,
-              let col = dayColumnUnderFinger(), let srcDate = host.liveModel?.date else {
+        guard let host, hasPromotedManipulation, let session = eventSession,
+              let srcDate = host.liveModel?.date else {
             clearInGridPreview(); return
+        }
+        // Only move + resize participate in the in-grid preview path. (Resize
+        // didn't run this before; the cross-midnight sibling-paint depends on
+        // it now, see fan-out below.)
+        switch currentMode {
+        case .move:
+            // Move runs only in snap mode; the floating chip handles free /
+            // auto-scroll.
+            guard !isHorizontalSnapSuppressed else {
+                clearInGridPreview(); return
+            }
+        case .resizeTop, .resizeBottom:
+            // Resize stays in the source column; there is no horizontal-snap
+            // distinction. The fan-out only paints SIBLING columns, so the
+            // source host's render flow keeps using `liveAdjustedOccurrence`
+            // for the resize-folded range as before.
+            break
         }
         // FIX 5: a dragged todo deliberately does NOT participate in overlap
         // (it's excluded from `overlapCandidates` via `draggedTodoOccurrenceID`),
@@ -4717,39 +4959,193 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         if session.event.kind == .todo {
             clearInGridPreview(); return
         }
+
         let cal = Calendar.current
-        let timeRange = calendarResolvedDragEditRange(
-            draggingOriginalRange: session.originalRange,
-            dragOffset: DragOffset(x: 0, y: liveResolvedOffset.y),
-            dragMode: .move,
-            hourHeight: host.liveModel?.hourHeight ?? 0,
-            dayColumnStep: 0
-        ) ?? session.originalRange
-        let dayDelta = cal.dateComponents([.day], from: cal.startOfDay(for: srcDate), to: cal.startOfDay(for: col.date)).day ?? 0
-        let shiftedStart = cal.date(byAdding: .day, value: dayDelta, to: timeRange.start) ?? timeRange.start
-        let shiftedEnd   = cal.date(byAdding: .day, value: dayDelta, to: timeRange.end)   ?? timeRange.end
-        let shifted = Event.TimeRange(start: shiftedStart, end: shiftedEnd)
-        let dayStart = cal.startOfDay(for: col.date)
-        let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
-        let clipped = calendarAdjustedOccurrenceRange(
+        let hourHeight = host.liveModel?.hourHeight ?? 0
+
+        // 1) Compute the live-adjusted range (move: shifted, resize: folded).
+        //    Move: keep the existing two-step shape (vertical via the helper,
+        //    horizontal day-delta from the column under the finger), so the
+        //    target column is still authoritative for the dropped day.
+        //    Resize: the helper folds the dragged edge into the range and
+        //    handles the natural flip when edges cross.
+        let liveRange: Event.TimeRange
+        switch currentMode {
+        case .move:
+            guard let col = dayColumnUnderFinger() else {
+                clearInGridPreview(); return
+            }
+            let timeRange = calendarResolvedDragEditRange(
+                draggingOriginalRange: session.originalRange,
+                dragOffset: DragOffset(x: 0, y: liveResolvedOffset.y),
+                dragMode: .move,
+                hourHeight: hourHeight,
+                dayColumnStep: 0
+            ) ?? session.originalRange
+            let dayDelta = cal.dateComponents(
+                [.day], from: cal.startOfDay(for: srcDate), to: cal.startOfDay(for: col.date)
+            ).day ?? 0
+            let shiftedStart = cal.date(byAdding: .day, value: dayDelta, to: timeRange.start) ?? timeRange.start
+            let shiftedEnd = cal.date(byAdding: .day, value: dayDelta, to: timeRange.end) ?? timeRange.end
+            liveRange = Event.TimeRange(start: shiftedStart, end: shiftedEnd)
+        case .resizeTop, .resizeBottom:
+            liveRange = calendarResolvedDragEditRange(
+                draggingOriginalRange: session.originalRange,
+                dragOffset: DragOffset(x: 0, y: liveResolvedOffset.y),
+                dragMode: currentMode,
+                hourHeight: hourHeight,
+                dayColumnStep: 0
+            ) ?? session.originalRange
+        }
+
+        // 2) Per-day clipper. Shared id (`#preview`) across hosts so the
+        //    sibling-paint render branch + source `previewChipGeometryInWindow`
+        //    keep their existing keying. Returns nil when the live range
+        //    doesn't touch this day at all.
+        let previewID = session.occurrenceID + "#preview"
+        func clippedPreview(forDay dayStart: Date) -> CalendarLayout.EventOccurrence? {
+            let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+            guard liveRange.end > dayStart, liveRange.start < dayEnd else { return nil }
+            let clipped = calendarAdjustedOccurrenceRange(
+                occurrenceID: session.occurrenceID,
+                occurrenceRange: liveRange,
+                draggingOccurrenceID: session.occurrenceID,
+                draggingOriginalRange: session.originalRange,
+                dragMode: currentMode,
+                previewRange: liveRange,
+                dayStart: dayStart,
+                dayEnd: dayEnd
+            ) ?? Event.TimeRange(
+                start: max(liveRange.start, dayStart),
+                end: min(liveRange.end, dayEnd)
+            )
+            return CalendarLayout.EventOccurrence(
+                id: previewID, event: session.event, range: clipped
+            )
+        }
+
+        // 3) Resolve the SOURCE host for this drag. For move that's the column
+        //    under the finger (drop target); for resize it's the
+        //    gesture-owning host (the source day, which keeps its
+        //    `liveAdjustedOccurrence` flow).
+        let sourceHost: DayLayerHostView
+        let sourceDayStart: Date
+        switch currentMode {
+        case .move:
+            guard let col = dayColumnUnderFinger() else {
+                clearInGridPreview(); return
+            }
+            sourceHost = col.host
+            sourceDayStart = cal.startOfDay(for: col.date)
+        case .resizeTop, .resizeBottom:
+            sourceHost = host
+            sourceDayStart = cal.startOfDay(for: srcDate)
+        }
+
+        // 4) Apply the source-column preview. Move's in-grid preview path is
+        //    unchanged: same `applyDragPreview` on the column under the
+        //    finger, which still drives chip width-morph + neighbor reflow on
+        //    that day. Resize source stays nil — its source-host block is
+        //    already painted via `liveAdjustedOccurrence`, and pushing a
+        //    preview here would drop the dragged occurrence from
+        //    `overlapCandidates` (it's currently filtered when a preview for
+        //    the same event id is present + dragged on this host) which would
+        //    blank the resized block on the source.
+        var newHosts: [DayLayerHostView] = []
+        switch currentMode {
+        case .move:
+            let sourcePreview = clippedPreview(forDay: sourceDayStart)
+                ?? CalendarLayout.EventOccurrence(
+                    id: previewID, event: session.event, range: liveRange
+                )
+            sourceHost.applyDragPreview(sourcePreview)
+            newHosts.append(sourceHost)
+        case .resizeTop, .resizeBottom:
+            // Source resize: no preview push — leave its existing render flow
+            // (overlap candidates, `liveAdjustedOccurrence`) untouched.
+            break
+        }
+
+        // 5) Fan out to SIBLING hosts whose day window the live range
+        //    intersects. Each sibling receives the foreign-drag signal + a
+        //    clipped preview, so the cross-midnight half tracks the live
+        //    drag in lockstep with the source. The source-host's local
+        //    `activeEventSession` remains the truth — only NON-source hosts
+        //    receive the foreign session.
+        // Fan-out skip rules (#53 sub-bug A):
+        //  • `sourceHost` already got its push above (move: drop target;
+        //    resize: no preview push, but its render flow paints via
+        //    `liveAdjustedOccurrence`).
+        //  • Skip the gesture-owning `host` if it is NOT also the source
+        //    host. `host` already has the LOCAL `activeEventSession`, so its
+        //    render flow handles the dragged occurrence via
+        //    `liveAdjustedOccurrence` (clipping to its day window) and its
+        //    `overlapCandidates` dedup already drops the dragged occurrence
+        //    when a preview for the same event id is present. Pushing a
+        //    foreign preview onto a host that has the local session would
+        //    confuse those gates AND interfere with the source's stable
+        //    overlap slot.
+        //
+        // A SIBLING is any other day host that has the dragged event's
+        // SAME-ID static occurrence (cross-midnight twin) AND/OR whose day
+        // window the LIVE range touches:
+        //  • Same-id twin (cross-midnight original) → push the foreign
+        //    session so `chipHidesSource` hides its frozen static block
+        //    (the bug — sibling was visibly decoupled from the dragged
+        //    chip). Whether it ALSO paints a preview depends on whether
+        //    the live range still touches its day.
+        //  • Live-range intersection (cross-midnight at the new position)
+        //    → push the foreign session + clipped preview so the sibling
+        //    paints the cross-midnight half at the live position.
+        let foreignSession = DayLayerHostView.ForeignDragSession(
             occurrenceID: session.occurrenceID,
-            occurrenceRange: shifted,
-            draggingOccurrenceID: session.occurrenceID,
-            draggingOriginalRange: session.originalRange,
-            dragMode: .move,
-            previewRange: shifted,
-            dayStart: dayStart,
-            dayEnd: dayEnd
-        ) ?? shifted
-        let occ = CalendarLayout.EventOccurrence(id: session.occurrenceID + "#preview", event: session.event, range: clipped)
-        if let last = lastPreviewHost, last !== col.host { last.applyDragPreview(nil) }
-        lastPreviewHost = col.host
-        col.host.applyDragPreview(occ)
+            event: session.event,
+            mode: currentMode
+        )
+        for sibling in allDayHosts() {
+            if sibling === sourceHost { continue }
+            if sibling === host, host !== sourceHost { continue }
+            guard let siblingDate = sibling.liveModel?.date else { continue }
+            let siblingDayStart = cal.startOfDay(for: siblingDate)
+            let hasSameIDStatic = sibling.liveModel?.occurrences.contains(where: {
+                $0.id == session.occurrenceID
+            }) ?? false
+            let preview = clippedPreview(forDay: siblingDayStart)
+            // Push only if there IS something to coordinate on this sibling:
+            // either it has the same-id static twin that needs to hide, or
+            // the live range now touches its day window (or both).
+            guard hasSameIDStatic || preview != nil else { continue }
+            sibling.setForeignDragSession(foreignSession)
+            // Preview is OPTIONAL on the sibling. Hosts whose live range
+            // newly LEAVES (cross-midnight collapsed to single-day) still
+            // need the static block hidden — push nil to clear any prior
+            // preview while keeping the foreign session active so
+            // `chipHidesSource` still hides the static twin.
+            sibling.applyDragPreview(preview)
+            newHosts.append(sibling)
+        }
+
+        // 6) Clear hosts that previously received a preview but are no longer
+        //    in the fan-out (the finger left a column, or the live range
+        //    receded from a cross-midnight sibling). This is what makes a
+        //    column the live range LEAVES clear (rather than freezing on its
+        //    last clip — explicit user requirement).
+        let kept = Set(newHosts.map { ObjectIdentifier($0) })
+        for ref in lastPreviewHosts {
+            guard let h = ref.host, !kept.contains(ObjectIdentifier(h)) else { continue }
+            h.applyDragPreview(nil)
+            h.setForeignDragSession(nil)
+        }
+        lastPreviewHosts = newHosts.map { WeakHostRef(host: $0) }
     }
 
     private func clearInGridPreview() {
-        lastPreviewHost?.applyDragPreview(nil)
-        lastPreviewHost = nil
+        for ref in lastPreviewHosts {
+            guard let h = ref.host else { continue }
+            h.applyDragPreview(nil)
+            h.setForeignDragSession(nil)
+        }
+        lastPreviewHosts.removeAll()
     }
 
     // MARK: Absorption drop-targeting (G-57..G-62)

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -574,37 +574,21 @@ final class DayLayerHostView: UIView {
     func setForeignDragSession(_ session: ForeignDragSession?) {
         guard foreignDragSession != session else { return }
         foreignDragSession = session
-        NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] setForeignDragSession -> \(session.map { "\($0.occurrenceID.suffix(8)) mode=\($0.mode)" } ?? "nil")")
         renderLiveDragFrame()
     }
 
-    /// #53A: When the live drag is cross-midnight (range spans > 1 day), the
-    /// floating chip cannot physically represent the whole event across two
-    /// columns (it's one window-space bitmap anchored to the finger). The
-    /// gesture controller sets this flag on the SOURCE host so the source
-    /// also paints its `synthesizedPreview` clip in-grid (joining the sibling
-    /// halves into a single contiguous visual). False during single-day drag,
-    /// where the chip remains the source's sole representation.
+    /// #53A: legacy flag preserved as a no-op for forward compatibility with
+    /// a potential return of the floating-chip mode. In the current chip-less
+    /// path the source host always paints its clip when there is an active
+    /// session, so this flag no longer gates anything; it is retained so a
+    /// future chip-on variant can re-introduce the cross-midnight source-paint
+    /// signal without re-plumbing the API surface.
     private(set) var paintSourceClipInGrid: Bool = false
     func setPaintSourceClipInGrid(_ on: Bool) {
         guard paintSourceClipInGrid != on else { return }
         paintSourceClipInGrid = on
-        NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] setPaintSourceClipInGrid -> \(on)")
         renderLiveDragFrame()
     }
-
-    // Short MM-dd tag for log identity. Uses the host's current model date so
-    // each log line identifies which day column logged it.
-    fileprivate static func logDayTag(_ date: Date?) -> String {
-        guard let date else { return "??" }
-        let c = Calendar.current
-        let m = c.component(.month, from: date)
-        let d = c.component(.day, from: date)
-        return String(format: "%02d-%02d", m, d)
-    }
-    // Tracks last sibling-paint log state to avoid per-frame spam — only logs
-    // on transition or when the painted slot/frame changes.
-    fileprivate var lastSiblingPaintLog: String?
 
     // MARK: Gestures (S4)
 
@@ -1644,16 +1628,7 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 rendered[preview.id] = painted
-                let role = activeSession != nil ? "source" : "sibling"
-                let fp = "render(\(role)) slot=\(String(format: "%.2f", slot.widthFraction)) frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))"
-                if lastSiblingPaintLog != fp {
-                    NSLog("[#53A][host \(Self.logDayTag(model.date))] paint \(fp)")
-                    lastSiblingPaintLog = fp
-                }
             }
-        } else if lastSiblingPaintLog != nil {
-            NSLog("[#53A][host \(Self.logDayTag(model.date))] paint gate CLOSED (activeSession=\(activeSession != nil) foreign=\(foreignDragSession != nil) paintSourceClip=\(paintSourceClipInGrid) preview=\(synthesizedPreview != nil))")
-            lastSiblingPaintLog = nil
         }
 
         // Recycle subtrees for occurrences that left the day OR were culled out
@@ -1892,7 +1867,6 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 renderedFrames[preview.id] = painted
-                NSLog("[#53A][host \(Self.logDayTag(model.date))] cullViewport sibling-paint kept frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))")
             }
         }
 
@@ -2699,12 +2673,6 @@ final class DayLayerHostView: UIView {
     func applyDragPreview(_ occ: CalendarLayout.EventOccurrence?) {
         guard dragPreviewOccurrence != occ else { return }   // EventOccurrence is Equatable
         dragPreviewOccurrence = occ
-        if let occ {
-            let f = DateFormatter(); f.dateFormat = "MM-dd HH:mm"
-            NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] applyDragPreview range=\(f.string(from: occ.range.start))->\(f.string(from: occ.range.end))")
-        } else {
-            NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] applyDragPreview nil (cleared)")
-        }
         renderLiveDragFrame()
     }
 
@@ -2993,7 +2961,6 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 renderedFrames[preview.id] = painted
-                NSLog("[#53A][host \(Self.logDayTag(model.date))] repaintVertical sibling-paint kept frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))")
             }
         }
 
@@ -4464,8 +4431,6 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     // cleared (not frozen on its last clip), and a column the live range
     // newly ENTERS is painted.
     private var lastPreviewHosts: [WeakHostRef] = []
-    // Log de-dup fingerprint for the fan-out summary line (#53A instrumentation).
-    private var lastFanoutFingerprint: String?
     // #53A: chip-as-finger-tracking-projection refresh throttle. Snapshot
     // (UIGraphicsImageRenderer over a CALayer tree) is expensive; refresh only
     // when the underlying preview's visual fingerprint changes (range +
@@ -4987,7 +4952,6 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             window.addSubview(chip)
             dragChip = chip
             isChipActive = true
-            NSLog("[#53A][autoscroll-chip] spawn")
         } else if !needsChip, dragChip != nil {
             dragChip?.removeFromSuperview()
             dragChip = nil
@@ -4995,7 +4959,6 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             lastSnappedColumnCenterX = nil
             lastChipSnapFingerprint = nil
             lastChipSnapSize = nil
-            NSLog("[#53A][autoscroll-chip] despawn")
         }
     }
 
@@ -5386,30 +5349,16 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         //    column the live range LEAVES clear (rather than freezing on its
         //    last clip — explicit user requirement).
         let kept = Set(newHosts.map { ObjectIdentifier($0) })
-        var clearedTags: [String] = []
         for ref in lastPreviewHosts {
             guard let h = ref.host, !kept.contains(ObjectIdentifier(h)) else { continue }
-            clearedTags.append(DayLayerHostView.logDayTag(h.liveModel?.date))
             h.applyDragPreview(nil)
             h.setForeignDragSession(nil)
             h.setPaintSourceClipInGrid(false)
-        }
-
-        // Fan-out summary log (rate-limited by host-set + cleared-set fingerprint).
-        let pushedTags = newHosts.map { DayLayerHostView.logDayTag($0.liveModel?.date) }
-        let fp = "kept=[\(pushedTags.joined(separator: ","))] cleared=[\(clearedTags.joined(separator: ","))]"
-        if fp != lastFanoutFingerprint {
-            let f = DateFormatter(); f.dateFormat = "MM-dd HH:mm"
-            NSLog("[#53A][fanout] src=\(DayLayerHostView.logDayTag(sourceDayStart)) mode=\(currentMode) liveRange=\(f.string(from: liveRange.start))->\(f.string(from: liveRange.end)) \(fp)")
-            lastFanoutFingerprint = fp
         }
         lastPreviewHosts = newHosts.map { WeakHostRef(host: $0) }
     }
 
     private func clearInGridPreview() {
-        if !lastPreviewHosts.isEmpty {
-            NSLog("[#53A][fanout] clear ALL (drag end / not eligible)")
-        }
         for ref in lastPreviewHosts {
             guard let h = ref.host else { continue }
             h.applyDragPreview(nil)
@@ -5417,7 +5366,6 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             h.setPaintSourceClipInGrid(false)
         }
         lastPreviewHosts.removeAll()
-        lastFanoutFingerprint = nil
     }
 
     // MARK: Absorption drop-targeting (G-57..G-62)

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -574,8 +574,37 @@ final class DayLayerHostView: UIView {
     func setForeignDragSession(_ session: ForeignDragSession?) {
         guard foreignDragSession != session else { return }
         foreignDragSession = session
+        NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] setForeignDragSession -> \(session.map { "\($0.occurrenceID.suffix(8)) mode=\($0.mode)" } ?? "nil")")
         renderLiveDragFrame()
     }
+
+    /// #53A: When the live drag is cross-midnight (range spans > 1 day), the
+    /// floating chip cannot physically represent the whole event across two
+    /// columns (it's one window-space bitmap anchored to the finger). The
+    /// gesture controller sets this flag on the SOURCE host so the source
+    /// also paints its `synthesizedPreview` clip in-grid (joining the sibling
+    /// halves into a single contiguous visual). False during single-day drag,
+    /// where the chip remains the source's sole representation.
+    private(set) var paintSourceClipInGrid: Bool = false
+    func setPaintSourceClipInGrid(_ on: Bool) {
+        guard paintSourceClipInGrid != on else { return }
+        paintSourceClipInGrid = on
+        NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] setPaintSourceClipInGrid -> \(on)")
+        renderLiveDragFrame()
+    }
+
+    // Short MM-dd tag for log identity. Uses the host's current model date so
+    // each log line identifies which day column logged it.
+    fileprivate static func logDayTag(_ date: Date?) -> String {
+        guard let date else { return "??" }
+        let c = Calendar.current
+        let m = c.component(.month, from: date)
+        let d = c.component(.day, from: date)
+        return String(format: "%02d-%02d", m, d)
+    }
+    // Tracks last sibling-paint log state to avoid per-frame spam — only logs
+    // on transition or when the painted slot/frame changes.
+    fileprivate var lastSiblingPaintLog: String?
 
     // MARK: Gestures (S4)
 
@@ -1597,8 +1626,16 @@ final class DayLayerHostView: UIView {
         // `activeSession == nil && foreignDragSession != nil`, so the source
         // host (which owns the local session) still treats `synthesizedPreview`
         // as reflow-only.
-        if activeSession == nil, foreignDragSession != nil,
-           let preview = synthesizedPreview {
+        // Paint synthesizedPreview whenever there's an active drag session
+        // on this host — local (source) OR foreign (sibling). Uniform
+        // N-column logic: every column the live range touches paints its
+        // clip as a real block. The chip (when enabled, gesture controller
+        // `chipEnabled`) is just an additional finger-tracking overlay on
+        // top of this; in chip-off mode the projection is the sole visual.
+        // (#53 sub-bug A)
+        let paintGateOpen = synthesizedPreview != nil &&
+            (activeSession != nil || foreignDragSession != nil)
+        if paintGateOpen, let preview = synthesizedPreview {
             let slot = slots[preview.id] ?? .default
             if let painted = paintSiblingPreview(
                 slot: slot, preview: preview, model: model, interrupt: interrupt,
@@ -1607,7 +1644,16 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 rendered[preview.id] = painted
+                let role = activeSession != nil ? "source" : "sibling"
+                let fp = "render(\(role)) slot=\(String(format: "%.2f", slot.widthFraction)) frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))"
+                if lastSiblingPaintLog != fp {
+                    NSLog("[#53A][host \(Self.logDayTag(model.date))] paint \(fp)")
+                    lastSiblingPaintLog = fp
+                }
             }
+        } else if lastSiblingPaintLog != nil {
+            NSLog("[#53A][host \(Self.logDayTag(model.date))] paint gate CLOSED (activeSession=\(activeSession != nil) foreign=\(foreignDragSession != nil) paintSourceClip=\(paintSourceClipInGrid) preview=\(synthesizedPreview != nil))")
+            lastSiblingPaintLog = nil
         }
 
         // Recycle subtrees for occurrences that left the day OR were culled out
@@ -1833,7 +1879,10 @@ final class DayLayerHostView: UIView {
         // the last full render placed it (the cull just re-keeps it; the next
         // `renderLiveDragFrame` repositions). Gated identically to `render`
         // / `repaintVertical` so all three paths agree.
-        if gestureController.activeEventSession == nil, foreignDragSession != nil,
+        let cullActive = gestureController.activeEventSession
+        let cullPaintGateOpen = dragPreviewOccurrence != nil && cachedPreviewSlot != nil &&
+            (cullActive != nil || foreignDragSession != nil)
+        if cullPaintGateOpen,
            let preview = dragPreviewOccurrence,
            let slot = cachedPreviewSlot {
             if let painted = paintSiblingPreview(
@@ -1843,6 +1892,7 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 renderedFrames[preview.id] = painted
+                NSLog("[#53A][host \(Self.logDayTag(model.date))] cullViewport sibling-paint kept frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))")
             }
         }
 
@@ -2038,13 +2088,16 @@ final class DayLayerHostView: UIView {
     /// and the `UIVisualEffectView` blur stay in lockstep. `draggedInterruptChildIDs`
     /// is recomputed once per `render(_:)` before either consumer runs.
     private func chipHidesSource(for occurrenceID: String) -> Bool {
-        // Source host (LOCAL session): the floating move-chip stands in for
-        // the dragged block — hide the source block + its embedded interrupt
-        // children. Resize on the source host folds into the range via
-        // `liveAdjustedOccurrence`, so the static block keeps painting itself
-        // and we do NOT hide it here.
-        if gestureController.isChipActive,
-           let session = gestureController.activeEventSession,
+        // Source host (LOCAL session): during a MOVE drag, the live preview
+        // (floating chip OR in-grid synth-preview projection — see
+        // `chipEnabled` in the gesture controller) stands in for the dragged
+        // block. Hide the source-position block + its embedded interrupt
+        // children so the preview is the sole representation. Resize on the
+        // source host folds into the range via `liveAdjustedOccurrence`, so
+        // the static block keeps painting itself and we do NOT hide it here.
+        // (The legacy name is kept — predicate now serves both chip-on and
+        // chip-off paths uniformly.)
+        if let session = gestureController.activeEventSession,
            session.mode == .move {
             if session.occurrenceID == occurrenceID { return true }
             if draggedInterruptChildIDs.contains(occurrenceID) { return true }
@@ -2627,6 +2680,12 @@ final class DayLayerHostView: UIView {
     func applyDragPreview(_ occ: CalendarLayout.EventOccurrence?) {
         guard dragPreviewOccurrence != occ else { return }   // EventOccurrence is Equatable
         dragPreviewOccurrence = occ
+        if let occ {
+            let f = DateFormatter(); f.dateFormat = "MM-dd HH:mm"
+            NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] applyDragPreview range=\(f.string(from: occ.range.start))->\(f.string(from: occ.range.end))")
+        } else {
+            NSLog("[#53A][host \(Self.logDayTag(currentModel?.date))] applyDragPreview nil (cleared)")
+        }
         renderLiveDragFrame()
     }
 
@@ -2643,6 +2702,20 @@ final class DayLayerHostView: UIView {
         let xLocal = model.eventHorizontalInset + eventAreaWidth * slot.xOffsetFraction
         let centerX = convert(CGPoint(x: xLocal + width / 2, y: 0), to: nil).x
         return (width, centerX)
+    }
+
+    /// Identity fingerprint for the would-be `snapshotPreviewBlock` output on
+    /// this host. Used by the chip-as-finger-tracking-projection refresh in
+    /// `CalendarDayGestureController.updateChipPosition` to throttle the
+    /// (expensive) `UIGraphicsImageRenderer` re-render to actual visual
+    /// changes — range / hourHeight / slot — instead of re-snapshotting every
+    /// drag frame. Returns nil when there is nothing snapshottable yet (same
+    /// preconditions as `snapshotPreviewBlock`). (#53 sub-bug A)
+    func chipSnapFingerprint() -> String? {
+        guard let model = currentModel,
+              let preview = dragPreviewOccurrence,
+              let slot = cachedPreviewSlot else { return nil }
+        return "\(model.date.timeIntervalSince1970)|\(preview.range.start.timeIntervalSince1970)|\(preview.range.end.timeIntervalSince1970)|\(model.hourHeight)|\(slot.widthFraction)"
     }
 
     /// Render the dragged event's `#preview` occurrence at the TARGET column's
@@ -2888,7 +2961,10 @@ final class DayLayerHostView: UIView {
         // does not freeze it. Uses the cached preview slot from the last full
         // render (cheap path discipline — no overlap recompute here). Gated
         // identically to the `render` branch so all three render paths agree.
-        if gestureController.activeEventSession == nil, foreignDragSession != nil,
+        let rpActive = gestureController.activeEventSession
+        let rpPaintGateOpen = dragPreviewOccurrence != nil && cachedPreviewSlot != nil &&
+            (rpActive != nil || foreignDragSession != nil)
+        if rpPaintGateOpen,
            let preview = dragPreviewOccurrence,
            let slot = cachedPreviewSlot {
             if let painted = paintSiblingPreview(
@@ -2898,6 +2974,7 @@ final class DayLayerHostView: UIView {
                 visibleRect: visibleRect, liveIDs: &liveIDs
             ) {
                 renderedFrames[preview.id] = painted
+                NSLog("[#53A][host \(Self.logDayTag(model.date))] repaintVertical sibling-paint kept frame=(\(Int(painted.frame.minY)),h\(Int(painted.frame.height)))")
             }
         }
 
@@ -4348,6 +4425,11 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     private var chipSourceImage: UIImage?           // source-width snapshot, restored in free mode
     private var lastSnappedColumnCenterX: CGFloat?  // avoid re-springing every frame
     private(set) var isChipActive = false
+    // #53A experimental: drop the floating chip entirely and rely on the
+    // in-grid synth-preview projections (source + every sibling the live
+    // range touches) as the sole visual feedback. Uniform N-column logic,
+    // no chip-vs-projection split. Flip to `true` to re-enable the chip.
+    private let chipEnabled = false
     // Weak handle so the fan-out list can survive host recycle without
     // retain cycles.
     private struct WeakHostRef {
@@ -4363,6 +4445,16 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
     // cleared (not frozen on its last clip), and a column the live range
     // newly ENTERS is painted.
     private var lastPreviewHosts: [WeakHostRef] = []
+    // Log de-dup fingerprint for the fan-out summary line (#53A instrumentation).
+    private var lastFanoutFingerprint: String?
+    // #53A: chip-as-finger-tracking-projection refresh throttle. Snapshot
+    // (UIGraphicsImageRenderer over a CALayer tree) is expensive; refresh only
+    // when the underlying preview's visual fingerprint changes (range +
+    // hourHeight + slot). `lastChipSnapSize` caches the snap dimensions so the
+    // chip can apply them every frame for animation continuity without
+    // re-snapshotting.
+    private var lastChipSnapFingerprint: String?
+    private var lastChipSnapSize: CGSize?
 
     // Creation drag state (mirrors CreationDragGesture consumer @State).
     private var isCreating = false
@@ -4588,7 +4680,8 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 // lift it into the window above all columns, and hide the source
                 // block (section G). If the snapshot can't be taken, fall through
                 // to the existing in-column finger-follow behavior.
-                if currentMode == .move, dragChip == nil, let window = host.window,
+                if chipEnabled,
+                   currentMode == .move, dragChip == nil, let window = host.window,
                    let snap = host.snapshotDraggedOccurrence(session.occurrenceID) {
                     let chip = UIImageView(image: snap.image)
                     chip.frame = snap.windowRect
@@ -4659,7 +4752,14 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 // (see `calendarBoundaryPagedHorizontalDragOffset`), so leave it
                 // untouched.
                 var finalOffset = liveResolvedOffset
-                if isChipActive, currentMode == .move, !usesHorizontalBoundaryPaging,
+                // FIX 2 (now chip-independent, #53A): the dayColumnUnderFinger
+                // override fires for any multi-day-continuous move drop,
+                // not only when the floating chip was up. Without it, after
+                // an autoscroll the snap-quantized `liveResolvedOffset.x`
+                // can be 1 column short of where the finger actually
+                // landed; reading the column under finger directly avoids
+                // that drift.
+                if currentMode == .move, !usesHorizontalBoundaryPaging,
                    let col = dayColumnUnderFinger(), let srcDate = host.liveModel?.date {
                     let cal = Calendar.current
                     let dayOffset = cal.dateComponents(
@@ -4821,23 +4921,32 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         // the whole drag — it must never be hidden, or the event vanishes when
         // the in-grid preview path hiccups (the "event disappears" bug). In snap
         // mode it snaps to the column center (sitting in the reflowed gap); in
-        // free/auto-scroll it follows the finger. The in-grid preview only drives
-        // neighbor reflow; it does NOT paint the event block (the chip does).
+        // free/auto-scroll it follows the finger.
+        //
+        // #53 sub-bug A: chip mirrors the in-grid projection on the column
+        // under the finger — same `configure` render path via
+        // `snapshotPreviewBlock`, just anchored to the finger instead of the
+        // time grid. So chip's WIDTH + HEIGHT + bitmap all refresh whenever
+        // the underlying preview changes (range, hourHeight, slot). For a
+        // cross-multi-day move, finger over column A → chip = A's clip; finger
+        // over column B → chip = B's clip. Uniform N-column logic — no
+        // overnight special case. Snapshot fingerprint throttles the
+        // UIGraphicsImageRenderer call to actual visual changes.
         chip.isHidden = false
         let finger = lastLocationInWindow
         let centerY = finger.y - chipGrabOffset.height
         let centerX: CGFloat
-        // The chip morphs its width to the target column's live `#preview` slot
-        // in snap mode (the dragged block narrows / columns to where it would
-        // land); in free/auto-scroll it keeps its source width and follows the
-        // finger 1:1.
         var targetWidth = chipSourceSize.width
+        var targetHeight = chipSourceSize.height
         if isHorizontalSnapSuppressed {
-            // FREE: follow finger at source width; restore the source-width
-            // snapshot if a prior snap morph had swapped in a narrower one.
+            // FREE: follow finger at source size; restore the source-size
+            // snapshot if a prior snap morph had swapped in a smaller one.
             if let iv = chip as? UIImageView, iv.image !== chipSourceImage {
                 iv.image = chipSourceImage
             }
+            // Invalidate the snap fingerprint so the next snap-mode frame
+            // re-renders + replaces the source-image fallback above.
+            lastChipSnapFingerprint = nil
             var x = finger.x - chipGrabOffset.width
             if let w = chip.window {
                 let half = chipSourceSize.width / 2
@@ -4848,13 +4957,27 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         } else if let col = dayColumnUnderFinger() {
             if let geo = col.host.previewChipGeometryInWindow() {
                 centerX = geo.centerX
-                targetWidth = geo.width
-                // Re-render the block at the new width (text reflowed via the
-                // real `configure` path) instead of stretching the bitmap.
-                if abs(chip.bounds.size.width - targetWidth) > 0.5,
-                   let iv = chip as? UIImageView,
+                // Refresh chip's bitmap + bounds from the projection on this
+                // column. The fingerprint throttles re-snapshotting (which
+                // renders a fresh CALayer tree to UIImage) to actual visual
+                // changes: range, hourHeight, slot widthFraction.
+                let snapFP = col.host.chipSnapFingerprint()
+                if snapFP != nil, snapFP != lastChipSnapFingerprint,
                    let snap = col.host.snapshotPreviewBlock() {
-                    iv.image = snap.image
+                    if let iv = chip as? UIImageView {
+                        iv.image = snap.image
+                    }
+                    lastChipSnapSize = snap.size
+                    lastChipSnapFingerprint = snapFP
+                }
+                // Prefer the live snap size (so chip mirrors the projection
+                // dimensions); fall back to the geo-derived width if the snap
+                // is briefly unavailable between drag-preview updates.
+                if let snapSize = lastChipSnapSize {
+                    targetWidth = snapSize.width
+                    targetHeight = snapSize.height
+                } else {
+                    targetWidth = geo.width
                 }
             } else {
                 centerX = col.windowCenterX
@@ -4862,19 +4985,21 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         } else {
             centerX = chip.center.x
         }
-        // Snap mode: spring when the target column center OR the morph width
-        // changes; free mode: set directly (1:1 finger-follow, no animation).
+        // Snap mode: spring when target X, width, OR height changes; free
+        // mode: set directly (1:1 finger-follow, no animation).
         let widthChanged = abs(chip.bounds.size.width - targetWidth) > 0.5
-        if !isHorizontalSnapSuppressed, lastSnappedColumnCenterX != centerX || widthChanged {
+        let heightChanged = abs(chip.bounds.size.height - targetHeight) > 0.5
+        if !isHorizontalSnapSuppressed,
+           lastSnappedColumnCenterX != centerX || widthChanged || heightChanged {
             lastSnappedColumnCenterX = centerX
             UIView.animate(withDuration: 0.18, delay: 0, usingSpringWithDamping: 0.85,
                            initialSpringVelocity: 0,
                            options: [.allowUserInteraction, .beginFromCurrentState]) {
-                chip.bounds.size.width = targetWidth
+                chip.bounds.size = CGSize(width: targetWidth, height: targetHeight)
                 chip.center = CGPoint(x: centerX, y: centerY)
             }
         } else {
-            chip.bounds.size.width = targetWidth
+            chip.bounds.size = CGSize(width: targetWidth, height: targetHeight)
             chip.center = CGPoint(x: centerX, y: centerY)
         }
     }
@@ -4933,23 +5058,14 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
               let srcDate = host.liveModel?.date else {
             clearInGridPreview(); return
         }
-        // Only move + resize participate in the in-grid preview path. (Resize
-        // didn't run this before; the cross-midnight sibling-paint depends on
-        // it now, see fan-out below.)
-        switch currentMode {
-        case .move:
-            // Move runs only in snap mode; the floating chip handles free /
-            // auto-scroll.
-            guard !isHorizontalSnapSuppressed else {
-                clearInGridPreview(); return
-            }
-        case .resizeTop, .resizeBottom:
-            // Resize stays in the source column; there is no horizontal-snap
-            // distinction. The fan-out only paints SIBLING columns, so the
-            // source host's render flow keeps using `liveAdjustedOccurrence`
-            // for the resize-folded range as before.
-            break
-        }
+        // Only move + resize participate in the in-grid preview path.
+        // (#53A: dropping the chip means in-grid is the sole visual — it
+        // must keep updating during edge auto-scroll too. The pre-chip-less
+        // gate `guard !isHorizontalSnapSuppressed` was there because the
+        // floating chip handled the free / auto-scroll visual; in chip-less
+        // mode that gate would BLANK the dragged event for every autoscroll
+        // tick. Each tick re-fans-out so the in-grid block tracks the
+        // scrolling time grid live.)
         // FIX 5: a dragged todo deliberately does NOT participate in overlap
         // (it's excluded from `overlapCandidates` via `draggedTodoOccurrenceID`),
         // so it must never squeeze peers. Pushing a `#preview` occurrence into
@@ -5042,15 +5158,27 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             sourceDayStart = cal.startOfDay(for: srcDate)
         }
 
-        // 4) Apply the source-column preview. Move's in-grid preview path is
-        //    unchanged: same `applyDragPreview` on the column under the
-        //    finger, which still drives chip width-morph + neighbor reflow on
-        //    that day. Resize source stays nil — its source-host block is
-        //    already painted via `liveAdjustedOccurrence`, and pushing a
-        //    preview here would drop the dragged occurrence from
-        //    `overlapCandidates` (it's currently filtered when a preview for
-        //    the same event id is present + dragged on this host) which would
-        //    blank the resized block on the source.
+        // 4) Apply the source-column preview. Move's in-grid preview path
+        //    pushes the clipped live range to the column under the finger.
+        //    Resize source stays nil — its source-host block is already
+        //    painted via `liveAdjustedOccurrence`, and pushing a preview
+        //    here would drop the dragged occurrence from `overlapCandidates`
+        //    (filtered when a preview for the same event id is present +
+        //    dragged on this host) which would blank the resized block.
+        //
+        //    For a CROSS-COLUMN move (finger crossed to a host that is NOT
+        //    the gesture-owning `host`), the new source has NO local
+        //    `activeEventSession` (gestures live on whichever host
+        //    promoted), so without a foreign-session push its paint gate
+        //    stays CLOSED and the synth preview block visually disappears
+        //    (#53A: chip-less cross-column bug). Set the foreign session
+        //    BEFORE applying the preview so the gate is open by the time
+        //    the apply-triggered render runs (no 1-frame flicker).
+        let foreignSession = DayLayerHostView.ForeignDragSession(
+            occurrenceID: session.occurrenceID,
+            event: session.event,
+            mode: currentMode
+        )
         var newHosts: [DayLayerHostView] = []
         switch currentMode {
         case .move:
@@ -5058,6 +5186,9 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 ?? CalendarLayout.EventOccurrence(
                     id: previewID, event: session.event, range: liveRange
                 )
+            if sourceHost !== host {
+                sourceHost.setForeignDragSession(foreignSession)
+            }
             sourceHost.applyDragPreview(sourcePreview)
             newHosts.append(sourceHost)
         case .resizeTop, .resizeBottom:
@@ -5097,14 +5228,13 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         //  • Live-range intersection (cross-midnight at the new position)
         //    → push the foreign session + clipped preview so the sibling
         //    paints the cross-midnight half at the live position.
-        let foreignSession = DayLayerHostView.ForeignDragSession(
-            occurrenceID: session.occurrenceID,
-            event: session.event,
-            mode: currentMode
-        )
+        var anySiblingPushed = false
         for sibling in allDayHosts() {
+            // Skip the gesture-owning host (local session covers it) and
+            // the source host (already pushed above with the right ordering:
+            // foreign session before applyDragPreview).
+            if sibling === host { continue }
             if sibling === sourceHost { continue }
-            if sibling === host, host !== sourceHost { continue }
             guard let siblingDate = sibling.liveModel?.date else { continue }
             let siblingDayStart = cal.startOfDay(for: siblingDate)
             let hasSameIDStatic = sibling.liveModel?.occurrences.contains(where: {
@@ -5123,7 +5253,16 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             // `chipHidesSource` still hides the static twin.
             sibling.applyDragPreview(preview)
             newHosts.append(sibling)
+            anySiblingPushed = true
         }
+
+        // Cross-midnight signal to the source host: when the live range spans
+        // more than one day, the chip (one window-space bitmap) cannot
+        // represent both halves at once. Tell the source to ALSO paint its
+        // clipped portion in-grid, so source + sibling(s) jointly form the
+        // visible representation. Reset to false when the drag collapses back
+        // to single-day so the chip resumes being the sole source visual.
+        sourceHost.setPaintSourceClipInGrid(anySiblingPushed)
 
         // 6) Clear hosts that previously received a preview but are no longer
         //    in the fan-out (the finger left a column, or the live range
@@ -5131,21 +5270,38 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         //    column the live range LEAVES clear (rather than freezing on its
         //    last clip — explicit user requirement).
         let kept = Set(newHosts.map { ObjectIdentifier($0) })
+        var clearedTags: [String] = []
         for ref in lastPreviewHosts {
             guard let h = ref.host, !kept.contains(ObjectIdentifier(h)) else { continue }
+            clearedTags.append(DayLayerHostView.logDayTag(h.liveModel?.date))
             h.applyDragPreview(nil)
             h.setForeignDragSession(nil)
+            h.setPaintSourceClipInGrid(false)
+        }
+
+        // Fan-out summary log (rate-limited by host-set + cleared-set fingerprint).
+        let pushedTags = newHosts.map { DayLayerHostView.logDayTag($0.liveModel?.date) }
+        let fp = "kept=[\(pushedTags.joined(separator: ","))] cleared=[\(clearedTags.joined(separator: ","))]"
+        if fp != lastFanoutFingerprint {
+            let f = DateFormatter(); f.dateFormat = "MM-dd HH:mm"
+            NSLog("[#53A][fanout] src=\(DayLayerHostView.logDayTag(sourceDayStart)) mode=\(currentMode) liveRange=\(f.string(from: liveRange.start))->\(f.string(from: liveRange.end)) \(fp)")
+            lastFanoutFingerprint = fp
         }
         lastPreviewHosts = newHosts.map { WeakHostRef(host: $0) }
     }
 
     private func clearInGridPreview() {
+        if !lastPreviewHosts.isEmpty {
+            NSLog("[#53A][fanout] clear ALL (drag end / not eligible)")
+        }
         for ref in lastPreviewHosts {
             guard let h = ref.host else { continue }
             h.applyDragPreview(nil)
             h.setForeignDragSession(nil)
+            h.setPaintSourceClipInGrid(false)
         }
         lastPreviewHosts.removeAll()
+        lastFanoutFingerprint = nil
     }
 
     // MARK: Absorption drop-targeting (G-57..G-62)
@@ -5432,6 +5588,8 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         dragChip = nil
         isChipActive = false
         lastSnappedColumnCenterX = nil
+        lastChipSnapFingerprint = nil
+        lastChipSnapSize = nil
         clearInGridPreview()
     }
 

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -4855,10 +4855,15 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         dragState.dayColumnStep = dragPreviewDayStep
         dragState.isHorizontalEdgeDragging = false
         dragState.isHorizontalAutoScrolling = false
-        // NOTE: dragState.dragOffset is deliberately NOT written per frame —
-        // the CALayer view renders the preview from `liveResolvedOffset`
-        // (plain UIKit state). Mirroring the per-frame offset into @Observable
-        // is the exact perf hazard the contract forbids (spec 05 section 7).
+        // dragState.dragOffset is initialized here; `applyDragOffset` mirrors
+        // the per-frame resolved value going forward so SwiftUI consumers
+        // (axis time-label pills, boundary extension) can track the live
+        // drag. Spec 05 §7's perf hazard is COARSE publishing
+        // (@Published / ObservableObject); EventDragState is @Observable so
+        // per-frame writes invalidate only views that read this property at
+        // body scope — same shape as the SwiftUI EventBlock path
+        // (EventBlock.swift:1712). (#53 sub-bug B)
+        dragState.dragOffset = .zero
     }
 
     // MARK: Drag offset math (G-16..G-22) — reuses the shared free funcs
@@ -4926,6 +4931,20 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
 
         guard resolved != liveResolvedOffset else { return }
         liveResolvedOffset = resolved
+        // #53 sub-bug B: mirror the resolved offset onto `dragState.dragOffset`
+        // (@Observable). SwiftUI consumers — the axis time-label pills
+        // (TimelineView's `editMappingPresentation` →
+        // `resolvedDragEditMapping`) and boundary-extension math — read this
+        // every frame to track the live drag time. Without the mirror they
+        // froze at zero (the original CALayer rewrite assumed the per-frame
+        // CALayer-internal `liveResolvedOffset` was enough; it isn't for
+        // SwiftUI siblings). The earlier comment cited spec 05 §7 as a perf
+        // hazard, but §7 actually forbids COARSE publishing (Combine
+        // @Published / ObservableObject); EventDragState is @Observable, so
+        // per-frame writes invalidate ONLY views that read `dragOffset` at
+        // body scope — same cost shape as the SwiftUI EventBlock path already
+        // pays. Mirrors EventBlock.swift:1712 in shape.
+        callbacks.dragState?.dragOffset = resolved
         updateAbsorptionDropTarget()
         host?.renderLiveDragFrame()
     }
@@ -5311,10 +5330,21 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         //    paints the cross-midnight half at the live position.
         var anySiblingPushed = false
         for sibling in allDayHosts() {
-            // Skip the gesture-owning host (local session covers it) and
-            // the source host (already pushed above with the right ordering:
-            // foreign session before applyDragPreview).
-            if sibling === host { continue }
+            // Skip the source host (already pushed above with the right
+            // ordering: foreign session before applyDragPreview).
+            //
+            // The gesture-owning `host` is NOT skipped here — when the
+            // finger has moved AWAY from its original column (the source
+            // is now elsewhere), the original column becomes a sibling
+            // whose half of the live range still needs an in-grid
+            // projection. Its local `activeEventSession` covers
+            // `chipHidesSource` (static block stays hidden) and the paint
+            // gate, but only IF `dragPreviewOccurrence` is non-nil — and
+            // that requires applyDragPreview pushed here. (#53 sub-bug A
+            // follow-on: "forward cross-day, previous-day part doesn't
+            // render".) We do skip the FOREIGN-session push for the
+            // gesture-owning host though, to keep one session source of
+            // truth per host.
             if sibling === sourceHost { continue }
             guard let siblingDate = sibling.liveModel?.date else { continue }
             let siblingDayStart = cal.startOfDay(for: siblingDate)
@@ -5326,7 +5356,14 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
             // either it has the same-id static twin that needs to hide, or
             // the live range now touches its day window (or both).
             guard hasSameIDStatic || preview != nil else { continue }
-            sibling.setForeignDragSession(foreignSession)
+            // The gesture-owning `host` already has the LOCAL
+            // activeEventSession — pushing the foreign session on top would
+            // duplicate the drag-identity signal. Skip the foreign push for
+            // it, but still apply the preview clip below so its synth
+            // preview is non-nil and its paint gate fires.
+            if sibling !== host {
+                sibling.setForeignDragSession(foreignSession)
+            }
             // Preview is OPTIONAL on the sibling. Hosts whose live range
             // newly LEAVES (cross-midnight collapsed to single-day) still
             // need the static block hidden — push nil to clear any prior

--- a/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
@@ -54,6 +54,18 @@ struct TimelineAxisMarkerPresentation: Equatable {
     let collapsedText: String?
     let isCollapsed: Bool
     var color: Color?
+    /// #53 sub-bug B follow-on: wrap-around marker Y positions for a
+    /// cross-midnight event. When the live range extends past the anchor
+    /// day's bounds (forward into next day OR backward into previous
+    /// day), this carries the second pair of Y positions computed under
+    /// the adjacent day's anchor. Both pairs render on the SAME shared
+    /// time axis (axis is one column on the left, but its Y space wraps
+    /// per day-column visually) so the user sees consistent start/end
+    /// pills whether scrolled to the source-half (column bottom) or the
+    /// sibling-half (column top). `nil` when the event fits inside the
+    /// anchor day.
+    let wrappedStartY: CGFloat?
+    let wrappedEndY: CGFloat?
 }
 
 struct TimelineBoundaryExtensionState: Equatable {
@@ -582,13 +594,58 @@ func calendarResolveAxisMarkerPresentation(
         threshold: collapseThreshold
     )
 
+    // Wrap-around markers (#53 B follow-on). When the live range extends
+    // past the anchor day in either direction, also compute the marker Y
+    // positions anchored to the ADJACENT day so the column-top / column-
+    // bottom view of the other half also shows a consistent pair of
+    // start/end pills.
+    let anchorDayStart = calendar.startOfDay(for: mappingState.anchorDate)
+    let anchorDayEnd = calendar.date(byAdding: .day, value: 1, to: anchorDayStart) ?? anchorDayStart
+    let extendsForward = mappingState.range.end > anchorDayEnd
+    let extendsBackward = mappingState.range.start < anchorDayStart
+    let wrapAnchor: Date?
+    if extendsForward {
+        wrapAnchor = calendar.date(byAdding: .day, value: 1, to: mappingState.anchorDate)
+    } else if extendsBackward {
+        wrapAnchor = calendar.date(byAdding: .day, value: -1, to: mappingState.anchorDate)
+    } else {
+        wrapAnchor = nil
+    }
+    let wrappedStartY: CGFloat?
+    let wrappedEndY: CGFloat?
+    if let wrapAnchor {
+        wrappedStartY = calendarTimelineYPosition(
+            for: mappingState.range.start,
+            containing: wrapAnchor,
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            leadingExtendedHours: leadingExtendedHours,
+            trailingExtendedHours: trailingExtendedHours,
+            calendar: calendar
+        )
+        wrappedEndY = calendarTimelineYPosition(
+            for: mappingState.range.end,
+            containing: wrapAnchor,
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            leadingExtendedHours: leadingExtendedHours,
+            trailingExtendedHours: trailingExtendedHours,
+            calendar: calendar
+        )
+    } else {
+        wrappedStartY = nil
+        wrappedEndY = nil
+    }
+
     return TimelineAxisMarkerPresentation(
         startY: startY,
         endY: endY,
         startText: startText,
         endText: endText,
         collapsedText: isCollapsed ? "\(startText) - \(endText)" : nil,
-        isCollapsed: isCollapsed
+        isCollapsed: isCollapsed,
+        wrappedStartY: wrappedStartY,
+        wrappedEndY: wrappedEndY
     )
 }
 

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2671,6 +2671,18 @@ private struct TimeAxisLabels: View {
             axisMarkerRow(text: presentation.endText, y: presentation.endY, color: presentation.color)
                 .zIndex(2)
         }
+        // Wrap-around pair for a cross-midnight live range (#53 B follow-on).
+        // Draws the SAME start/end texts at the OTHER day's column-anchored Y
+        // positions, so the user gets a consistent pill pair whether scrolled
+        // to the source-half view (column bottom) or the sibling-half view
+        // (column top). Single-day events have nil wrapped fields → no-op.
+        if let wrappedStartY = presentation.wrappedStartY,
+           let wrappedEndY = presentation.wrappedEndY {
+            axisMarkerRow(text: presentation.startText, y: wrappedStartY, color: presentation.color)
+                .zIndex(2)
+            axisMarkerRow(text: presentation.endText, y: wrappedEndY, color: presentation.color)
+                .zIndex(2)
+        }
     }
 
     private func axisMarkerRow(text: String, y: CGFloat, color: Color? = nil) -> some View {

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -241,7 +241,12 @@ func calendarIsMoveDragActive(
 }
 
 // Extracted for regression tests: boundary-extension reflow should not animate
-// while a move-drag is actively crossing day boundaries.
+// while a move-drag is actively crossing day boundaries. SwiftUI's
+// `ScrollPosition.scrollTo` ignores ambient `withAnimation` (iOS 26: it always
+// snaps), so animating `leading` while scroll snaps produces visible content
+// drift during the spring. Keep both INSTANT during drag — they snap together
+// in lockstep, visible content stays glued. Outside drag, the spring is fine
+// because no scroll compensation runs concurrently.
 func calendarShouldAnimateTimelineBoundaryExtension(
     isMoveDragActive: Bool,
     isCreationDragActive: Bool,
@@ -1261,17 +1266,24 @@ struct TimelinePagerView: View {
     private var rawBoundaryExtensionHours: (leading: Int, trailing: Int) {
         var result = calendarTimelineBoundaryExtensionHours(mappingState: boundaryExtensionMappingState)
 
-        // Cross-day event fix: when the scroll is already near the top
+        // Cross-day event fix: when the scroll has hit the top boundary
         // (can't go further up) and the user is actively dragging upward,
         // proactively open the leading extension even though the event
         // range hasn't technically crossed midnight. Without this, events
         // starting late at night (e.g. 23:00) can never reach midnight by
         // finger drag alone (23h × hourHeight is physically unreachable)
         // and the vertical autoscroll is stuck at y=0 with nowhere to go.
+        //
+        // Trigger gate tightened: previously `< hourHeight * 2` (within 2
+        // hours of top) — too generous, the extension fired even when the
+        // user was still mid-column. Now only when scroll is at the top
+        // boundary (`< 1pt`), so the extension only opens when the user
+        // is literally at the edge and out of room to scroll. (#53
+        // single-day follow-on)
         if let state = boundaryExtensionMappingState,
            state.source == .moveDrag || state.source == .resizeTop,
            result.leading == 0,
-           verticalScrollY < hourHeight * 2,
+           verticalScrollY < 1,
            dragState.dragOffset.y < -hourHeight {
             result.leading = calendarTimelineMaximumBoundaryExtensionHours
         }


### PR DESCRIPTION
## Summary

Closes #53 sub-bugs A + B, plus a single-day regression that surfaced during the refactor.

- **Sub-bug A (cross-midnight sibling)**: each day-host that the live drag range touches now paints its synth-preview projection in lockstep. Uniform N-column logic (single-day, cross-midnight, multi-day all run the same gate).
- **Sub-bug B (axis time-label pills)**: gesture controller now mirrors `dragState.dragOffset` per frame so SwiftUI axis pills track the live drag time; the pills also wrap to the other half's column view on cross-midnight.
- **Chip-less refactor**: dropped the floating drag chip in favor of in-grid projections everywhere; chip lazy-spawns only during edge auto-scroll (where snap flicker would be intrusive). Cross-column drag, autoscroll, and event-color preservation all flow through the same uniform paint gate.
- **Single-day extended-view regression**: drag-end dismiss of the boundary extension was bouncing the canvas. Routed through `applyTimelineBoundaryExtensionState(.none)` with symmetric scroll compensation + `disablesAnimations` transaction so leading + scroll snap together. Proactive trigger threshold tightened to `verticalScrollY < 1`.

The animated open transition (smooth-spring-expand instead of snap) is parked on #55 because SwiftUI `ScrollPosition.scrollTo` ignores ambient `withAnimation` on iOS 26.

## Commits

| SHA | Title |
| --- | --- |
| a3aac78 | fix(calendar): cross-midnight sibling tracks live move + resize (#53 A) |
| 3fc175c | refactor(calendar): chip-less in-grid drag — uniform N-column projection (#53 A) |
| 0009d01 | fix(calendar): autoscroll chip + dragged-projection keeps full color (#53 A) |
| db1fcd0 | fix(calendar): axis pills track + previous-day half renders on cross-day (#53 B + A follow-on) |
| bcd02b9 | fix(calendar): cross-midnight in-block time text shows full event range (#53 A follow-on) |
| ea04f65 | chore(calendar): strip #53A NSLog instrumentation |
| 5cc7b0c | feat(calendar): cross-midnight axis pills wrap to the other half's column view (#53 B follow-on) |
| 1495c45 | fix(calendar): drag-end extension dismiss compensates scroll + skips animation (#53 single-day regression) |
| c43ff41 | fix(calendar): proactive boundary-extension trigger fires only at scroll top (#53 follow-on) |

## Test plan

- [ ] Move-drag a single-day event across columns (3-day / week view) — block visibly moves with finger across columns; lands on the column under finger
- [ ] Move-drag a cross-midnight event (e.g., 22:30→07:00) vertically within source day — both halves track in lockstep
- [ ] Move-drag a single-day event so it becomes cross-midnight — sibling column lights up with its half painted
- [ ] Move-drag pre-existing cross-midnight forward into new column (e.g., Mon-Tue → Wed-Thu) — both new columns paint clips, original columns clear
- [ ] Edge-autoscroll while dragging — autoscroll chip spawns smoothly, despawns when releasing edge; in-grid resumes
- [ ] Axis time pills (left-side green) track the live drag time; on cross-midnight also show a second pair on the other half's column view
- [ ] In-block time text shows the unified event range on both halves of a cross-midnight drag (e.g., both halves say "23:30 - 02:30")
- [ ] Single-day drag that triggers the proactive extension (drag up at scroll top) — no canvas bounce on release
- [ ] Resize cross-midnight events — both halves grow/shrink in lockstep

## Related

- Closes #53 (A + B)
- Tracks #55 (animated open transition for extended view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)