### PR TITLE
Calendar #55: cross-midnight follow-event + same-day extension abandon

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		8DC4025C6FA74F94A38D43BA /* Calendar/CalendarEventFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811A80895C7432E8B33CC9A /* Calendar/CalendarEventFormView.swift */; };
 		A1B2C3D82F50000000000001 /* CalendarDragLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */; };
 		AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */; };
+		BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */; };
 		AABB20012F60000000000001 /* Agent/ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10012F60000000000001 /* Agent/ChatMessage.swift */; };
 		AABB20022F60000000000002 /* Agent/LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10022F60000000000002 /* Agent/LLMProvider.swift */; };
 		AABB20032F60000000000003 /* Agent/AgentTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10032F60000000000003 /* Agent/AgentTools.swift */; };
@@ -192,6 +193,7 @@
 		A1B2C3D52F50000000000001 /* DoneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DoneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDragLogicTests.swift; sourceTree = "<group>"; };
 		AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/CalendarPageState.swift; sourceTree = "<group>"; };
+		BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/BoundaryExtensionScrollAnimator.swift; sourceTree = "<group>"; };
 		AABB10012F60000000000001 /* Agent/ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/ChatMessage.swift; sourceTree = "<group>"; };
 		AABB10022F60000000000002 /* Agent/LLMProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/LLMProvider.swift; sourceTree = "<group>"; };
 		AABB10032F60000000000003 /* Agent/AgentTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/AgentTools.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 				EEEEFA1C2F16A101000397C6 /* Todo/AddToCalendarView.swift */,
 				EEEEFA1E2F16B200000397C6 /* Calendar/CalendarPageView.swift */,
 				AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */,
+				BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */,
 				EEEEFA8F2F200000000397C6 /* Calendar/CalendarViewState.swift */,
 				EEEEFA912F200000000397C6 /* Calendar/CalendarFocusState.swift */,
 				EEEEFA1F2F16B200000397C6 /* Calendar/CalendarLayout.swift */,
@@ -732,6 +735,7 @@
 				EEEEFA1D2F16A101000397C6 /* Todo/AddToCalendarView.swift in Sources */,
 				EEEEFA242F16B200000397C6 /* Calendar/CalendarPageView.swift in Sources */,
 				AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */,
+				BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */,
 				EEEEFA902F200000000397C6 /* Calendar/CalendarViewState.swift in Sources */,
 				EEEEFA922F200000000397C6 /* Calendar/CalendarFocusState.swift in Sources */,
 				EEEEFA252F16B200000397C6 /* Calendar/CalendarLayout.swift in Sources */,

--- a/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
+++ b/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
@@ -19,7 +19,6 @@ final class BoundaryExtensionScrollAnimator: NSObject {
     private let onTick: (CGFloat) -> Void
     private let onComplete: () -> Void
     private var completed = false
-    private var tickCount = 0
 
     init(
         duration: CFTimeInterval = 0.28,
@@ -39,17 +38,13 @@ final class BoundaryExtensionScrollAnimator: NSObject {
     func cancel(reason: String = "external") {
         guard !completed else { return }
         completed = true
-        NSLog("[#55ext] animator CANCEL tick=%d elapsed=%.3f reason=%@",
-              tickCount, CACurrentMediaTime() - startTime, reason)
         displayLink?.invalidate()
         displayLink = nil
     }
 
     @objc private func handleTick() {
         let elapsed = CACurrentMediaTime() - startTime
-        tickCount += 1
         if elapsed >= duration {
-            NSLog("[#55ext] animator tick=%d FINAL elapsed=%.3f progress=1.0", tickCount, elapsed)
             onTick(1.0)
             displayLink?.invalidate()
             displayLink = nil
@@ -59,10 +54,6 @@ final class BoundaryExtensionScrollAnimator: NSObject {
         }
         let t = elapsed / duration
         let progress = CGFloat(Self.springEase(t))
-        if tickCount % 3 == 1 {
-            NSLog("[#55ext] animator tick=%d elapsed=%.3f t=%.2f progress=%.3f",
-                  tickCount, elapsed, t, progress)
-        }
         onTick(progress)
     }
 

--- a/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
+++ b/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
@@ -80,3 +80,64 @@ final class BoundaryExtensionScrollAnimator: NSObject {
         return 1 - envelope * (1 + omega * t)
     }
 }
+
+/// Single-overshoot "rebounce" animator (#55 follow-event-across-midnight).
+/// Emits a unitless amplitude value in [0, 1] that peaks early and decays
+/// back to 0, suitable for adding a temporary scroll-offset overshoot on
+/// top of an already-snapped target so the user feels an elastic settle
+/// after the cross-day re-anchor.
+@MainActor
+final class CalendarRebounceAnimator: NSObject {
+    private var displayLink: CADisplayLink?
+    private let startTime: CFTimeInterval
+    private let duration: CFTimeInterval
+    private let onTick: (CGFloat) -> Void
+    private let onComplete: () -> Void
+    private var completed = false
+
+    init(
+        duration: CFTimeInterval = 0.42,
+        onTick: @escaping (CGFloat) -> Void,
+        onComplete: @escaping () -> Void
+    ) {
+        self.startTime = CACurrentMediaTime()
+        self.duration = duration
+        self.onTick = onTick
+        self.onComplete = onComplete
+        super.init()
+        let link = CADisplayLink(target: self, selector: #selector(handleTick))
+        link.add(to: .main, forMode: .common)
+        self.displayLink = link
+    }
+
+    func cancel() {
+        guard !completed else { return }
+        completed = true
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    @objc private func handleTick() {
+        let elapsed = CACurrentMediaTime() - startTime
+        if elapsed >= duration {
+            onTick(0)
+            displayLink?.invalidate()
+            displayLink = nil
+            completed = true
+            onComplete()
+            return
+        }
+        let t = elapsed / duration
+        // Damped spring "release-from-stretch" response: starts at 1
+        // (fully stretched), decays toward 0 with a single visible
+        // overshoot past zero (perceived as a brief settle past the
+        // target before snapping back). Softer ω + slightly more ζ
+        // gives a gentler, more flowing settle (was ω=11, ζ=0.55).
+        let omega = 7.5
+        let zeta = 0.62
+        let envelope = exp(-zeta * omega * t)
+        let omegaD = omega * (1 - zeta * zeta).squareRoot()
+        let stepResponse = 1 - envelope * (cos(omegaD * t) + (zeta * omega / omegaD) * sin(omegaD * t))
+        onTick(CGFloat(1 - stepResponse))
+    }
+}

--- a/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
+++ b/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
@@ -128,13 +128,14 @@ final class CalendarRebounceAnimator: NSObject {
             return
         }
         let t = elapsed / duration
-        // Damped spring "release-from-stretch" response: starts at 1
-        // (fully stretched), decays toward 0 with a single visible
-        // overshoot past zero (perceived as a brief settle past the
-        // target before snapping back). Softer ω + slightly more ζ
-        // gives a gentler, more flowing settle (was ω=11, ζ=0.55).
-        let omega = 7.5
-        let zeta = 0.62
+        // Damped spring "release-from-stretch" response: starts at 1 (fully
+        // stretched), decays toward 0 with a SINGLE, restrained settle past the
+        // target. Higher ζ trades the old ~8% bounce for a ~1.5% overshoot — a
+        // refined "ease into place" rather than a spring-back — and a softer ω
+        // makes the deceleration more graceful. (#55: silkier rebounce; was
+        // ω=7.5 ζ=0.62, originally ω=11 ζ=0.55.)
+        let omega = 7.0
+        let zeta = 0.78
         let envelope = exp(-zeta * omega * t)
         let omegaD = omega * (1 - zeta * zeta).squareRoot()
         let stepResponse = 1 - envelope * (cos(omegaD * t) + (zeta * omega / omegaD) * sin(omegaD * t))

--- a/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
+++ b/Done/Views/Calendar/BoundaryExtensionScrollAnimator.swift
@@ -1,0 +1,82 @@
+import Foundation
+import QuartzCore
+
+/// Drives a CADisplayLink-paced spring interpolation over a fixed duration.
+/// Used for the proactive boundary-extension OPEN transition during drag:
+/// SwiftUI's `ScrollPosition.scrollTo(point:)` snaps in one frame on iOS 26
+/// regardless of ambient `withAnimation`, so we feed it 60 interpolated
+/// targets/sec from this animator while the `.animation(_:value:)` modifier
+/// on `leading` springs over the same duration. Both run on the same time
+/// axis → events stay glued to their visible window position as the canvas
+/// unfolds. (#55)
+@MainActor
+final class BoundaryExtensionScrollAnimator: NSObject {
+    private var displayLink: CADisplayLink?
+    private let startTime: CFTimeInterval
+    private let duration: CFTimeInterval
+    /// Receives spring-eased progress in [0, 1]. Caller computes scroll/offset
+    /// from progress so both writes stay on the same time axis.
+    private let onTick: (CGFloat) -> Void
+    private let onComplete: () -> Void
+    private var completed = false
+    private var tickCount = 0
+
+    init(
+        duration: CFTimeInterval = 0.28,
+        onTick: @escaping (CGFloat) -> Void,
+        onComplete: @escaping () -> Void
+    ) {
+        self.startTime = CACurrentMediaTime()
+        self.duration = duration
+        self.onTick = onTick
+        self.onComplete = onComplete
+        super.init()
+        let link = CADisplayLink(target: self, selector: #selector(handleTick))
+        link.add(to: .main, forMode: .common)
+        self.displayLink = link
+    }
+
+    func cancel(reason: String = "external") {
+        guard !completed else { return }
+        completed = true
+        NSLog("[#55ext] animator CANCEL tick=%d elapsed=%.3f reason=%@",
+              tickCount, CACurrentMediaTime() - startTime, reason)
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+
+    @objc private func handleTick() {
+        let elapsed = CACurrentMediaTime() - startTime
+        tickCount += 1
+        if elapsed >= duration {
+            NSLog("[#55ext] animator tick=%d FINAL elapsed=%.3f progress=1.0", tickCount, elapsed)
+            onTick(1.0)
+            displayLink?.invalidate()
+            displayLink = nil
+            completed = true
+            onComplete()
+            return
+        }
+        let t = elapsed / duration
+        let progress = CGFloat(Self.springEase(t))
+        if tickCount % 3 == 1 {
+            NSLog("[#55ext] animator tick=%d elapsed=%.3f t=%.2f progress=%.3f",
+                  tickCount, elapsed, t, progress)
+        }
+        onTick(progress)
+    }
+
+    /// Closed-form damped-spring approximation matching the visual feel of
+    /// `.interactiveSpring(response: 0.28, dampingFraction: 0.88, blendDuration: 0.12)`.
+    /// Slight under-damping (ζ=0.88) for a barely-perceptible settle, no overshoot.
+    private static func springEase(_ t: Double) -> Double {
+        let omega = 8.0
+        let zeta = 0.88
+        let envelope = exp(-zeta * omega * t)
+        if zeta < 1 {
+            let omegaD = omega * (1 - zeta * zeta).squareRoot()
+            return 1 - envelope * (cos(omegaD * t) + (zeta * omega / omegaD) * sin(omegaD * t))
+        }
+        return 1 - envelope * (1 + omega * t)
+    }
+}

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1134,6 +1134,12 @@ struct CalendarPageView: View {
     /// they never overlap because follow only fires on commit (drag is
     /// already done). (#55 follow-event-across-midnight)
     @State private var crossDayRebounceAnimator: CalendarRebounceAnimator? = nil
+    /// Drives the same-day abandon settle (extension used but NOT crossed):
+    /// elastically scrolls the extension band off-screen, then collapses it —
+    /// reuses the cross-midnight rebounce curve so the feel matches. Distinct
+    /// slot from `crossDayRebounceAnimator` (the two never run together, but a
+    /// shared slot would muddle cancellation semantics). (#55 same-day rebounce)
+    @State private var sameDayRebounceAnimator: CalendarRebounceAnimator? = nil
     /// Timestamp of the last follow-event-across-midnight re-anchor. Used by
     /// `handleTimelineBoundaryExtensionStateChange` to suppress the 150ms
     /// delayed dismiss path on small-viewport days — that path would
@@ -2829,36 +2835,98 @@ private extension CalendarPageView {
             let baseContentHeight = CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
             let scrollableRange = baseContentHeight - timelineScrollViewportHeight
             if scrollableRange < hourHeight * 2 {
-                // Abandon-release on a small viewport (band can't be scrolled
-                // away): FADE the band out first (visible dissolve — this is
-                // the only abandon path the user actually hits, since the
-                // gesture is "open → release" with no scroll), THEN collapse.
-                // The fade runs while not scrolling, so VerticalScrollGate
-                // isn't frozen and the mask re-renders. (#55 follow-on)
-                withAnimation(.easeIn(duration: 0.3)) {
-                    timelineLeadingFadeProgress = 1
-                    timelineTrailingFadeProgress = 1
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [self] in
-                    guard timelineRawBoundaryExtensionState.source == nil else {
-                        // Re-engaged before the fade finished — restore solid.
-                        withAnimation(.easeOut(duration: 0.2)) {
+                let leading = timelineBoundaryExtensionState.leadingHours
+                let trailing = timelineBoundaryExtensionState.trailingHours
+                let singleSide = (leading > 0) != (trailing > 0)
+                if singleSide {
+                    // Abandon-release, ONE side open: "弹性收回基准日" — settle
+                    // back to the base day with the same elastic rebounce as the
+                    // cross-midnight follow. We REBOUNCE-SCROLL the extension band
+                    // off the viewport edge (0:00→top for leading, 24:00→bottom
+                    // for trailing) — content stays a fixed size during the scroll
+                    // (band is still present), so there's no contentH/scroll
+                    // co-commit jump — then collapse it once it's off-screen.
+                    // (#55 same-day rebounce)
+                    sameDayRebounceAnimator?.cancel()
+                    let preStart = timelineVerticalScrollY
+                    let fadeLeading = leading > 0
+                    let settlePost: CGFloat = fadeLeading
+                        ? CGFloat(leading) * hourHeight
+                        : max(0, baseContentHeight - timelineScrollViewportHeight)
+                    sameDayRebounceAnimator = CalendarRebounceAnimator(
+                        duration: 1.1,
+                        onTick: { [self] value in
+                            guard timelineRawBoundaryExtensionState.source == nil else {
+                                // Re-engaged mid-settle → abort, restore solid.
+                                sameDayRebounceAnimator?.cancel()
+                                sameDayRebounceAnimator = nil
+                                var tx = Transaction(); tx.disablesAnimations = true
+                                withTransaction(tx) {
+                                    timelineLeadingFadeProgress = 0
+                                    timelineTrailingFadeProgress = 0
+                                }
+                                return
+                            }
+                            // Inverted "release-from-stretch": progress 0→1 with a
+                            // single overshoot past 1. Scroll preStart→settlePost;
+                            // the band fades FRONT-LOADED so it dissolves while
+                            // still on-screen instead of snapping off the edge.
+                            let progress = 1 - value
+                            let frac = min(1, max(0, progress))
+                            let inv = 1 - frac
+                            let fade = 1 - inv * inv
+                            let y = max(0, preStart + (settlePost - preStart) * progress)
+                            var tx = Transaction(); tx.disablesAnimations = true
+                            withTransaction(tx) {
+                                verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: y))
+                                if fadeLeading {
+                                    timelineLeadingFadeProgress = max(timelineLeadingFadeProgress, fade)
+                                } else {
+                                    timelineTrailingFadeProgress = max(timelineTrailingFadeProgress, fade)
+                                }
+                            }
+                        },
+                        onComplete: { [self] in
+                            // Band is faded + off-screen → collapse removes nothing
+                            // visible; applyState comps the scroll for the side.
+                            var tx = Transaction(); tx.disablesAnimations = true
+                            applyTimelineBoundaryExtensionState(.none)
+                            withTransaction(tx) {
+                                timelineLeadingFadeProgress = 0
+                                timelineTrailingFadeProgress = 0
+                            }
+                            sameDayRebounceAnimator = nil
+                        }
+                    )
+                } else {
+                    // Both sides open (or none): can't settle both edges off at
+                    // once — keep the fade-out-then-instant-collapse. FADE the
+                    // band out first (visible dissolve), THEN collapse. The fade
+                    // runs while not scrolling, so VerticalScrollGate isn't frozen
+                    // and the mask re-renders. (#55 follow-on)
+                    withAnimation(.easeIn(duration: 0.3)) {
+                        timelineLeadingFadeProgress = 1
+                        timelineTrailingFadeProgress = 1
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [self] in
+                        guard timelineRawBoundaryExtensionState.source == nil else {
+                            // Re-engaged before the fade finished — restore solid.
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                timelineLeadingFadeProgress = 0
+                                timelineTrailingFadeProgress = 0
+                            }
+                            return
+                        }
+                        // Collapse animation-free in lockstep with the scroll snap.
+                        // Band is already invisible from the fade, so the collapse
+                        // removes nothing visible. (#53 single-day follow-on)
+                        var transaction = Transaction()
+                        transaction.disablesAnimations = true
+                        withTransaction(transaction) {
+                            applyTimelineBoundaryExtensionState(.none)
                             timelineLeadingFadeProgress = 0
                             timelineTrailingFadeProgress = 0
                         }
-                        return
-                    }
-                    // Collapse animation-free in lockstep with the scroll snap
-                    // (the `leading` change would otherwise spring out-of-sync
-                    // with the instant scroll comp). Band is already invisible
-                    // from the fade, so the collapse removes nothing visible.
-                    // (#53 single-day follow-on)
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        applyTimelineBoundaryExtensionState(.none)
-                        timelineLeadingFadeProgress = 0
-                        timelineTrailingFadeProgress = 0
                     }
                 }
             }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1145,6 +1145,12 @@ struct CalendarPageView: View {
     /// flash the header back to the original day. Cleared at follow-event
     /// completion. (#55 follow-event header continuity)
     @State private var pendingFollowEventDayOverride: Int? = nil
+    /// 0 = extension bands fully visible, 1 = fully transparent. Driven by
+    /// the follow-event rebounce post-swap: the previous day's remnant
+    /// (the mirrored extension band) fades out in lockstep with being
+    /// pushed out of the viewport, so the final silent collapse removes
+    /// content that's already invisible. (#55 follow-on)
+    @State private var timelineExtensionFadeProgress: CGFloat = 0
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -3034,6 +3040,7 @@ private extension CalendarPageView {
             liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
             boundaryExtensionVisualYOffset: boundaryExtensionVisualYOffset,
             suppressDayColumnHorizontalAnimation: suppressDayColumnHorizontalAnimation,
+            extensionFadeProgress: timelineExtensionFadeProgress,
             isDayOffsetFrozen: calendarState.isDayOffsetFrozen,
             daysCount: timelineDaysCount(for: calendarState.rangeMode),
             mode: .preview,
@@ -4025,31 +4032,42 @@ private extension CalendarPageView {
         // `selectedDayOffset` until the animator clears it.
         pendingFollowEventDayOverride = newHostDayOffset
         let hourHeight = calendarState.timelineHourHeight
-        let extensionMaxHours = calendarTimelineMaximumBoundaryExtensionHours
+        // FULL-DAY mirror (24h, not the 12h drag-extension max): the post-swap
+        // canvas must contain *everything* the pre-swap canvas showed, or the
+        // swap visibly discards content. With a 12h mirror the shared window
+        // is only 24h tall — at small hourHeight the viewport is TALLER than
+        // that, so up to 12h of the old day vanished in one frame (the
+        // "previous day's slot disappears instantly" bug). With a 24h mirror
+        // the pre canvas (36h) is a strict subset of the post canvas (48h):
+        // nothing is discarded at any zoom. The destination day scrolls in
+        // solid; only the old day (the mirrored band) fades out.
+        let mirroredHours = calendarTimelineBaseVisibleHours
         let mirroredExtension: TimelineBoundaryExtensionState
         let scrollDelta: CGFloat
         if dayDelta < 0 {
-            // Forward-time was today + leading 12h (yesterday's late hours
-            // visible above today). After the jump, anchor=yesterday and the
-            // visible window's lower 12h is today's first 12h → trailing=12.
+            // Was on today + leading 12h (yesterday's late hours above).
+            // After the jump, anchor=yesterday and ALL of today mirrors to
+            // trailing=24. Canvas start moves from (today − leading) to
+            // yesterday 00:00 → same instant sits `leading*hh` lower.
             mirroredExtension = TimelineBoundaryExtensionState(
                 leadingHours: 0,
-                trailingHours: extensionMaxHours,
+                trailingHours: mirroredHours,
                 source: nil,
                 anchorDayOffset: newHostDayOffset
             )
-            scrollDelta = CGFloat(extensionMaxHours) * hourHeight
+            scrollDelta = CGFloat(timelineBoundaryExtensionState.leadingHours) * hourHeight
         } else {
-            // Mirror of the above: was on today + trailing 12h (tomorrow's
-            // first hours visible below today); after jumping to tomorrow,
-            // today's last 12h becomes leading=12 of tomorrow's view.
+            // Was on today + trailing 12h (tomorrow's first hours below);
+            // after jumping to tomorrow, ALL of today mirrors to leading=24.
+            // Canvas start is today 00:00 in BOTH coordinate systems →
+            // the swap is a pure rename, zero scroll delta.
             mirroredExtension = TimelineBoundaryExtensionState(
-                leadingHours: extensionMaxHours,
+                leadingHours: mirroredHours,
                 trailingHours: 0,
                 source: nil,
                 anchorDayOffset: newHostDayOffset
             )
-            scrollDelta = -CGFloat(extensionMaxHours) * hourHeight
+            scrollDelta = 0
         }
         let targetScrollY = max(0, timelineVerticalScrollY + scrollDelta)
         calendarDebugLog(
@@ -4063,104 +4081,75 @@ private extension CalendarPageView {
                 "scrollTarget": String(format: "%.2f", targetScrollY)
             ]
         )
-        // Atomic re-anchor at t=0: day-column horizontal snap, extension
-        // state mirror, and scroll all land in one render pass. CRITICALLY:
-        // the post-swap state at scrollY=targetScrollY is *mathematically
-        // identical* to the pre-swap state at scrollY=currentScrollY (same
-        // canvas content visible, same event viewport position). The user
-        // sees no change at this moment — the swap is a coordinate-system
-        // rename, not a content shift.
+        // IMMEDIATE atomic re-anchor + single-spring settle (full-day-mirror
+        // revision). Because the post-swap canvas (48h) strictly contains the
+        // pre-swap canvas (36h), ANY pre-swap scrollY maps to a valid
+        // post-swap scrollY = preStart + scrollDelta showing identical
+        // content — so the swap fires on the first animator tick, with no
+        // pre-phase and no content discarded at any zoom level. Validity:
+        //   UP   (dayDelta<0): swapPost = K + 12h*hh ≤ postMaxScroll because
+        //        preMaxScroll + 12h*hh = postMaxScroll exactly.
+        //   DOWN (dayDelta>0): swapPost = K (pure rename) < postMaxScroll.
         //
-        // Then the rebounce animator continues the autoscroll's vertical
-        // momentum: scrollY slides from `targetScrollY` toward 0 (top of
-        // the new-day canvas, anchored to yesterday 00:00 or tomorrow
-        // 00:00 + 12h trailing). Visually this reads as "the autoscroll
-        // kept going past the day boundary and settled the view on the
-        // new day's natural top". The event's canvas y is fixed in the
-        // post-swap coordinates, so as the viewport scrolls up the event
-        // visually slides toward the bottom of the viewport — its
-        // natural position in the new day's late-evening / early-morning
-        // hours. (#55 follow-event-across-midnight)
+        // Then ONE spring continues the autoscroll's vertical momentum from
+        // swapPost to the settle position (new day's 00:00 just below the
+        // floating header). In lockstep with that scroll, the mirrored band
+        // (the ENTIRE old day) fades out front-loaded so it's nearly gone by
+        // the time it slides off the edge. The destination day stays solid
+        // and just scrolls in. At completion the band is invisible, so
+        // `applyTimelineBoundaryExtensionState(.none)` (which compensates
+        // scrollY for the leading-collapse case) closes silently.
         //
-        // At animator completion, scrollY ≈ 0 and the mirrored extension
-        // can collapse silently: contentH shrinks ~322pt but scrollY=0
-        // is within both the pre- and post-collapse scrollable ranges so
-        // ScrollView never clamps → no visible flash.
-        // Two-phase scroll animation to bridge the day-swap cleanly.
-        //
-        // The naive "atomic swap immediately" approach clamps `targetScrollY`
-        // to [0, maxScroll] whenever the user releases mid-autoscroll, which
-        // breaks the math-equivalence between pre- and post-swap canvas
-        // coordinates → visible content jump at the swap moment.
-        //
-        // Instead: continue the autoscroll's vertical motion in pre-swap
-        // coordinates until scrollY reaches a "swap-safe edge" where the
-        // mathematical translation to post-swap coordinates lands within
-        // [0, postMaxScroll]. Then atomically swap day + extension + scrollY
-        // (invisible because content is identical) and continue the same
-        // motion in post-swap coordinates to the settle position. Two
-        // sequential animators with proportional duration totaling 0.5s.
-        //
-        // Math:
-        // For dayDelta < 0 (autoscroll was UP, going to previous day):
-        //   pre = today + leading=12, scrollY=K
-        //   swap_pre = 0 (top of canvas — always within range)
-        //   swap_post = 0 + scrollDelta = 12h*hourHeight (math-equivalent)
-        //   settle_post = 0 (top of new day's canvas)
-        // For dayDelta > 0 (autoscroll DOWN, going to next day):
-        //   pre = yesterday + trailing=12, scrollY=K
-        //   swap_pre = 12h*hourHeight (≈ maxScroll, where math holds)
-        //   swap_post = swap_pre + scrollDelta = 0
-        //   settle_post = 12h*hourHeight (showing new day's start at viewport top)
-        //
-        // At phase 2 onComplete, route the extension close through
-        // `applyTimelineBoundaryExtensionState(.none)` which compensates
-        // scrollY for the leading-collapse case (no compensation needed
-        // for trailing-only collapse when scrollY=0). Either way: silent
-        // close. (#55 follow-event-across-midnight)
-        // Single-spring continuous animation across the day-swap boundary.
-        //
-        // A "virtual scroll distance" P is driven by ONE spring from 0 → total.
-        // At each tick we convert P to actual scrollY in either pre- or
-        // post-swap coordinates depending on which side of the boundary
-        // we're on. At P = preMotion, the boundary is crossed:
-        //   • Mathematically: swapPre (pre-coord) ↔ swapPost (post-coord)
-        //     show identical canvas content (the math-equivalent rename),
-        //     so the coordinate swap is invisible.
-        //   • Velocity continuity: dP/dt is continuous through the boundary,
-        //     and the conversion preserves screen-space velocity → no
-        //     "stop and restart" feel that two separate springs would have.
-        //
-        // For dayDelta < 0 (backward, autoscroll was UP):
-        //   preStart = K, swapPre = 0, swapPost = 12h*hh, settlePost = 0
-        // For dayDelta > 0 (forward, autoscroll was DOWN):
-        //   preStart = K, swapPre = 12h*hh, swapPost = 0, settlePost = 12h*hh
-        // (#55 follow-event-across-midnight, continuous-spring revision)
-        let extensionMaxPt = CGFloat(extensionMaxHours) * hourHeight
+        //   UP:   settlePost = 0           (old day = trailing 24h band)
+        //   DOWN: settlePost = 24h*hh      (old day = leading 24h band)
+        // (#55 follow-event-across-midnight)
         let preStart = timelineVerticalScrollY
-        let swapPre: CGFloat = dayDelta < 0 ? 0 : extensionMaxPt
-        let swapPost: CGFloat = swapPre + scrollDelta
-        let settlePost: CGFloat = dayDelta < 0 ? 0 : extensionMaxPt
-        let preMotion = abs(preStart - swapPre)
-        let postMotion = abs(settlePost - swapPost)
-        let totalMotion = preMotion + postMotion
-        NSLog("[#follow] continuous-spring plan: preStart=%.2f swapPre=%.2f swapPost=%.2f settlePost=%.2f preMotion=%.1f postMotion=%.1f totalMotion=%.1f",
-              preStart, swapPre, swapPost, settlePost, preMotion, postMotion, totalMotion)
+        let swapPost: CGFloat = preStart + scrollDelta
+        let settlePost: CGFloat = dayDelta < 0 ? 0 : CGFloat(mirroredHours) * hourHeight
+        NSLog("[#follow] plan(full-day-mirror): preStart=%.2f swapPost=%.2f settlePost=%.2f motion=%.1f",
+              preStart, swapPost, settlePost, abs(settlePost - swapPost))
         crossDayFollowEventAt = Date()
         let prepareHaptic = UINotificationFeedbackGenerator()
         prepareHaptic.prepare()
         prepareHaptic.notificationOccurred(.success)
         crossDayRebounceAnimator?.cancel()
+        // A canceled predecessor never runs its onComplete, so its fade
+        // could be stuck mid-ramp — the new run would start with a
+        // pre-faded band. Reset before the new animator.
+        if timelineExtensionFadeProgress != 0 {
+            var fadeResetTx = Transaction()
+            fadeResetTx.disablesAnimations = true
+            withTransaction(fadeResetTx) {
+                timelineExtensionFadeProgress = 0
+            }
+        }
         // Pre-set the horizontal-swipe suppression so the upcoming
-        // selectedDayOffset write (at the boundary tick) doesn't trigger
-        // the day-column horizontal slide animation. Cleared at onComplete.
+        // selectedDayOffset write doesn't trigger the day-column
+        // horizontal slide animation. Cleared at onComplete.
         suppressDayColumnHorizontalAnimation = true
-        var swapDone = false
+        // Atomic swap NOW — synchronously, with the compensating scrollTo
+        // in the SAME transaction, so the first frame after the state
+        // change renders the new canvas at the exact equivalence offset.
+        // (Doing this inside the animator's first tick rendered a frame
+        // with the new canvas at the old offset — the spring had already
+        // advanced ~70ms — a visible content jump in the UP direction.)
+        NSLog("[#follow] ATOMIC SWAP (sync) → selectedDay=%d ext=(l=%d,t=%d) scrollY %.2f → %.2f",
+              newHostDayOffset,
+              mirroredExtension.leadingHours, mirroredExtension.trailingHours,
+              preStart, swapPost)
+        var swapTx = Transaction()
+        swapTx.disablesAnimations = true
+        withTransaction(swapTx) {
+            calendarState.selectedDayOffset = newHostDayOffset
+            timelineBoundaryExtensionState = mirroredExtension
+            timelineRawBoundaryExtensionState = .none
+            verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: swapPost))
+        }
+        crossDayFollowEventAt = Date()
         var tickCount = 0
-        // Reuse BoundaryExtensionScrollAnimator: its spring curve drives
-        // a 0→1 progress with a light under-damped settle, which is the
-        // exact shape we want for "autoscroll-continuation". We multiply
-        // by totalMotion to get virtual distance.
+        // CalendarRebounceAnimator's inverted curve gives a 0→1 progress
+        // with a single elastic overshoot — the "autoscroll kept going and
+        // settled" feel for the swapPost → settlePost scroll.
         crossDayRebounceAnimator = CalendarRebounceAnimator(
             duration: 1.1,
             onTick: { value in
@@ -4169,37 +4158,28 @@ private extension CalendarPageView {
                 // curve that goes 1 → 0 with overshoot past 0. Invert to
                 // get a "progress" curve 0 → 1 with overshoot past 1.
                 let progress = 1 - value
-                let virtualP = max(0, totalMotion * progress)
-                let y: CGFloat
-                if virtualP < preMotion {
-                    // Still in pre-coord. scrollY interpolates linearly from
-                    // preStart toward swapPre proportional to virtualP.
-                    let preFrac = virtualP / max(preMotion, 1)
-                    y = preStart + (swapPre - preStart) * preFrac
-                } else {
-                    // Crossed the boundary — trigger the atomic swap exactly
-                    // once, then interpolate in post-coord.
-                    if !swapDone {
-                        swapDone = true
-                        NSLog("[#follow] BOUNDARY CROSSED at tick=%d virtualP=%.2f → atomic swap selectedDay=%d ext=(l=%d,t=%d) scrollY=%.2f",
-                              tickCount, virtualP, newHostDayOffset,
-                              mirroredExtension.leadingHours, mirroredExtension.trailingHours,
-                              swapPost)
-                        var swapTx = Transaction()
-                        swapTx.disablesAnimations = true
-                        withTransaction(swapTx) {
-                            calendarState.selectedDayOffset = newHostDayOffset
-                            timelineBoundaryExtensionState = mirroredExtension
-                            timelineRawBoundaryExtensionState = .none
-                        }
-                        crossDayFollowEventAt = Date()
+                let frac = min(1, max(0, progress))
+                let y = swapPost + (settlePost - swapPost) * progress
+                // Old day (the mirrored band) fades out FRONT-LOADED
+                // (`1-(1-frac)²`, ease-out): it dissolves smoothly while
+                // it's still large in the viewport, so it's nearly gone by
+                // the time it scrolls off the edge — a gradual "慢慢消失"
+                // instead of a snap at the end. The destination day is NOT
+                // touched (it stays solid and just scrolls in). Monotonic
+                // ratchet so the spring's overshoot past 1 can't flash the
+                // band back. (#55 follow-on)
+                let inv = 1 - frac
+                let fade = max(timelineExtensionFadeProgress, 1 - inv * inv)
+                if fade != timelineExtensionFadeProgress {
+                    var fadeTx = Transaction()
+                    fadeTx.disablesAnimations = true
+                    withTransaction(fadeTx) {
+                        timelineExtensionFadeProgress = fade
                     }
-                    let postFrac = (virtualP - preMotion) / max(postMotion, 1)
-                    y = swapPost + (settlePost - swapPost) * postFrac
                 }
                 if tickCount % 3 == 1 {
-                    NSLog("[#follow] tick=%d progress=%.3f virtualP=%.2f y=%.2f swapDone=%d",
-                          tickCount, progress, virtualP, y, swapDone ? 1 : 0)
+                    NSLog("[#follow] tick=%d progress=%.3f y=%.2f fade=%.3f",
+                          tickCount, progress, y, timelineExtensionFadeProgress)
                 }
                 let clampedY = max(0, y)
                 var t = Transaction()
@@ -4209,30 +4189,18 @@ private extension CalendarPageView {
                 }
             },
             onComplete: {
-                // Safety net: if progress never quite reached `preMotion`
-                // (preMotion≈0 edge cases, or very tiny totalMotion), make
-                // sure the swap fires before we close the extension.
-                if !swapDone {
-                    NSLog("[#follow] onComplete: swap not yet done, firing now")
-                    swapDone = true
-                    var swapTx = Transaction()
-                    swapTx.disablesAnimations = true
-                    withTransaction(swapTx) {
-                        calendarState.selectedDayOffset = newHostDayOffset
-                        timelineBoundaryExtensionState = mirroredExtension
-                        timelineRawBoundaryExtensionState = .none
-                        verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: swapPost))
-                    }
-                    crossDayFollowEventAt = Date()
-                }
                 NSLog("[#follow] COMPLETE at scrollY=%.2f → applyState(.none) for clean close",
                       timelineVerticalScrollY)
+                // The band is already faded to ~0 by the front-loaded ramp,
+                // so collapsing it here removes already-invisible content.
                 // Route close through applyTimelineBoundaryExtensionState
                 // which compensates scrollY for the leading collapse case.
-                // For trailing-only collapse it's a no-op on scrollY (no
-                // leadingHours change), and contentH shrink at scrollY=0
-                // doesn't clamp. Both directions end silently.
+                var fadeResetTx = Transaction()
+                fadeResetTx.disablesAnimations = true
                 applyTimelineBoundaryExtensionState(.none)
+                withTransaction(fadeResetTx) {
+                    timelineExtensionFadeProgress = 0
+                }
                 crossDayRebounceAnimator = nil
                 suppressDayColumnHorizontalAnimation = false
                 pendingFollowEventDayOverride = nil

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2202,6 +2202,7 @@ private extension CalendarPageView {
             leftCapsuleSubtitle: currentDayAnnotationSubtitle,
             isCapsulesVisible: isCapsulesVisible,
             isActionCapsuleVisible: isActionCapsulesVisible,
+            leftCapsuleSlowTransition: crossDayRebounceAnimator != nil,
             onMonthTap: {
                 clearFocus()
                 presentDatePicker(for: headerDisplayDate)

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -4257,6 +4257,12 @@ private extension CalendarPageView {
             let resolvedRange = resolvedEvent.effectiveTimeRanges.first(where: {
                 calendarRangesApproximatelyEqual(lhs: $0, rhs: newRange)
             }) ?? resolvedEvent.effectiveTimeRanges.first ?? newRange
+            // Same cross-midnight follow as the non-recurring resize-top
+            // path (#55). Only fires when extension is open + host day
+            // actually changed (function-internal guards).
+            if dragMode == .resizeTop {
+                followEventAcrossMidnightIfNeeded(committedRange: resolvedRange)
+            }
             restartResizeGrace(
                 for: committedOccurrenceContext(
                     event: resolvedEvent,
@@ -4286,6 +4292,14 @@ private extension CalendarPageView {
         )
         updated.timeRanges = ranges
         store.updateCalendarEvent(updated)
+        // Unify the cross-midnight follow with move: resize-top moves the
+        // event's start, which can cross midnight in extended view and
+        // change the host day. resize-bottom only moves the end, so the
+        // host day is unchanged → no follow needed there. (#55 follow-event
+        // unify across drag-move + drag-resize)
+        if dragMode == .resizeTop {
+            followEventAcrossMidnightIfNeeded(committedRange: newRange)
+        }
         restartResizeGrace(
             for: committedOccurrenceContext(
                 event: updated,

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1172,6 +1172,11 @@ struct CalendarPageView: View {
     /// bands dissolve separately — abandoning one must not fade the other.
     @State private var timelineLeadingFadeProgress: CGFloat = 0
     @State private var timelineTrailingFadeProgress: CGFloat = 0
+    /// Whole-timeline opacity, briefly dipped to cover the same-day collapse's
+    /// single-frame layout flash (the pre/post visible content is identical, so
+    /// a quick fade-out → instant collapse-while-dim → fade-in hides the jump
+    /// without trying to co-commit contentSize+scroll). 1 = normal. (#55)
+    @State private var timelineCollapseDim: Double = 1
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -2748,10 +2753,6 @@ private extension CalendarPageView {
     }
 
     func handleTimelineBoundaryExtensionStateChange(_ newState: TimelineBoundaryExtensionState) {
-        NSLog("[#55ext] handleStateChange entry raw=(l=%d,t=%d,src=%@) currentEffective=(l=%d,t=%d) animator=%@",
-              newState.leadingHours, newState.trailingHours, String(describing: newState.source),
-              timelineBoundaryExtensionState.leadingHours, timelineBoundaryExtensionState.trailingHours,
-              boundaryExtensionScrollAnimator == nil ? "nil" : "running")
         // Extended view is only supported in day view — multi-day
         // columns are too narrow for meaningful extended interaction.
         guard calendarState.rangeMode == .day else {
@@ -2765,8 +2766,6 @@ private extension CalendarPageView {
             currentState: timelineBoundaryExtensionState,
             rawState: newState
         )
-        NSLog("[#55ext] handleStateChange retained=(l=%d,t=%d,src=%@)",
-              retainedState.leadingHours, retainedState.trailingHours, String(describing: retainedState.source))
 
         let followGuardActive: Bool = {
             guard let stamp = crossDayFollowEventAt else { return false }
@@ -2825,11 +2824,6 @@ private extension CalendarPageView {
         // dismiss path (designed for small-day post-drag cleanup) would
         // collapse it and flash the canvas. The guard window covers the
         // dispatch delay + a margin. (#55 follow-event-across-midnight)
-        if newState.source == nil, retainedState.hasAnyExtension {
-            NSLog("[#follow] dismiss-path eval: src=nil, hasExt=true, followGuardActive=%d → %@",
-                  followGuardActive ? 1 : 0,
-                  followGuardActive ? "SUPPRESSED" : "scheduled 150ms dismiss")
-        }
         if newState.source == nil, retainedState.hasAnyExtension, !followGuardActive {
             let hourHeight = calendarState.timelineHourHeight
             let baseContentHeight = CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
@@ -2887,15 +2881,23 @@ private extension CalendarPageView {
                             }
                         },
                         onComplete: { [self] in
-                            // Band is faded + off-screen → collapse removes nothing
-                            // visible; applyState comps the scroll for the side.
-                            var tx = Transaction(); tx.disablesAnimations = true
-                            applyTimelineBoundaryExtensionState(.none)
-                            withTransaction(tx) {
-                                timelineLeadingFadeProgress = 0
-                                timelineTrailingFadeProgress = 0
-                            }
+                            // The band is off-screen and the displayed content
+                            // (base day from 0:00) is IDENTICAL before and after
+                            // the collapse — only the 1-frame contentSize+scroll
+                            // co-commit flashes. Cover it with a brief opacity
+                            // dip: fade out → instant collapse while dim → fade
+                            // back in, so the flash lands while invisible. (#55)
                             sameDayRebounceAnimator = nil
+                            withAnimation(.easeIn(duration: 0.09)) { timelineCollapseDim = 0 }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.09) { [self] in
+                                var tx = Transaction(); tx.disablesAnimations = true
+                                withTransaction(tx) {
+                                    applyTimelineBoundaryExtensionState(.none)
+                                    timelineLeadingFadeProgress = 0
+                                    timelineTrailingFadeProgress = 0
+                                }
+                                withAnimation(.easeOut(duration: 0.14)) { timelineCollapseDim = 1 }
+                            }
                         }
                     )
                 } else {
@@ -2953,12 +2955,6 @@ private extension CalendarPageView {
             hourHeight: calendarState.timelineHourHeight
         )
 
-        NSLog("[#55ext] applyState prev=(l=%d,t=%d) new=(l=%d,t=%d,src=%@) currentScrollY=%.2f targetY=%@",
-              previousState.leadingHours, previousState.trailingHours,
-              newState.leadingHours, newState.trailingHours,
-              String(describing: newState.source),
-              timelineVerticalScrollY,
-              targetY.map { String(format: "%.2f", $0) } ?? "nil")
 
         timelineBoundaryExtensionState = newState
 
@@ -2984,7 +2980,6 @@ private extension CalendarPageView {
         if leadingOpened, newState.source == .moveDrag || newState.source == .resizeTop {
             let startY = timelineVerticalScrollY
             let delta = targetY - startY
-            NSLog("[#55ext] animator START from=%.2f to=%.2f delta=%.2f", startY, targetY, delta)
             liveBoundaryExtensionAnimating.value = true
             // Seed the visual offset to -delta so the first rendered frame
             // shows pre-open positions (cancels the leading-snap layout jump).
@@ -3003,7 +2998,6 @@ private extension CalendarPageView {
                     }
                 },
                 onComplete: {
-                    NSLog("[#55ext] animator COMPLETE")
                     liveBoundaryExtensionAnimating.value = false
                     boundaryExtensionVisualYOffset = 0
                     boundaryExtensionScrollAnimator = nil
@@ -3016,11 +3010,9 @@ private extension CalendarPageView {
             pendingBoundaryExtensionScrollTask = nil
             var transaction = Transaction()
             transaction.disablesAnimations = true
-            NSLog("[#55ext] scrollTo IMMEDIATE target=%.2f preScrollY=%.2f", targetY, timelineVerticalScrollY)
             withTransaction(transaction) {
                 verticalScrollPosition.scrollTo(point: targetPoint)
             }
-            NSLog("[#55ext] scrollTo IMMEDIATE returned postScrollY=%.2f", timelineVerticalScrollY)
             return
         }
         pendingBoundaryExtensionScrollTask = Task { @MainActor in
@@ -3028,11 +3020,9 @@ private extension CalendarPageView {
             guard !Task.isCancelled else { return }
             var transaction = Transaction()
             transaction.disablesAnimations = true
-            NSLog("[#55ext] scrollTo DEFERRED target=%.2f preScrollY=%.2f", targetY, timelineVerticalScrollY)
             withTransaction(transaction) {
                 verticalScrollPosition.scrollTo(point: targetPoint)
             }
-            NSLog("[#55ext] scrollTo DEFERRED returned postScrollY=%.2f", timelineVerticalScrollY)
         }
     }
 
@@ -3054,13 +3044,6 @@ private extension CalendarPageView {
             leadingVisible: visibility.leadingVisible,
             trailingVisible: visibility.trailingVisible
         )
-        NSLog("[#55ext] collapse check scrollY=%.2f leadingVis=%d trailingVis=%d cur=(l=%d,t=%d) collapsed=(l=%d,t=%d) willCollapse=%d animator=%@",
-              timelineVerticalScrollY,
-              visibility.leadingVisible ? 1 : 0, visibility.trailingVisible ? 1 : 0,
-              timelineBoundaryExtensionState.leadingHours, timelineBoundaryExtensionState.trailingHours,
-              collapsedState.leadingHours, collapsedState.trailingHours,
-              collapsedState != timelineBoundaryExtensionState ? 1 : 0,
-              boundaryExtensionScrollAnimator == nil ? "nil" : "running")
         guard collapsedState != timelineBoundaryExtensionState else { return }
         // Mirror the drag-end dismiss path's `disablesAnimations` guard
         // (see 2580-2591). `applyTimelineBoundaryExtensionState` now snaps
@@ -3149,6 +3132,7 @@ private extension CalendarPageView {
                     // timeline content consume the trailing page inset.
                     .padding(.trailing, -metrics.horizontalPadding)
                     .geometryGroup()
+                    .opacity(timelineCollapseDim)
             }
             .padding(.top, topOverlayInset)
             .padding(.horizontal, metrics.horizontalPadding)
@@ -3170,12 +3154,6 @@ private extension CalendarPageView {
         }
         .onScrollGeometryChange(for: ScrollGeometry.self, of: { $0 }) { _, newValue in
             let scrollY = newValue.contentOffset.y
-            if timelineBoundaryExtensionState.hasAnyExtension || timelineRawBoundaryExtensionState.hasAnyExtension || boundaryExtensionScrollAnimator != nil {
-                NSLog("[#55ext] scrollGeom raw scrollY=%.2f contentH=%.2f viewportH=%.2f extL=%d rawL=%d animator=%@",
-                      scrollY, newValue.contentSize.height, newValue.visibleRect.height,
-                      timelineBoundaryExtensionState.leadingHours, timelineRawBoundaryExtensionState.leadingHours,
-                      boundaryExtensionScrollAnimator == nil ? "nil" : "running")
-            }
             // Pull down past the top to reveal reminders; scroll up to collapse.
             updateReminderPanelForScroll(scrollY)
             // Viewport height almost never changes during a scroll — gate the
@@ -3211,11 +3189,6 @@ private extension CalendarPageView {
             if abs(scrollY - timelineVerticalScrollY) >= 2 {
                 cancelResizeGrace(reason: "timeline.verticalScroll")
                 timelineVerticalScrollY = scrollY
-                if timelineBoundaryExtensionState.hasAnyExtension || timelineRawBoundaryExtensionState.hasAnyExtension || boundaryExtensionScrollAnimator != nil {
-                    NSLog("[#55ext] scrollGeom scrollY=%.2f extLeading=%d rawLeading=%d animator=%@",
-                          scrollY, timelineBoundaryExtensionState.leadingHours, timelineRawBoundaryExtensionState.leadingHours,
-                          boundaryExtensionScrollAnimator == nil ? "nil" : "running")
-                }
             }
             lastTimelineTopOverlayInset = topOverlayInset
             // Realtime: refresh the abandoned-extension dissolve/collapse as the
@@ -4234,19 +4207,10 @@ private extension CalendarPageView {
     /// Re-anchor `selectedDayOffset` + mirror extension when a drag-commit
     /// moves the event's start onto a different day. See #55 design notes.
     private func followEventAcrossMidnightIfNeeded(committedRange: Event.TimeRange) {
-        NSLog("[#follow] entry rangeMode=%@ hasExt=%d preEffective=(l=%d,t=%d) preScrollY=%.2f hourHeight=%.2f",
-              String(describing: calendarState.rangeMode),
-              timelineBoundaryExtensionState.hasAnyExtension ? 1 : 0,
-              timelineBoundaryExtensionState.leadingHours,
-              timelineBoundaryExtensionState.trailingHours,
-              timelineVerticalScrollY,
-              calendarState.timelineHourHeight)
         guard calendarState.rangeMode == .day else {
-            NSLog("[#follow] SKIP — not day mode")
             return
         }
         guard timelineBoundaryExtensionState.hasAnyExtension else {
-            NSLog("[#follow] SKIP — extension already closed")
             return
         }
         let calendar = Calendar.current
@@ -4254,13 +4218,9 @@ private extension CalendarPageView {
         let originalDayOffset = calendarState.selectedDayOffset
         let newStartDay = calendar.startOfDay(for: committedRange.start)
         guard let newHostDayOffset = calendar.dateComponents([.day], from: todayStart, to: newStartDay).day else {
-            NSLog("[#follow] SKIP — could not compute newHostDayOffset")
             return
         }
-        NSLog("[#follow] originalDay=%d newHostDay=%d committedStart=%@",
-              originalDayOffset, newHostDayOffset, "\(committedRange.start)")
         guard newHostDayOffset != originalDayOffset else {
-            NSLog("[#follow] SKIP — same day, no jump needed")
             return
         }
         let dayDelta = newHostDayOffset - originalDayOffset
@@ -4268,7 +4228,6 @@ private extension CalendarPageView {
         // from a single drag with ≤12h boundary extension, but if they ever
         // are, fall back to the existing collapse-and-snap behavior.
         guard abs(dayDelta) == 1 else {
-            NSLog("[#follow] SKIP — |dayDelta|=%d > 1", abs(dayDelta))
             return
         }
         // Set the header day-override immediately so the brief drag-end →
@@ -4351,8 +4310,6 @@ private extension CalendarPageView {
         let preStart = timelineVerticalScrollY
         let swapPost: CGFloat = preStart + scrollDelta
         let settlePost: CGFloat = dayDelta < 0 ? 0 : CGFloat(mirroredHours) * hourHeight
-        NSLog("[#follow] plan(full-day-mirror): preStart=%.2f swapPost=%.2f settlePost=%.2f motion=%.1f",
-              preStart, swapPost, settlePost, abs(settlePost - swapPost))
         crossDayFollowEventAt = Date()
         let prepareHaptic = UINotificationFeedbackGenerator()
         prepareHaptic.prepare()
@@ -4379,10 +4336,6 @@ private extension CalendarPageView {
         // (Doing this inside the animator's first tick rendered a frame
         // with the new canvas at the old offset — the spring had already
         // advanced ~70ms — a visible content jump in the UP direction.)
-        NSLog("[#follow] ATOMIC SWAP (sync) → selectedDay=%d ext=(l=%d,t=%d) scrollY %.2f → %.2f",
-              newHostDayOffset,
-              mirroredExtension.leadingHours, mirroredExtension.trailingHours,
-              preStart, swapPost)
         var swapTx = Transaction()
         swapTx.disablesAnimations = true
         withTransaction(swapTx) {
@@ -4392,14 +4345,12 @@ private extension CalendarPageView {
             verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: swapPost))
         }
         crossDayFollowEventAt = Date()
-        var tickCount = 0
         // CalendarRebounceAnimator's inverted curve gives a 0→1 progress
         // with a single elastic overshoot — the "autoscroll kept going and
         // settled" feel for the swapPost → settlePost scroll.
         crossDayRebounceAnimator = CalendarRebounceAnimator(
             duration: 1.1,
             onTick: { value in
-                tickCount += 1
                 // CalendarRebounceAnimator emits a "release from stretch"
                 // curve that goes 1 → 0 with overshoot past 0. Invert to
                 // get a "progress" curve 0 → 1 with overshoot past 1.
@@ -4426,10 +4377,6 @@ private extension CalendarPageView {
                         timelineTrailingFadeProgress = fade
                     }
                 }
-                if tickCount % 3 == 1 {
-                    NSLog("[#follow] tick=%d progress=%.3f y=%.2f fade=%.3f",
-                          tickCount, progress, y, fade)
-                }
                 let clampedY = max(0, y)
                 var t = Transaction()
                 t.disablesAnimations = true
@@ -4438,8 +4385,6 @@ private extension CalendarPageView {
                 }
             },
             onComplete: {
-                NSLog("[#follow] COMPLETE at scrollY=%.2f → applyState(.none) for clean close",
-                      timelineVerticalScrollY)
                 // The band is already faded to ~0 by the front-loaded ramp,
                 // so collapsing it here removes already-invisible content.
                 // Route close through applyTimelineBoundaryExtensionState
@@ -4454,10 +4399,6 @@ private extension CalendarPageView {
                 crossDayRebounceAnimator = nil
                 suppressDayColumnHorizontalAnimation = false
                 pendingFollowEventDayOverride = nil
-                NSLog("[#follow] all done: scrollY=%.2f effExt=(l=%d,t=%d)",
-                      timelineVerticalScrollY,
-                      timelineBoundaryExtensionState.leadingHours,
-                      timelineBoundaryExtensionState.trailingHours)
             }
         )
     }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -741,6 +741,12 @@ func calendarRetainedTimelineBoundaryExtensionState(
     let clampedExtensionHours = max(0, maxExtensionHours)
 
     if let source = rawState.source {
+        // Latch each side once triggered and keep it for the rest of the drag
+        // (per-side, OR of current + raw). We do NOT drop a side mid-drag even
+        // when the other gets triggered: collapsing a side mid-drag would shift
+        // scroll and detach the dragged event from the finger. The abandoned
+        // side is instead faded to transparent (per-side fade) and only
+        // collapses on release. (#55)
         return TimelineBoundaryExtensionState(
             leadingHours: (currentState.leadingHours > 0 || rawState.leadingHours > 0) ? clampedExtensionHours : 0,
             trailingHours: (currentState.trailingHours > 0 || rawState.trailingHours > 0) ? clampedExtensionHours : 0,
@@ -1104,6 +1110,11 @@ struct CalendarPageView: View {
     @State private var timelineBoundaryExtensionState: TimelineBoundaryExtensionState = .none
     @State private var timelineRawBoundaryExtensionState: TimelineBoundaryExtensionState = .none
     @State private var timelineScrollViewportHeight: CGFloat = 0
+    /// Latest `topOverlayInset` seen by the scroll handler. Stashed so
+    /// `handleTimelineBoundaryExtensionStateChange` (a callback that doesn't
+    /// receive it) can compute boundary-extension visibility for the
+    /// fade-out-only-when-scrolled-away guard. (#55 follow-on)
+    @State private var lastTimelineTopOverlayInset: CGFloat = 0
     @State private var lastDynamicPinchMinInputs: DynamicPinchMinInputs? = nil
     /// Vertical-scroll phase flag.  When true, `VerticalScrollGate` short-
     /// circuits header and TimelinePagerView body re-evaluation, mirroring the
@@ -1150,7 +1161,11 @@ struct CalendarPageView: View {
     /// (the mirrored extension band) fades out in lockstep with being
     /// pushed out of the viewport, so the final silent collapse removes
     /// content that's already invisible. (#55 follow-on)
-    @State private var timelineExtensionFadeProgress: CGFloat = 0
+    /// Band-fade opacity, controlled INDEPENDENTLY per side (0 = solid,
+    /// 1 = transparent). The leading (top) and trailing (bottom) extension
+    /// bands dissolve separately — abandoning one must not fade the other.
+    @State private var timelineLeadingFadeProgress: CGFloat = 0
+    @State private var timelineTrailingFadeProgress: CGFloat = 0
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -2619,6 +2634,88 @@ private extension CalendarPageView {
         }
     }
 
+    /// Fade the extension band IN (pure opacity — contentH is untouched).
+    /// Seeded transparent first (on the next runloop tick so SwiftUI doesn't
+    /// collapse the set-then-animate into a no-op), then eased to solid.
+    /// Guards the race where the drag leaves the zone before the async fires.
+    private func fadeInBoundaryExtension() {
+        // Seed both transparent and fade both in — only the side that actually
+        // opened has a band (the other's fade is ignored by the mask).
+        var tx = Transaction()
+        tx.disablesAnimations = true
+        withTransaction(tx) {
+            timelineLeadingFadeProgress = 1
+            timelineTrailingFadeProgress = 1
+        }
+        DispatchQueue.main.async { [self] in
+            guard timelineRawBoundaryExtensionState.hasAnyExtension else { return }
+            withAnimation(.easeOut(duration: 0.25)) {
+                timelineLeadingFadeProgress = 0
+                timelineTrailingFadeProgress = 0
+            }
+        }
+    }
+
+    /// DURING-DRAG, FINGER-DRIVEN dissolve for an abandoned-but-still-open
+    /// extension. While dragging (move OR resize) with the intent (`raw`) OUT
+    /// of the trigger zone, the band's opacity tracks how far the dragged edge
+    /// has pulled BACK across the boundary into the day — solid while still
+    /// crossing, dissolving once the edge is `abandonFadeStartHours` into the
+    /// day, fully transparent by `+ abandonFadeRangeHours`. This responds to the
+    /// drag itself (not the scroll), so it works even when the scroll doesn't
+    /// move. A separate gate collapses the contentH only once the band is fully
+    /// off the viewport edge (exact comp → no jump). Called on every drag-offset
+    /// change, scroll tick, and zone change. (#55 follow-on)
+    private func refreshAbandonedExtension(topOverlayInset: CGFloat) {
+        guard timelineBoundaryExtensionState.hasAnyExtension else { return }
+        if let stamp = crossDayFollowEventAt, Date().timeIntervalSince(stamp) < 0.6 { return }
+        let raw = timelineRawBoundaryExtensionState
+        // Only while actively dragging with the intent (raw) OUT of the zone.
+        guard raw.source != nil, !raw.hasAnyExtension else { return }
+        guard let original = timelineDragState.draggingOriginalRange else { return }
+        let hh = calendarState.timelineHourHeight
+        guard hh > 0 else { return }
+        let leading = timelineBoundaryExtensionState.leadingHours
+        let trailing = timelineBoundaryExtensionState.trailingHours
+
+        // FINGER-DRIVEN fade. The dragged edge = original edge + drag offset
+        // (move shifts both; resizeTop shifts start; resizeBottom shifts end —
+        // leading keys on start, trailing on end, so this is correct for all).
+        let offsetHours = Double(timelineDragState.dragOffset.y) / Double(hh)
+        let cal = Calendar.current
+        let dayStart = cal.startOfDay(for: original.start)
+        let abandonFadeStartHours: Double = 4   // tunable: dissolve begins here
+        let abandonFadeRangeHours: Double = 4   // tunable: fully gone after this
+        func ramp(_ distHours: Double) -> CGFloat {
+            CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours)))
+        }
+        // Per-side fade — leading and trailing dissolve INDEPENDENTLY.
+        var fadeTx = Transaction()
+        fadeTx.disablesAnimations = true
+        if leading > 0 {
+            // distance of the dragged START past the 0:00 boundary INTO today.
+            let liveStart = original.start.addingTimeInterval(offsetHours * 3600)
+            let lf = ramp(liveStart.timeIntervalSince(dayStart) / 3600)
+            if abs(timelineLeadingFadeProgress - lf) > 0.001 {
+                withTransaction(fadeTx) { timelineLeadingFadeProgress = lf }
+            }
+        }
+        if trailing > 0 {
+            // distance of the dragged END pulled up past the 24:00 boundary.
+            let dayEnd = dayStart.addingTimeInterval(24 * 3600)
+            let liveEnd = original.end.addingTimeInterval(offsetHours * 3600)
+            let tf = ramp(dayEnd.timeIntervalSince(liveEnd) / 3600)
+            if abs(timelineTrailingFadeProgress - tf) > 0.001 {
+                withTransaction(fadeTx) { timelineTrailingFadeProgress = tf }
+            }
+        }
+        // NB: NO collapse here. Collapsing mid-drag changes contentH → forces a
+        // scroll compensation ("auto-recenter") that shifts the still-dragged
+        // event off the finger. During the drag we ONLY fade (opacity, no
+        // contentH/scroll change); the contentH collapse waits for release.
+        // (#55 follow-on)
+    }
+
     func handleTimelineBoundaryExtensionStateChange(_ newState: TimelineBoundaryExtensionState) {
         NSLog("[#55ext] handleStateChange entry raw=(l=%d,t=%d,src=%@) currentEffective=(l=%d,t=%d) animator=%@",
               newState.leadingHours, newState.trailingHours, String(describing: newState.source),
@@ -2639,7 +2736,45 @@ private extension CalendarPageView {
         )
         NSLog("[#55ext] handleStateChange retained=(l=%d,t=%d,src=%@)",
               retainedState.leadingHours, retainedState.trailingHours, String(describing: retainedState.source))
+
+        let followGuardActive: Bool = {
+            guard let stamp = crossDayFollowEventAt else { return false }
+            return Date().timeIntervalSince(stamp) < 0.6
+        }()
+
+        let wasOpen = timelineBoundaryExtensionState.hasAnyExtension
         applyTimelineBoundaryExtensionState(retainedState)
+
+        // Pure-opacity intent tracking. contentH follows the RETAINED state
+        // (kept open for the whole drag — we never collapse mid-drag, which
+        // would force a scroll re-compensation and the visible misalignment).
+        // The band's OPACITY follows the RAW (intent) state: enter the zone →
+        // fade the band IN, leave it → fade OUT (band goes transparent, canvas
+        // height untouched). The actual collapse waits for release (handled by
+        // the dismiss / scroll-driven paths below + in
+        // `collapseTimelineBoundaryExtensionsIfNeeded`). (#55 follow-on)
+        if newState.source != nil, retainedState.hasAnyExtension, !followGuardActive {
+            if newState.hasAnyExtension {
+                // In the zone (intent to cross) → keep the band solid.
+                if !wasOpen {
+                    fadeInBoundaryExtension()
+                } else {
+                    // Re-engaging: make SOLID only the side(s) currently being
+                    // crossed (per `newState`). Leave the other side at its
+                    // current fade — if it was abandoned earlier, it stays
+                    // dissolved instead of snapping back to solid. (#55)
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        if newState.leadingHours > 0 { timelineLeadingFadeProgress = 0 }
+                        if newState.trailingHours > 0 { timelineTrailingFadeProgress = 0 }
+                    }
+                }
+            } else {
+                // Left the zone → the finger-driven dissolve (also re-run on
+                // every drag-offset change + scroll tick) handles the fade and
+                // the off-screen collapse. (#55 follow-on)
+                refreshAbandonedExtension(topOverlayInset: lastTimelineTopOverlayInset)
+            }
+        }
 
         // When the drag source clears (finger lifted) near max
         // pinch, the extension can't be scrolled away naturally
@@ -2659,10 +2794,6 @@ private extension CalendarPageView {
         // dismiss path (designed for small-day post-drag cleanup) would
         // collapse it and flash the canvas. The guard window covers the
         // dispatch delay + a margin. (#55 follow-event-across-midnight)
-        let followGuardActive: Bool = {
-            guard let stamp = crossDayFollowEventAt else { return false }
-            return Date().timeIntervalSince(stamp) < 0.6
-        }()
         if newState.source == nil, retainedState.hasAnyExtension {
             NSLog("[#follow] dismiss-path eval: src=nil, hasExt=true, followGuardActive=%d → %@",
                   followGuardActive ? 1 : 0,
@@ -2673,26 +2804,36 @@ private extension CalendarPageView {
             let baseContentHeight = CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
             let scrollableRange = baseContentHeight - timelineScrollViewportHeight
             if scrollableRange < hourHeight * 2 {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [self] in
-                    guard timelineRawBoundaryExtensionState.source == nil else { return }
-                    // `applyTimelineBoundaryExtensionState` snaps scroll
-                    // instantly (`disablesAnimations = true` on the inner
-                    // scrollTo transaction) but the `leading` state change
-                    // is observed by TimelineView's
-                    // `.animation(boundaryExtensionAnimation, value: leading)`
-                    // modifier — and post-drag that animation is a spring
-                    // (~0.28s). The scroll snap + spring leading shift
-                    // get out-of-sync, so an event committed mid-collapse
-                    // jumps to its new window-y at t=0 (scroll snap) and
-                    // then slides back over the spring duration. Wrap the
-                    // apply in a `disablesAnimations` transaction so the
-                    // leading change propagates animation-free, in lockstep
-                    // with the scroll snap (and the event holds its
-                    // visual position). (#53 single-day follow-on)
+                // Abandon-release on a small viewport (band can't be scrolled
+                // away): FADE the band out first (visible dissolve — this is
+                // the only abandon path the user actually hits, since the
+                // gesture is "open → release" with no scroll), THEN collapse.
+                // The fade runs while not scrolling, so VerticalScrollGate
+                // isn't frozen and the mask re-renders. (#55 follow-on)
+                withAnimation(.easeIn(duration: 0.3)) {
+                    timelineLeadingFadeProgress = 1
+                    timelineTrailingFadeProgress = 1
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [self] in
+                    guard timelineRawBoundaryExtensionState.source == nil else {
+                        // Re-engaged before the fade finished — restore solid.
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            timelineLeadingFadeProgress = 0
+                            timelineTrailingFadeProgress = 0
+                        }
+                        return
+                    }
+                    // Collapse animation-free in lockstep with the scroll snap
+                    // (the `leading` change would otherwise spring out-of-sync
+                    // with the instant scroll comp). Band is already invisible
+                    // from the fade, so the collapse removes nothing visible.
+                    // (#53 single-day follow-on)
                     var transaction = Transaction()
                     transaction.disablesAnimations = true
                     withTransaction(transaction) {
                         applyTimelineBoundaryExtensionState(.none)
+                        timelineLeadingFadeProgress = 0
+                        timelineTrailingFadeProgress = 0
                     }
                 }
             }
@@ -2983,6 +3124,10 @@ private extension CalendarPageView {
                           boundaryExtensionScrollAnimator == nil ? "nil" : "running")
                 }
             }
+            lastTimelineTopOverlayInset = topOverlayInset
+            // Realtime: refresh the abandoned-extension dissolve/collapse as the
+            // scroll moves (the finger-driven fade also runs on drag changes).
+            refreshAbandonedExtension(topOverlayInset: topOverlayInset)
             collapseTimelineBoundaryExtensionsIfNeeded(topOverlayInset: topOverlayInset)
             // Keep header capsules always visible — don't hide on scroll.
             if !headerCapsulesVisible {
@@ -2998,6 +3143,12 @@ private extension CalendarPageView {
             if isVerticallyScrolling != isScrollingNow {
                 isVerticallyScrolling = isScrollingNow
             }
+        }
+        // FINGER-DRIVEN dissolve: re-run on every drag-offset change so an
+        // abandoned-but-open extension fades as the dragged event/edge pulls
+        // back into the day — even when the scroll never moves. (#55 follow-on)
+        .onChange(of: timelineDragState.dragOffset.y) { _, _ in
+            refreshAbandonedExtension(topOverlayInset: lastTimelineTopOverlayInset)
         }
         .mask {
             TimelineMaskView(
@@ -3040,7 +3191,8 @@ private extension CalendarPageView {
             liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
             boundaryExtensionVisualYOffset: boundaryExtensionVisualYOffset,
             suppressDayColumnHorizontalAnimation: suppressDayColumnHorizontalAnimation,
-            extensionFadeProgress: timelineExtensionFadeProgress,
+            leadingFadeProgress: timelineLeadingFadeProgress,
+            trailingFadeProgress: timelineTrailingFadeProgress,
             isDayOffsetFrozen: calendarState.isDayOffsetFrozen,
             daysCount: timelineDaysCount(for: calendarState.rangeMode),
             mode: .preview,
@@ -4116,11 +4268,12 @@ private extension CalendarPageView {
         // A canceled predecessor never runs its onComplete, so its fade
         // could be stuck mid-ramp — the new run would start with a
         // pre-faded band. Reset before the new animator.
-        if timelineExtensionFadeProgress != 0 {
+        if timelineLeadingFadeProgress != 0 || timelineTrailingFadeProgress != 0 {
             var fadeResetTx = Transaction()
             fadeResetTx.disablesAnimations = true
             withTransaction(fadeResetTx) {
-                timelineExtensionFadeProgress = 0
+                timelineLeadingFadeProgress = 0
+                timelineTrailingFadeProgress = 0
             }
         }
         // Pre-set the horizontal-swipe suppression so the upcoming
@@ -4169,17 +4322,20 @@ private extension CalendarPageView {
                 // ratchet so the spring's overshoot past 1 can't flash the
                 // band back. (#55 follow-on)
                 let inv = 1 - frac
-                let fade = max(timelineExtensionFadeProgress, 1 - inv * inv)
-                if fade != timelineExtensionFadeProgress {
+                // The mirror is a single side; drive both fades together (the
+                // absent side is ignored by the mask). Monotonic ratchet.
+                let fade = max(timelineLeadingFadeProgress, 1 - inv * inv)
+                if fade != timelineLeadingFadeProgress || fade != timelineTrailingFadeProgress {
                     var fadeTx = Transaction()
                     fadeTx.disablesAnimations = true
                     withTransaction(fadeTx) {
-                        timelineExtensionFadeProgress = fade
+                        timelineLeadingFadeProgress = fade
+                        timelineTrailingFadeProgress = fade
                     }
                 }
                 if tickCount % 3 == 1 {
                     NSLog("[#follow] tick=%d progress=%.3f y=%.2f fade=%.3f",
-                          tickCount, progress, y, timelineExtensionFadeProgress)
+                          tickCount, progress, y, fade)
                 }
                 let clampedY = max(0, y)
                 var t = Transaction()
@@ -4199,7 +4355,8 @@ private extension CalendarPageView {
                 fadeResetTx.disablesAnimations = true
                 applyTimelineBoundaryExtensionState(.none)
                 withTransaction(fadeResetTx) {
-                    timelineExtensionFadeProgress = 0
+                    timelineLeadingFadeProgress = 0
+                    timelineTrailingFadeProgress = 0
                 }
                 crossDayRebounceAnimator = nil
                 suppressDayColumnHorizontalAnimation = false

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1117,6 +1117,26 @@ struct CalendarPageView: View {
     /// lockstep with `.animation(_:value:leading)` so the canvas unfolds
     /// smoothly instead of snapping. (#55)
     @State private var boundaryExtensionScrollAnimator: BoundaryExtensionScrollAnimator? = nil
+    /// Single-overshoot scroll rebounce after a cross-midnight commit
+    /// follows the event to the new day. CADisplayLink-driven, ~0.4s, one
+    /// damped half-sine peak. Decouples cleanly from the open animator —
+    /// they never overlap because follow only fires on commit (drag is
+    /// already done). (#55 follow-event-across-midnight)
+    @State private var crossDayRebounceAnimator: CalendarRebounceAnimator? = nil
+    /// Timestamp of the last follow-event-across-midnight re-anchor. Used by
+    /// `handleTimelineBoundaryExtensionStateChange` to suppress the 150ms
+    /// delayed dismiss path on small-viewport days — that path would
+    /// collapse the post-follow extension (mirrored leading↔trailing) right
+    /// after follow-event set it, causing a visible 322pt scroll clamp +
+    /// content-shift flash. (#55 follow-event-across-midnight)
+    @State private var crossDayFollowEventAt: Date? = nil
+    /// When true, the day-column horizontal swipe animation triggered by
+    /// `selectedDayOffset` changes is skipped — the day swap in the middle
+    /// of a follow-event two-phase animation must be a content-equivalent
+    /// rename (math holds), not a visible horizontal slide. Set true right
+    /// before the atomic swap, cleared at phase 2 onComplete.
+    /// (#55 follow-event-across-midnight)
+    @State private var suppressDayColumnHorizontalAnimation: Bool = false
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -2593,7 +2613,22 @@ private extension CalendarPageView {
         // back into range out-of-sync with the leading-driven content
         // shift — the user-observed "canvas slides up then snaps
         // back" bounce. (#53 single-day regression)
+        // Suppress the 150ms small-day dismiss when follow-event-across-
+        // midnight just ran. Follow-event intentionally leaves the mirrored
+        // extension open as the post-commit settled state; the original
+        // dismiss path (designed for small-day post-drag cleanup) would
+        // collapse it and flash the canvas. The guard window covers the
+        // dispatch delay + a margin. (#55 follow-event-across-midnight)
+        let followGuardActive: Bool = {
+            guard let stamp = crossDayFollowEventAt else { return false }
+            return Date().timeIntervalSince(stamp) < 0.6
+        }()
         if newState.source == nil, retainedState.hasAnyExtension {
+            NSLog("[#follow] dismiss-path eval: src=nil, hasExt=true, followGuardActive=%d → %@",
+                  followGuardActive ? 1 : 0,
+                  followGuardActive ? "SUPPRESSED" : "scheduled 150ms dismiss")
+        }
+        if newState.source == nil, retainedState.hasAnyExtension, !followGuardActive {
             let hourHeight = calendarState.timelineHourHeight
             let baseContentHeight = CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
             let scrollableRange = baseContentHeight - timelineScrollViewportHeight
@@ -2964,6 +2999,7 @@ private extension CalendarPageView {
             liveHourHeight: liveHourHeight,
             liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
             boundaryExtensionVisualYOffset: boundaryExtensionVisualYOffset,
+            suppressDayColumnHorizontalAnimation: suppressDayColumnHorizontalAnimation,
             isDayOffsetFrozen: calendarState.isDayOffsetFrozen,
             daysCount: timelineDaysCount(for: calendarState.rangeMode),
             mode: .preview,
@@ -3886,6 +3922,19 @@ private extension CalendarPageView {
             ]
         )
         store.updateCalendarEvent(updated)
+        // Pseudo-vertical follow (#55): when a single-day extended-view drag
+        // commits the event onto a NEW host day (its start crossed midnight),
+        // re-anchor the view to the new day in lockstep with mirroring the
+        // extension state — so the user follows the event vertically without
+        // the canvas appearing to move. Reuses the same visualOffset rationale
+        // as the OPEN animator: with leading=12 on `today`, visibleStart is
+        // `yesterday 12:00`; on `yesterday` with trailing=12, visibleStart is
+        // `yesterday 00:00`. Both windows cover the same content slice when
+        // scrollY shifts by 12h*hourHeight. Wrap all writes in
+        // `disablesAnimations` so the horizontal day-snap and the scroll
+        // adjustment land in the same render pass — no horizontal slide, no
+        // vertical jump.
+        followEventAcrossMidnightIfNeeded(committedRange: newRange)
         restartResizeGrace(
             for: committedOccurrenceContext(
                 event: updated,
@@ -3893,6 +3942,265 @@ private extension CalendarPageView {
                 occurrenceDate: newRange.start
             ),
             trigger: .moveCommit
+        )
+    }
+
+    /// Re-anchor `selectedDayOffset` + mirror extension when a drag-commit
+    /// moves the event's start onto a different day. See #55 design notes.
+    private func followEventAcrossMidnightIfNeeded(committedRange: Event.TimeRange) {
+        NSLog("[#follow] entry rangeMode=%@ hasExt=%d preEffective=(l=%d,t=%d) preScrollY=%.2f hourHeight=%.2f",
+              String(describing: calendarState.rangeMode),
+              timelineBoundaryExtensionState.hasAnyExtension ? 1 : 0,
+              timelineBoundaryExtensionState.leadingHours,
+              timelineBoundaryExtensionState.trailingHours,
+              timelineVerticalScrollY,
+              calendarState.timelineHourHeight)
+        guard calendarState.rangeMode == .day else {
+            NSLog("[#follow] SKIP — not day mode")
+            return
+        }
+        guard timelineBoundaryExtensionState.hasAnyExtension else {
+            NSLog("[#follow] SKIP — extension already closed")
+            return
+        }
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        let originalDayOffset = calendarState.selectedDayOffset
+        let newStartDay = calendar.startOfDay(for: committedRange.start)
+        guard let newHostDayOffset = calendar.dateComponents([.day], from: todayStart, to: newStartDay).day else {
+            NSLog("[#follow] SKIP — could not compute newHostDayOffset")
+            return
+        }
+        NSLog("[#follow] originalDay=%d newHostDay=%d committedStart=%@",
+              originalDayOffset, newHostDayOffset, "\(committedRange.start)")
+        guard newHostDayOffset != originalDayOffset else {
+            NSLog("[#follow] SKIP — same day, no jump needed")
+            return
+        }
+        let dayDelta = newHostDayOffset - originalDayOffset
+        // Only handle adjacent-day jumps; larger jumps shouldn't be reachable
+        // from a single drag with ≤12h boundary extension, but if they ever
+        // are, fall back to the existing collapse-and-snap behavior.
+        guard abs(dayDelta) == 1 else {
+            NSLog("[#follow] SKIP — |dayDelta|=%d > 1", abs(dayDelta))
+            return
+        }
+        let hourHeight = calendarState.timelineHourHeight
+        let extensionMaxHours = calendarTimelineMaximumBoundaryExtensionHours
+        let mirroredExtension: TimelineBoundaryExtensionState
+        let scrollDelta: CGFloat
+        if dayDelta < 0 {
+            // Forward-time was today + leading 12h (yesterday's late hours
+            // visible above today). After the jump, anchor=yesterday and the
+            // visible window's lower 12h is today's first 12h → trailing=12.
+            mirroredExtension = TimelineBoundaryExtensionState(
+                leadingHours: 0,
+                trailingHours: extensionMaxHours,
+                source: nil,
+                anchorDayOffset: newHostDayOffset
+            )
+            scrollDelta = CGFloat(extensionMaxHours) * hourHeight
+        } else {
+            // Mirror of the above: was on today + trailing 12h (tomorrow's
+            // first hours visible below today); after jumping to tomorrow,
+            // today's last 12h becomes leading=12 of tomorrow's view.
+            mirroredExtension = TimelineBoundaryExtensionState(
+                leadingHours: extensionMaxHours,
+                trailingHours: 0,
+                source: nil,
+                anchorDayOffset: newHostDayOffset
+            )
+            scrollDelta = -CGFloat(extensionMaxHours) * hourHeight
+        }
+        let targetScrollY = max(0, timelineVerticalScrollY + scrollDelta)
+        calendarDebugLog(
+            "calendar.followEventAcrossMidnight",
+            fields: [
+                "originalDayOffset": "\(originalDayOffset)",
+                "newHostDayOffset": "\(newHostDayOffset)",
+                "dayDelta": "\(dayDelta)",
+                "scrollPre": String(format: "%.2f", timelineVerticalScrollY),
+                "scrollDelta": String(format: "%.2f", scrollDelta),
+                "scrollTarget": String(format: "%.2f", targetScrollY)
+            ]
+        )
+        // Atomic re-anchor at t=0: day-column horizontal snap, extension
+        // state mirror, and scroll all land in one render pass. CRITICALLY:
+        // the post-swap state at scrollY=targetScrollY is *mathematically
+        // identical* to the pre-swap state at scrollY=currentScrollY (same
+        // canvas content visible, same event viewport position). The user
+        // sees no change at this moment — the swap is a coordinate-system
+        // rename, not a content shift.
+        //
+        // Then the rebounce animator continues the autoscroll's vertical
+        // momentum: scrollY slides from `targetScrollY` toward 0 (top of
+        // the new-day canvas, anchored to yesterday 00:00 or tomorrow
+        // 00:00 + 12h trailing). Visually this reads as "the autoscroll
+        // kept going past the day boundary and settled the view on the
+        // new day's natural top". The event's canvas y is fixed in the
+        // post-swap coordinates, so as the viewport scrolls up the event
+        // visually slides toward the bottom of the viewport — its
+        // natural position in the new day's late-evening / early-morning
+        // hours. (#55 follow-event-across-midnight)
+        //
+        // At animator completion, scrollY ≈ 0 and the mirrored extension
+        // can collapse silently: contentH shrinks ~322pt but scrollY=0
+        // is within both the pre- and post-collapse scrollable ranges so
+        // ScrollView never clamps → no visible flash.
+        // Two-phase scroll animation to bridge the day-swap cleanly.
+        //
+        // The naive "atomic swap immediately" approach clamps `targetScrollY`
+        // to [0, maxScroll] whenever the user releases mid-autoscroll, which
+        // breaks the math-equivalence between pre- and post-swap canvas
+        // coordinates → visible content jump at the swap moment.
+        //
+        // Instead: continue the autoscroll's vertical motion in pre-swap
+        // coordinates until scrollY reaches a "swap-safe edge" where the
+        // mathematical translation to post-swap coordinates lands within
+        // [0, postMaxScroll]. Then atomically swap day + extension + scrollY
+        // (invisible because content is identical) and continue the same
+        // motion in post-swap coordinates to the settle position. Two
+        // sequential animators with proportional duration totaling 0.5s.
+        //
+        // Math:
+        // For dayDelta < 0 (autoscroll was UP, going to previous day):
+        //   pre = today + leading=12, scrollY=K
+        //   swap_pre = 0 (top of canvas — always within range)
+        //   swap_post = 0 + scrollDelta = 12h*hourHeight (math-equivalent)
+        //   settle_post = 0 (top of new day's canvas)
+        // For dayDelta > 0 (autoscroll DOWN, going to next day):
+        //   pre = yesterday + trailing=12, scrollY=K
+        //   swap_pre = 12h*hourHeight (≈ maxScroll, where math holds)
+        //   swap_post = swap_pre + scrollDelta = 0
+        //   settle_post = 12h*hourHeight (showing new day's start at viewport top)
+        //
+        // At phase 2 onComplete, route the extension close through
+        // `applyTimelineBoundaryExtensionState(.none)` which compensates
+        // scrollY for the leading-collapse case (no compensation needed
+        // for trailing-only collapse when scrollY=0). Either way: silent
+        // close. (#55 follow-event-across-midnight)
+        // Single-spring continuous animation across the day-swap boundary.
+        //
+        // A "virtual scroll distance" P is driven by ONE spring from 0 → total.
+        // At each tick we convert P to actual scrollY in either pre- or
+        // post-swap coordinates depending on which side of the boundary
+        // we're on. At P = preMotion, the boundary is crossed:
+        //   • Mathematically: swapPre (pre-coord) ↔ swapPost (post-coord)
+        //     show identical canvas content (the math-equivalent rename),
+        //     so the coordinate swap is invisible.
+        //   • Velocity continuity: dP/dt is continuous through the boundary,
+        //     and the conversion preserves screen-space velocity → no
+        //     "stop and restart" feel that two separate springs would have.
+        //
+        // For dayDelta < 0 (backward, autoscroll was UP):
+        //   preStart = K, swapPre = 0, swapPost = 12h*hh, settlePost = 0
+        // For dayDelta > 0 (forward, autoscroll was DOWN):
+        //   preStart = K, swapPre = 12h*hh, swapPost = 0, settlePost = 12h*hh
+        // (#55 follow-event-across-midnight, continuous-spring revision)
+        let extensionMaxPt = CGFloat(extensionMaxHours) * hourHeight
+        let preStart = timelineVerticalScrollY
+        let swapPre: CGFloat = dayDelta < 0 ? 0 : extensionMaxPt
+        let swapPost: CGFloat = swapPre + scrollDelta
+        let settlePost: CGFloat = dayDelta < 0 ? 0 : extensionMaxPt
+        let preMotion = abs(preStart - swapPre)
+        let postMotion = abs(settlePost - swapPost)
+        let totalMotion = preMotion + postMotion
+        NSLog("[#follow] continuous-spring plan: preStart=%.2f swapPre=%.2f swapPost=%.2f settlePost=%.2f preMotion=%.1f postMotion=%.1f totalMotion=%.1f",
+              preStart, swapPre, swapPost, settlePost, preMotion, postMotion, totalMotion)
+        crossDayFollowEventAt = Date()
+        let prepareHaptic = UINotificationFeedbackGenerator()
+        prepareHaptic.prepare()
+        prepareHaptic.notificationOccurred(.success)
+        crossDayRebounceAnimator?.cancel()
+        // Pre-set the horizontal-swipe suppression so the upcoming
+        // selectedDayOffset write (at the boundary tick) doesn't trigger
+        // the day-column horizontal slide animation. Cleared at onComplete.
+        suppressDayColumnHorizontalAnimation = true
+        var swapDone = false
+        var tickCount = 0
+        // Reuse BoundaryExtensionScrollAnimator: its spring curve drives
+        // a 0→1 progress with a light under-damped settle, which is the
+        // exact shape we want for "autoscroll-continuation". We multiply
+        // by totalMotion to get virtual distance.
+        crossDayRebounceAnimator = CalendarRebounceAnimator(
+            duration: 1.1,
+            onTick: { value in
+                tickCount += 1
+                // CalendarRebounceAnimator emits a "release from stretch"
+                // curve that goes 1 → 0 with overshoot past 0. Invert to
+                // get a "progress" curve 0 → 1 with overshoot past 1.
+                let progress = 1 - value
+                let virtualP = max(0, totalMotion * progress)
+                let y: CGFloat
+                if virtualP < preMotion {
+                    // Still in pre-coord. scrollY interpolates linearly from
+                    // preStart toward swapPre proportional to virtualP.
+                    let preFrac = virtualP / max(preMotion, 1)
+                    y = preStart + (swapPre - preStart) * preFrac
+                } else {
+                    // Crossed the boundary — trigger the atomic swap exactly
+                    // once, then interpolate in post-coord.
+                    if !swapDone {
+                        swapDone = true
+                        NSLog("[#follow] BOUNDARY CROSSED at tick=%d virtualP=%.2f → atomic swap selectedDay=%d ext=(l=%d,t=%d) scrollY=%.2f",
+                              tickCount, virtualP, newHostDayOffset,
+                              mirroredExtension.leadingHours, mirroredExtension.trailingHours,
+                              swapPost)
+                        var swapTx = Transaction()
+                        swapTx.disablesAnimations = true
+                        withTransaction(swapTx) {
+                            calendarState.selectedDayOffset = newHostDayOffset
+                            timelineBoundaryExtensionState = mirroredExtension
+                            timelineRawBoundaryExtensionState = .none
+                        }
+                        crossDayFollowEventAt = Date()
+                    }
+                    let postFrac = (virtualP - preMotion) / max(postMotion, 1)
+                    y = swapPost + (settlePost - swapPost) * postFrac
+                }
+                if tickCount % 3 == 1 {
+                    NSLog("[#follow] tick=%d progress=%.3f virtualP=%.2f y=%.2f swapDone=%d",
+                          tickCount, progress, virtualP, y, swapDone ? 1 : 0)
+                }
+                let clampedY = max(0, y)
+                var t = Transaction()
+                t.disablesAnimations = true
+                withTransaction(t) {
+                    verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: clampedY))
+                }
+            },
+            onComplete: {
+                // Safety net: if progress never quite reached `preMotion`
+                // (preMotion≈0 edge cases, or very tiny totalMotion), make
+                // sure the swap fires before we close the extension.
+                if !swapDone {
+                    NSLog("[#follow] onComplete: swap not yet done, firing now")
+                    swapDone = true
+                    var swapTx = Transaction()
+                    swapTx.disablesAnimations = true
+                    withTransaction(swapTx) {
+                        calendarState.selectedDayOffset = newHostDayOffset
+                        timelineBoundaryExtensionState = mirroredExtension
+                        timelineRawBoundaryExtensionState = .none
+                        verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: swapPost))
+                    }
+                    crossDayFollowEventAt = Date()
+                }
+                NSLog("[#follow] COMPLETE at scrollY=%.2f → applyState(.none) for clean close",
+                      timelineVerticalScrollY)
+                // Route close through applyTimelineBoundaryExtensionState
+                // which compensates scrollY for the leading collapse case.
+                // For trailing-only collapse it's a no-op on scrollY (no
+                // leadingHours change), and contentH shrink at scrollY=0
+                // doesn't clamp. Both directions end silently.
+                applyTimelineBoundaryExtensionState(.none)
+                crossDayRebounceAnimator = nil
+                suppressDayColumnHorizontalAnimation = false
+                NSLog("[#follow] all done: scrollY=%.2f effExt=(l=%d,t=%d)",
+                      timelineVerticalScrollY,
+                      timelineBoundaryExtensionState.leadingHours,
+                      timelineBoundaryExtensionState.trailingHours)
+            }
         )
     }
 

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1772,13 +1772,19 @@ private extension CalendarPageView {
                 )
                 monthLegendBar(metrics: metrics)
             } else {
-                VerticalScrollGate(isScrolling: isVerticallyScrolling) {
-                    header(
-                        metrics: metrics,
-                        isCapsulesVisible: topOverlayCapsulesVisible,
-                        isActionCapsulesVisible: topOverlayActionCapsulesVisible
-                    )
-                }
+                // Header is intentionally OUTSIDE `VerticalScrollGate` —
+                // the gate freezes its subtree's body re-evaluation while
+                // the user is vertically scrolling (which is fine for the
+                // heavy timeline content), but the header date label needs
+                // to reactively follow `timelineVerticalScrollY` during
+                // scroll in extended view (leading=12 / trailing=12 spans
+                // multiple days; the visible day flips as the user crosses
+                // a 12h*hourHeight scroll threshold). (#55 follow-on)
+                header(
+                    metrics: metrics,
+                    isCapsulesVisible: topOverlayCapsulesVisible,
+                    isActionCapsulesVisible: topOverlayActionCapsulesVisible
+                )
                 if showsDateLegend {
                     dateLegendBar(metrics: metrics)
                         .offset(y: dateLegendVerticalNudge)

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1137,6 +1137,14 @@ struct CalendarPageView: View {
     /// before the atomic swap, cleared at phase 2 onComplete.
     /// (#55 follow-event-across-midnight)
     @State private var suppressDayColumnHorizontalAnimation: Bool = false
+    /// Set at follow-event entry to the target host-day offset. The header
+    /// reads this as a preferred override over `selectedDayOffset` until
+    /// the animator completes — without it, the brief window between
+    /// drag-end (drag-driven header date drops out: `draggingEventID=nil`)
+    /// and the boundary-tick swap (selectedDayOffset still old) would
+    /// flash the header back to the original day. Cleared at follow-event
+    /// completion. (#55 follow-event header continuity)
+    @State private var pendingFollowEventDayOverride: Int? = nil
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -2149,7 +2157,18 @@ private extension CalendarPageView {
 private extension CalendarPageView {
     /// The date the header capsule currently represents (tracks scroll + drag).
     var currentHeaderDisplayDate: Date {
-        calendarResolvedHeaderDisplayDate(
+        // Follow-event override: forcefully pin to the override day. The
+        // default scroll-derived computation would map viewport-top to a
+        // time on the OLD day (e.g. yesterday 12:00 at scrollY=0 when
+        // leading=12 post-swap), and `startOfDay` would resolve to
+        // yesterday — defeating the override. Pin instead so the header
+        // shows the new day uninterrupted across drag-end → boundary-tick
+        // → animator completion. (#55 follow-event header continuity)
+        if let override = pendingFollowEventDayOverride {
+            let date = calendarDateForSelectedDayOffset(override)
+            return Calendar.current.startOfDay(for: date)
+        }
+        return calendarResolvedHeaderDisplayDate(
             selectedDayOffset: calendarState.selectedDayOffset,
             rangeMode: calendarState.rangeMode,
             currentScrollY: timelineVerticalScrollY,
@@ -2177,20 +2196,28 @@ private extension CalendarPageView {
         isCapsulesVisible: Bool,
         isActionCapsulesVisible: Bool
     ) -> some View {
-        let headerDisplayDate = calendarResolvedHeaderDisplayDate(
-            selectedDayOffset: calendarState.selectedDayOffset,
-            rangeMode: calendarState.rangeMode,
-            currentScrollY: timelineVerticalScrollY,
-            headerHeight: timelineHeaderHeight,
-            hourHeight: calendarState.timelineHourHeight,
-            boundaryExtensionState: timelineBoundaryExtensionState,
-            draggingEventID: timelineDragState.draggingEventID,
-            dragMode: timelineDragState.dragMode,
-            dragTouchPointGlobal: timelineDragState.currentTouchPointGlobal,
-            timelineFrameGlobal: timelineVisibleDayFrameGlobal
-        )
+        // See `currentHeaderDisplayDate` — same follow-event override.
+        let headerDisplayDate: Date = {
+            if let override = pendingFollowEventDayOverride {
+                let date = calendarDateForSelectedDayOffset(override)
+                return Calendar.current.startOfDay(for: date)
+            }
+            return calendarResolvedHeaderDisplayDate(
+                selectedDayOffset: calendarState.selectedDayOffset,
+                rangeMode: calendarState.rangeMode,
+                currentScrollY: timelineVerticalScrollY,
+                headerHeight: timelineHeaderHeight,
+                hourHeight: calendarState.timelineHourHeight,
+                boundaryExtensionState: timelineBoundaryExtensionState,
+                draggingEventID: timelineDragState.draggingEventID,
+                dragMode: timelineDragState.dragMode,
+                dragTouchPointGlobal: timelineDragState.currentTouchPointGlobal,
+                timelineFrameGlobal: timelineVisibleDayFrameGlobal
+            )
+        }()
+        let effectiveDayOffset = pendingFollowEventDayOverride ?? calendarState.selectedDayOffset
         let leftCapsuleTitle = calendarResolvedHeaderCapsuleTitle(
-            selectedDayOffset: calendarState.selectedDayOffset,
+            selectedDayOffset: effectiveDayOffset,
             rangeMode: calendarState.rangeMode,
             headerDisplayDate: headerDisplayDate
         )
@@ -3986,6 +4013,11 @@ private extension CalendarPageView {
             NSLog("[#follow] SKIP — |dayDelta|=%d > 1", abs(dayDelta))
             return
         }
+        // Set the header day-override immediately so the brief drag-end →
+        // boundary-tick window doesn't flash the header back to the
+        // original day. The header reads this in preference to
+        // `selectedDayOffset` until the animator clears it.
+        pendingFollowEventDayOverride = newHostDayOffset
         let hourHeight = calendarState.timelineHourHeight
         let extensionMaxHours = calendarTimelineMaximumBoundaryExtensionHours
         let mirroredExtension: TimelineBoundaryExtensionState
@@ -4197,6 +4229,7 @@ private extension CalendarPageView {
                 applyTimelineBoundaryExtensionState(.none)
                 crossDayRebounceAnimator = nil
                 suppressDayColumnHorizontalAnimation = false
+                pendingFollowEventDayOverride = nil
                 NSLog("[#follow] all done: scrollY=%.2f effExt=(l=%d,t=%d)",
                       timelineVerticalScrollY,
                       timelineBoundaryExtensionState.leadingHours,

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2881,15 +2881,31 @@ private extension CalendarPageView {
                             }
                         },
                         onComplete: { [self] in
+                            sameDayRebounceAnimator = nil
+                            // Re-engaged on the completion frame → don't collapse
+                            // out from under a now-active drag; keep the band
+                            // solid and bail (mirrors onTick's guard). (#55)
+                            guard timelineRawBoundaryExtensionState.source == nil else {
+                                var tx = Transaction(); tx.disablesAnimations = true
+                                withTransaction(tx) {
+                                    timelineLeadingFadeProgress = 0
+                                    timelineTrailingFadeProgress = 0
+                                }
+                                return
+                            }
                             // The band is off-screen and the displayed content
                             // (base day from 0:00) is IDENTICAL before and after
                             // the collapse — only the 1-frame contentSize+scroll
                             // co-commit flashes. Cover it with a brief opacity
                             // dip: fade out → instant collapse while dim → fade
                             // back in, so the flash lands while invisible. (#55)
-                            sameDayRebounceAnimator = nil
                             withAnimation(.easeIn(duration: 0.09)) { timelineCollapseDim = 0 }
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.09) { [self] in
+                                // Re-engaged during the dim window → restore, skip.
+                                guard timelineRawBoundaryExtensionState.source == nil else {
+                                    withAnimation(.easeOut(duration: 0.14)) { timelineCollapseDim = 1 }
+                                    return
+                                }
                                 var tx = Transaction(); tx.disablesAnimations = true
                                 withTransaction(tx) {
                                     applyTimelineBoundaryExtensionState(.none)
@@ -3071,8 +3087,16 @@ private extension CalendarPageView {
         pendingBoundaryExtensionScrollTask = nil
         boundaryExtensionScrollAnimator?.cancel(reason: "clearState")
         boundaryExtensionScrollAnimator = nil
+        sameDayRebounceAnimator?.cancel()
+        sameDayRebounceAnimator = nil
         liveBoundaryExtensionAnimating.value = false
         boundaryExtensionVisualYOffset = 0
+        // Restore the abandon-collapse opacity dip + per-side fades so a
+        // teardown landing mid-animation (leave day mode / change day / detail
+        // route) can't strand the timeline dim or faded. (#55)
+        timelineCollapseDim = 1
+        timelineLeadingFadeProgress = 0
+        timelineTrailingFadeProgress = 0
         timelineRawBoundaryExtensionState = .none
         timelineBoundaryExtensionState = .none
     }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1042,6 +1042,21 @@ struct CalendarPageView: View {
     // `timelineLayer`.  Passed down to EventBlock so its struct identity
     // does not change on pinch.
     @State private var liveHourHeight = CalendarHourHeightBox()
+    /// See [[#55]] — animator START sets value=true, COMPLETE/CANCEL sets
+    /// false. EventBlock.Coordinator reads this to suppress vertical
+    /// auto-scroll while the spring open transition is in flight.
+    @State private var liveBoundaryExtensionAnimating = CalendarBoundaryExtensionAnimatingBox()
+    /// #55: visual y-offset applied to TimelineView content during the
+    /// boundary-extension OPEN animation. Cancels the layout jump caused
+    /// by `leading` snapping to 12 in logical state while scroll catches
+    /// up over 0.28s. Computed each animator tick as `scrollY - targetY`
+    /// (negative during animation, 0 at end), so events stay glued to the
+    /// finger position visually:
+    ///   event_viewport_y = layout_y + dragOffset.y + visualOffset - scrollY
+    ///                    = layout_y + dragOffset.y + (scrollY - targetY) - scrollY
+    ///                    = layout_y + dragOffset.y - targetY
+    /// which equals the pre-open position + finger delta.
+    @State private var boundaryExtensionVisualYOffset: CGFloat = 0
     @State private var selectedEventDetailRoute: CalendarEventDetailRoute? = nil
     @State private var selectedEventChatOccurrence: CalendarEventOccurrenceContext? = nil
     @State private var selectedEventForEdit: Event? = nil
@@ -1097,6 +1112,11 @@ struct CalendarPageView: View {
     @State private var isVerticallyScrolling: Bool = false
     @State private var timelineVisibleDayFrameGlobal: CGRect = .zero
     @State private var pendingBoundaryExtensionScrollTask: Task<Void, Never>? = nil
+    /// Spring animator for the proactive boundary-extension OPEN transition
+    /// during drag. CADisplayLink-paced, runs scrollTo 60×/sec over ~0.28s in
+    /// lockstep with `.animation(_:value:leading)` so the canvas unfolds
+    /// smoothly instead of snapping. (#55)
+    @State private var boundaryExtensionScrollAnimator: BoundaryExtensionScrollAnimator? = nil
     @State private var progressiveCacheTask: Task<Void, Never>? = nil
     /// Captured page geometry, written by `.onGeometryChange` on the body root.
     /// Reading geometry through @State (instead of a top-level GeometryReader
@@ -2540,6 +2560,10 @@ private extension CalendarPageView {
     }
 
     func handleTimelineBoundaryExtensionStateChange(_ newState: TimelineBoundaryExtensionState) {
+        NSLog("[#55ext] handleStateChange entry raw=(l=%d,t=%d,src=%@) currentEffective=(l=%d,t=%d) animator=%@",
+              newState.leadingHours, newState.trailingHours, String(describing: newState.source),
+              timelineBoundaryExtensionState.leadingHours, timelineBoundaryExtensionState.trailingHours,
+              boundaryExtensionScrollAnimator == nil ? "nil" : "running")
         // Extended view is only supported in day view — multi-day
         // columns are too narrow for meaningful extended interaction.
         guard calendarState.rangeMode == .day else {
@@ -2553,6 +2577,8 @@ private extension CalendarPageView {
             currentState: timelineBoundaryExtensionState,
             rawState: newState
         )
+        NSLog("[#55ext] handleStateChange retained=(l=%d,t=%d,src=%@)",
+              retainedState.leadingHours, retainedState.trailingHours, String(describing: retainedState.source))
         applyTimelineBoundaryExtensionState(retainedState)
 
         // When the drag source clears (finger lifted) near max
@@ -2618,19 +2644,74 @@ private extension CalendarPageView {
             hourHeight: calendarState.timelineHourHeight
         )
 
+        NSLog("[#55ext] applyState prev=(l=%d,t=%d) new=(l=%d,t=%d,src=%@) currentScrollY=%.2f targetY=%@",
+              previousState.leadingHours, previousState.trailingHours,
+              newState.leadingHours, newState.trailingHours,
+              String(describing: newState.source),
+              timelineVerticalScrollY,
+              targetY.map { String(format: "%.2f", $0) } ?? "nil")
+
         timelineBoundaryExtensionState = newState
 
         guard let targetY else { return }
 
         pendingBoundaryExtensionScrollTask?.cancel()
+        if boundaryExtensionScrollAnimator != nil {
+            boundaryExtensionScrollAnimator?.cancel(reason: "applyState reentry")
+            boundaryExtensionScrollAnimator = nil
+            liveBoundaryExtensionAnimating.value = false
+            boundaryExtensionVisualYOffset = 0
+        }
         let targetPoint = CGPoint(x: 0, y: targetY)
+
+        // Spring-animate scroll when opening the extension during drag
+        // (#55): SwiftUI ScrollPosition.scrollTo snaps in one frame on iOS
+        // 26 regardless of ambient animation, so we feed it 60 interpolated
+        // targets/sec from a CADisplayLink. The `.animation(_:value:)`
+        // modifier on `leading` springs over the same 0.28s duration, so
+        // both canvas height and scroll position move on the same time
+        // axis and the dragged event stays glued to its visible window
+        // position as the canvas unfolds above it.
+        if leadingOpened, newState.source == .moveDrag || newState.source == .resizeTop {
+            let startY = timelineVerticalScrollY
+            let delta = targetY - startY
+            NSLog("[#55ext] animator START from=%.2f to=%.2f delta=%.2f", startY, targetY, delta)
+            liveBoundaryExtensionAnimating.value = true
+            // Seed the visual offset to -delta so the first rendered frame
+            // shows pre-open positions (cancels the leading-snap layout jump).
+            boundaryExtensionVisualYOffset = -delta
+            boundaryExtensionScrollAnimator = BoundaryExtensionScrollAnimator(
+                onTick: { progress in
+                    let y = startY + delta * progress
+                    // offset = scrollY - targetY: at progress=0 → -delta, at progress=1 → 0.
+                    // Keeps events glued to their pre-open visible position throughout the spring.
+                    let offset = y - targetY
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        verticalScrollPosition.scrollTo(point: CGPoint(x: 0, y: y))
+                        boundaryExtensionVisualYOffset = offset
+                    }
+                },
+                onComplete: {
+                    NSLog("[#55ext] animator COMPLETE")
+                    liveBoundaryExtensionAnimating.value = false
+                    boundaryExtensionVisualYOffset = 0
+                    boundaryExtensionScrollAnimator = nil
+                }
+            )
+            return
+        }
+
         if calendarShouldApplyBoundaryExtensionScrollCompensationImmediately(source: newState.source) {
             pendingBoundaryExtensionScrollTask = nil
             var transaction = Transaction()
             transaction.disablesAnimations = true
+            NSLog("[#55ext] scrollTo IMMEDIATE target=%.2f preScrollY=%.2f", targetY, timelineVerticalScrollY)
             withTransaction(transaction) {
                 verticalScrollPosition.scrollTo(point: targetPoint)
             }
+            NSLog("[#55ext] scrollTo IMMEDIATE returned postScrollY=%.2f", timelineVerticalScrollY)
             return
         }
         pendingBoundaryExtensionScrollTask = Task { @MainActor in
@@ -2638,9 +2719,11 @@ private extension CalendarPageView {
             guard !Task.isCancelled else { return }
             var transaction = Transaction()
             transaction.disablesAnimations = true
+            NSLog("[#55ext] scrollTo DEFERRED target=%.2f preScrollY=%.2f", targetY, timelineVerticalScrollY)
             withTransaction(transaction) {
                 verticalScrollPosition.scrollTo(point: targetPoint)
             }
+            NSLog("[#55ext] scrollTo DEFERRED returned postScrollY=%.2f", timelineVerticalScrollY)
         }
     }
 
@@ -2662,6 +2745,13 @@ private extension CalendarPageView {
             leadingVisible: visibility.leadingVisible,
             trailingVisible: visibility.trailingVisible
         )
+        NSLog("[#55ext] collapse check scrollY=%.2f leadingVis=%d trailingVis=%d cur=(l=%d,t=%d) collapsed=(l=%d,t=%d) willCollapse=%d animator=%@",
+              timelineVerticalScrollY,
+              visibility.leadingVisible ? 1 : 0, visibility.trailingVisible ? 1 : 0,
+              timelineBoundaryExtensionState.leadingHours, timelineBoundaryExtensionState.trailingHours,
+              collapsedState.leadingHours, collapsedState.trailingHours,
+              collapsedState != timelineBoundaryExtensionState ? 1 : 0,
+              boundaryExtensionScrollAnimator == nil ? "nil" : "running")
         guard collapsedState != timelineBoundaryExtensionState else { return }
         // Mirror the drag-end dismiss path's `disablesAnimations` guard
         // (see 2580-2591). `applyTimelineBoundaryExtensionState` now snaps
@@ -2687,6 +2777,10 @@ private extension CalendarPageView {
     func clearTimelineBoundaryExtensionState() {
         pendingBoundaryExtensionScrollTask?.cancel()
         pendingBoundaryExtensionScrollTask = nil
+        boundaryExtensionScrollAnimator?.cancel(reason: "clearState")
+        boundaryExtensionScrollAnimator = nil
+        liveBoundaryExtensionAnimating.value = false
+        boundaryExtensionVisualYOffset = 0
         timelineRawBoundaryExtensionState = .none
         timelineBoundaryExtensionState = .none
     }
@@ -2767,6 +2861,12 @@ private extension CalendarPageView {
         }
         .onScrollGeometryChange(for: ScrollGeometry.self, of: { $0 }) { _, newValue in
             let scrollY = newValue.contentOffset.y
+            if timelineBoundaryExtensionState.hasAnyExtension || timelineRawBoundaryExtensionState.hasAnyExtension || boundaryExtensionScrollAnimator != nil {
+                NSLog("[#55ext] scrollGeom raw scrollY=%.2f contentH=%.2f viewportH=%.2f extL=%d rawL=%d animator=%@",
+                      scrollY, newValue.contentSize.height, newValue.visibleRect.height,
+                      timelineBoundaryExtensionState.leadingHours, timelineRawBoundaryExtensionState.leadingHours,
+                      boundaryExtensionScrollAnimator == nil ? "nil" : "running")
+            }
             // Pull down past the top to reveal reminders; scroll up to collapse.
             updateReminderPanelForScroll(scrollY)
             // Viewport height almost never changes during a scroll — gate the
@@ -2802,6 +2902,11 @@ private extension CalendarPageView {
             if abs(scrollY - timelineVerticalScrollY) >= 2 {
                 cancelResizeGrace(reason: "timeline.verticalScroll")
                 timelineVerticalScrollY = scrollY
+                if timelineBoundaryExtensionState.hasAnyExtension || timelineRawBoundaryExtensionState.hasAnyExtension || boundaryExtensionScrollAnimator != nil {
+                    NSLog("[#55ext] scrollGeom scrollY=%.2f extLeading=%d rawLeading=%d animator=%@",
+                          scrollY, timelineBoundaryExtensionState.leadingHours, timelineRawBoundaryExtensionState.leadingHours,
+                          boundaryExtensionScrollAnimator == nil ? "nil" : "running")
+                }
             }
             collapseTimelineBoundaryExtensionsIfNeeded(topOverlayInset: topOverlayInset)
             // Keep header capsules always visible — don't hide on scroll.
@@ -2857,6 +2962,8 @@ private extension CalendarPageView {
             rangeMode: $calendarState.rangeMode,
             hourHeight: timelineHourHeightBinding,
             liveHourHeight: liveHourHeight,
+            liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
+            boundaryExtensionVisualYOffset: boundaryExtensionVisualYOffset,
             isDayOffsetFrozen: calendarState.isDayOffsetFrozen,
             daysCount: timelineDaysCount(for: calendarState.rangeMode),
             mode: .preview,

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2678,42 +2678,67 @@ private extension CalendarPageView {
         let leading = timelineBoundaryExtensionState.leadingHours
         let trailing = timelineBoundaryExtensionState.trailingHours
 
-        // FINGER-DRIVEN fade. The dragged edge = original edge + drag offset
-        // (move shifts both; resizeTop shifts start; resizeBottom shifts end —
-        // leading keys on start, trailing on end, so this is correct for all).
+        // STAGE 1 — finger-driven dim, CAPPED below full transparency. The
+        // dragged edge = original edge + drag offset (move shifts both;
+        // resizeTop shifts start; resizeBottom shifts end — leading keys on
+        // start, trailing on end). As you pull the edge back into the day the
+        // band dims, but only to `stage1MaxFade` (never empties → no in-view
+        // gap). (#55 two-stage fade)
         let offsetHours = Double(timelineDragState.dragOffset.y) / Double(hh)
         let cal = Calendar.current
         let dayStart = cal.startOfDay(for: original.start)
-        let abandonFadeStartHours: Double = 4   // tunable: dissolve begins here
-        let abandonFadeRangeHours: Double = 4   // tunable: fully gone after this
-        func ramp(_ distHours: Double) -> CGFloat {
-            CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours)))
+        let abandonFadeStartHours: Double = 4   // tunable: dim begins here
+        let abandonFadeRangeHours: Double = 4   // tunable: reaches the cap after this
+        let stage1MaxFade: CGFloat = 0.6        // tunable: opacity floor = 1 - this
+        func stage1(_ distHours: Double) -> CGFloat {
+            min(stage1MaxFade, CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours))))
         }
-        // Per-side fade — leading and trailing dissolve INDEPENDENTLY.
+
+        // STAGE 2 — ABSOLUTE position fade keyed on WHERE THE MIDNIGHT LINE is
+        // relative to the viewport edge (scroll only moves it indirectly). The
+        // band fully fades as its boundary (0:00 / 24:00) reaches the edge. At
+        // min pinch the band is tiny and the boundary already sits near the
+        // edge → it can reach full transparency with little/no scroll; at max
+        // pinch the boundary is deep in view → it needs the edge to come to it.
+        // Pure opacity (no scroll write → no detach).
+        let extensionOriginY = topOverlayInset + timelineAllDayHeight + timelineHeaderHeight
+        let visibleTop = max(0, timelineVerticalScrollY)
+        let visibleBottom = visibleTop + timelineScrollViewportHeight
+        func combine(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat { 1 - (1 - s1) * (1 - s2) }
+
         var fadeTx = Transaction()
         fadeTx.disablesAnimations = true
         if leading > 0 {
-            // distance of the dragged START past the 0:00 boundary INTO today.
             let liveStart = original.start.addingTimeInterval(offsetHours * 3600)
-            let lf = ramp(liveStart.timeIntervalSince(dayStart) / 3600)
-            if abs(timelineLeadingFadeProgress - lf) > 0.001 {
-                withTransaction(fadeTx) { timelineLeadingFadeProgress = lf }
+            let s1 = stage1(liveStart.timeIntervalSince(dayStart) / 3600)
+            let bandHeight = CGFloat(leading) * hh
+            // d = how far the 0:00 line sits below the viewport top.
+            // 0 = boundary at the top (band fully off) → s2 = 1.
+            let d = (extensionOriginY + bandHeight) - visibleTop
+            let s2 = max(0, min(1, 1 - d / bandHeight))
+            let f = combine(s1, s2)
+            if abs(timelineLeadingFadeProgress - f) > 0.001 {
+                withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
             }
         }
         if trailing > 0 {
-            // distance of the dragged END pulled up past the 24:00 boundary.
             let dayEnd = dayStart.addingTimeInterval(24 * 3600)
             let liveEnd = original.end.addingTimeInterval(offsetHours * 3600)
-            let tf = ramp(dayEnd.timeIntervalSince(liveEnd) / 3600)
-            if abs(timelineTrailingFadeProgress - tf) > 0.001 {
-                withTransaction(fadeTx) { timelineTrailingFadeProgress = tf }
+            let s1 = stage1(dayEnd.timeIntervalSince(liveEnd) / 3600)
+            let bandHeight = CGFloat(trailing) * hh
+            let bandTop = extensionOriginY
+                + CGFloat(leading + calendarTimelineBaseVisibleHours) * hh
+            // d = how far the 24:00 line sits above the viewport bottom.
+            let d = visibleBottom - bandTop
+            let s2 = max(0, min(1, 1 - d / bandHeight))
+            let f = combine(s1, s2)
+            if abs(timelineTrailingFadeProgress - f) > 0.001 {
+                withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
             }
         }
-        // NB: NO collapse here. Collapsing mid-drag changes contentH → forces a
-        // scroll compensation ("auto-recenter") that shifts the still-dragged
-        // event off the finger. During the drag we ONLY fade (opacity, no
-        // contentH/scroll change); the contentH collapse waits for release.
-        // (#55 follow-on)
+        // NB: still NO collapse here. Both stages are pure opacity (no contentH/
+        // scroll write → no auto-recenter, no detach). The contentH collapse
+        // waits for release. (#55 follow-on)
     }
 
     func handleTimelineBoundaryExtensionStateChange(_ newState: TimelineBoundaryExtensionState) {

--- a/Done/Views/Calendar/Components/Header/AppleCalendarHeaderView.swift
+++ b/Done/Views/Calendar/Components/Header/AppleCalendarHeaderView.swift
@@ -93,6 +93,11 @@ struct AppleCalendarHeaderView: View {
     let leftCapsuleSubtitle: String
     let isCapsulesVisible: Bool
     let isActionCapsuleVisible: Bool
+    /// When true, AnimatedCapsuleTitleText uses a slower, opacity-dominant
+    /// transition that perceptually matches the longer follow-event scroll
+    /// re-anchor animation (#55), so the day-label change doesn't read as
+    /// a hard "step" in the middle of a smooth vertical motion.
+    var leftCapsuleSlowTransition: Bool = false
     var onMonthTap: () -> Void
     var onMonthLongPress: () -> Void
     var onSelectRangeMode: (RangeMode) -> Void
@@ -109,6 +114,7 @@ struct AppleCalendarHeaderView: View {
         leftCapsuleSubtitle: String = "",
         isCapsulesVisible: Bool,
         isActionCapsuleVisible: Bool,
+        leftCapsuleSlowTransition: Bool = false,
         onMonthTap: @escaping () -> Void,
         onMonthLongPress: @escaping () -> Void,
         onSelectRangeMode: @escaping (RangeMode) -> Void,
@@ -124,6 +130,7 @@ struct AppleCalendarHeaderView: View {
         self.leftCapsuleSubtitle = leftCapsuleSubtitle
         self.isCapsulesVisible = isCapsulesVisible
         self.isActionCapsuleVisible = isActionCapsuleVisible
+        self.leftCapsuleSlowTransition = leftCapsuleSlowTransition
         self.onMonthTap = onMonthTap
         self.onMonthLongPress = onMonthLongPress
         self.onSelectRangeMode = onSelectRangeMode
@@ -235,7 +242,7 @@ struct AppleCalendarHeaderView: View {
                         Image(systemName: "chevron.left")
                             .font(.system(size: 13, weight: .semibold))
                         VStack(alignment: .leading, spacing: 0) {
-                            AnimatedCapsuleTitleText(title: leftCapsuleTitle)
+                            AnimatedCapsuleTitleText(title: leftCapsuleTitle, slowTransition: leftCapsuleSlowTransition)
                             if !leftCapsuleSubtitle.isEmpty {
                                 Text(leftCapsuleSubtitle)
                                     .font(.system(size: 11, weight: .medium))
@@ -351,6 +358,7 @@ private struct AnimatedCapsuleTitleText: View {
     @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
 
     let title: String
+    let slowTransition: Bool
 
     @State private var displayedTitle: String
     @State private var outgoingTitle: String?
@@ -359,8 +367,9 @@ private struct AnimatedCapsuleTitleText: View {
     @State private var slideDirection: CGFloat = 1
     @State private var cleanupTask: Task<Void, Never>?
 
-    init(title: String) {
+    init(title: String, slowTransition: Bool = false) {
         self.title = title
+        self.slowTransition = slowTransition
         _displayedTitle = State(initialValue: title)
     }
 
@@ -399,7 +408,13 @@ private struct AnimatedCapsuleTitleText: View {
 
         let wasAnimating = transitionProgress < 0.95
         cleanupTask?.cancel()
-        if accessibilityReduceMotion {
+        if accessibilityReduceMotion || slowTransition {
+            // `slowTransition` mode: follow-event re-anchor (#55) drives the
+            // perception through the scroll motion itself; an additional
+            // label slide/fade on top breaks coherence (either too fast =
+            // mid-scroll "click", or too slow = label still settling after
+            // scroll done). Snap the label instantly and let the scroll
+            // carry the temporal sense.
             outgoingTitle = nil
             displayedTitle = newValue
             transitionProgress = 1

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -722,11 +722,30 @@ final class DayLayerHostView: UIView {
         // KVO callbacks land on the main thread for a main-thread scroll view.
         scrollOffsetObservation = sv.observe(\.contentOffset, options: [.new]) { [weak self] _, _ in
             self?.cullViewportIfChanged()
+            // Window-frame moves with content offset; the header's
+            // touch-driven date calc reads it to convert finger.y → canvas-y.
+            // Without this, the date is stuck at scrollY=0's value during
+            // drag (gh#55 follow-on: 14→13→14→15 only saw 14→13→14).
+            self?.reportVisibleFrameIfNeeded()
         }
         // Bounds size changes (rotation / split-view) also move the visible rect.
         scrollBoundsObservation = sv.observe(\.bounds, options: [.new]) { [weak self] _, _ in
             self?.cullViewportIfChanged()
+            self?.reportVisibleFrameIfNeeded()
         }
+    }
+
+    /// The last value handed to `onVisibleTimelineFrameChange`. Tracked so
+    /// we don't spam the @State setter every scroll tick when nothing moved.
+    private var lastReportedVisibleFrame: CGRect = .null
+
+    private func reportVisibleFrameIfNeeded() {
+        guard let callback = gestureController.callbacks.onVisibleTimelineFrameChange else { return }
+        guard window != nil, bounds.width > 0, bounds.height > 0 else { return }
+        let frame = convert(bounds, to: nil)
+        guard frame != lastReportedVisibleFrame else { return }
+        lastReportedVisibleFrame = frame
+        callback(frame)
     }
 
     private func detachScrollObserver() {
@@ -838,7 +857,10 @@ final class DayLayerHostView: UIView {
             // The enclosing scroll view is only resolvable once we're in the
             // hierarchy; (re)attach the scroll observer that drives S6 re-cull.
             attachScrollObserverIfNeeded()
+            // First chance to know our window-relative frame.
+            reportVisibleFrameIfNeeded()
         } else {
+            lastReportedVisibleFrame = .null
             nowLineTimer?.invalidate()
             nowLineTimer = nil
             detachScrollObserver()
@@ -1259,6 +1281,9 @@ final class DayLayerHostView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        // Report window-relative frame to the host (#55 follow-on) so the
+        // header's touch-driven date calc has a current `timelineFrameGlobal`.
+        reportVisibleFrameIfNeeded()
         guard let model = currentModel else { return }
         // Cheap-repaint decision (S3): if the structural identity is unchanged
         // since the last FULL render, the only thing that moved is the vertical

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -2036,13 +2036,12 @@ final class DayLayerHostView: UIView {
             dayColumnStep: session.mode == .move ? model.dragPreviewDayStep : 0
         ) ?? occurrence.range
         // Use the EXTENDED visible window so the live preview keeps tracking
-        // the finger when the dragged range crosses midnight into the leading
-        // / trailing extension area. Using the base 24h window here would
-        // make `calendarAdjustedOccurrenceRange` snap the block back to its
-        // original position the moment the preview fully crosses midnight,
-        // and the block then disappears off-screen (extended scroll is far
-        // from the original canvas y). Resize stays clipped to the base day
-        // window since resized blocks cannot legitimately cross midnight.
+        // the finger when the dragged / resized range crosses midnight into
+        // the leading / trailing extension area. Using the base 24h window
+        // here would make `calendarAdjustedOccurrenceRange` snap a move
+        // block back to its original position (and chop a resized block's
+        // portion past midnight) the moment the preview fully crosses
+        // midnight. (#55 follow-on)
         let visibleStart = calendarTimelineVisibleStart(
             containing: model.date,
             leadingExtendedHours: model.leadingExtendedHours
@@ -2051,8 +2050,6 @@ final class DayLayerHostView: UIView {
             containing: model.date,
             trailingExtendedHours: model.trailingExtendedHours
         )
-        let baseDayStart = Calendar.current.startOfDay(for: model.date)
-        let baseDayEnd = Calendar.current.date(byAdding: .day, value: 1, to: baseDayStart) ?? baseDayStart
         let adjusted: Event.TimeRange
         if session.mode == .move {
             adjusted = calendarAdjustedOccurrenceRange(
@@ -2069,14 +2066,17 @@ final class DayLayerHostView: UIView {
             // Resize: `calendarAdjustedOccurrenceRange` honors the preview only
             // for `.move` (`isActiveDraggedOccurrence` gates on `== .move`), so a
             // resize would freeze at the original range — the "extend doesn't
-            // grow" bug. A resized range stays within the day, so clip the live
-            // preview to the day window directly.
+            // grow" bug. A resized range can legitimately cross midnight WHEN
+            // extended view is active (the user resized far enough to reach the
+            // leading/trailing extension area), so clip to the EXTENDED visible
+            // window — not the base 24h day, which would chop off the portion
+            // of the resized block past midnight. (#55 follow-on)
             // Allow a zero / near-zero span at the flip crossing point (block
             // shrinks to nothing as the edges meet). Do NOT fall back to
             // `occurrence.range` there — that flashes the block at its ORIGINAL
             // height for one frame as the dragged edge crosses the anchor.
-            let clippedStart = max(preview.start, baseDayStart)
-            let clippedEnd = min(preview.end, baseDayEnd)
+            let clippedStart = max(preview.start, visibleStart)
+            let clippedEnd = min(preview.end, visibleEnd)
             adjusted = Event.TimeRange(start: clippedStart, end: max(clippedStart, clippedEnd))
         }
         return CalendarLayout.EventOccurrence(

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -1423,9 +1423,28 @@ final class DayLayerHostView: UIView {
             )
         }()
         if let creationDraft { overlapCandidates.append(creationDraft) }
+        // Use the EXTENDED visible window for overlap detection so events in
+        // the leading 12h / trailing 12h extension area (yesterday's late
+        // hours / tomorrow's early hours) participate in cluster detection.
+        // The convenience `overlapLayout(for:on:)` overload clips to a base
+        // 24h day window, which makes extension-area events drop out of all
+        // clusters (their clipped duration is zero) and fall back to the
+        // default full-width slot — so the dragged preview lands on top of
+        // them instead of forcing a width split. Multi-day never opens
+        // extensions (calendar-state gate), so this widening is a no-op
+        // outside single-day. (#55 live-overlap follow-on)
+        let overlapVisibleStart = calendarTimelineVisibleStart(
+            containing: model.date,
+            leadingExtendedHours: model.leadingExtendedHours
+        )
+        let overlapVisibleEnd = calendarTimelineVisibleEnd(
+            containing: model.date,
+            trailingExtendedHours: model.trailingExtendedHours
+        )
         let slots = CalendarLayout.overlapLayout(
             for: overlapCandidates,
-            on: model.date,
+            visibleStart: overlapVisibleStart,
+            visibleEnd: overlapVisibleEnd,
             peekFraction: peekFraction,
             peerTolerance: peerTolerance
         )
@@ -1441,7 +1460,8 @@ final class DayLayerHostView: UIView {
             }
             stableSlots = CalendarLayout.overlapLayout(
                 for: stableCandidates,
-                on: model.date,
+                visibleStart: overlapVisibleStart,
+                visibleEnd: overlapVisibleEnd,
                 peekFraction: peekFraction,
                 peerTolerance: peerTolerance
             )
@@ -1455,14 +1475,8 @@ final class DayLayerHostView: UIView {
             trailingExtendedHours: model.trailingExtendedHours
         )
 
-        let visibleStart = calendarTimelineVisibleStart(
-            containing: model.date,
-            leadingExtendedHours: model.leadingExtendedHours
-        )
-        let visibleEnd = calendarTimelineVisibleEnd(
-            containing: model.date,
-            trailingExtendedHours: model.trailingExtendedHours
-        )
+        let visibleStart = overlapVisibleStart
+        let visibleEnd = overlapVisibleEnd
 
         // S6 viewport: the buffered visible rect (this view's coords). `nil`
         // means "show all" (no scroll view resolved yet / non-scrolling

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -1368,10 +1368,25 @@ final class DayLayerHostView: UIView {
         // overlap layout columns the dragged event into this day's timeline.
         let synthesizedPreview: CalendarLayout.EventOccurrence? = {
             guard let preview = dragPreviewOccurrence else { return nil }
-            let cal = Calendar.current
-            let dayStart = cal.startOfDay(for: model.date)
-            let dayEnd = cal.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
-            guard preview.range.end > dayStart, preview.range.start < dayEnd else { return nil }
+            // Use the EXTENDED visible window so single-day drag past midnight
+            // still renders the preview in the column's leading/trailing
+            // extension area. The base 24h window is correct for multi-day
+            // (each column renders its own slice; cross-midnight siblings
+            // handle the other half), but single-day with extension active
+            // has no sibling — its extension area IS this column's leading
+            // 12h / trailing 12h, so the preview must keep rendering here
+            // even when its range fully crosses midnight. Multi-day never
+            // opens extensions (calendar gate), so this widening is no-op
+            // outside single-day. (#55 follow-on)
+            let visibleStart = calendarTimelineVisibleStart(
+                containing: model.date,
+                leadingExtendedHours: model.leadingExtendedHours
+            )
+            let visibleEnd = calendarTimelineVisibleEnd(
+                containing: model.date,
+                trailingExtendedHours: model.trailingExtendedHours
+            )
+            guard preview.range.end > visibleStart, preview.range.start < visibleEnd else { return nil }
             // Dedup against OTHER real occurrences of this event on this day
             // (e.g. a recurring projection), but NOT against the actively-dragged
             // occurrence itself — on the source day it's in `model.occurrences`
@@ -2006,8 +2021,24 @@ final class DayLayerHostView: UIView {
             hourHeight: model.hourHeight,
             dayColumnStep: session.mode == .move ? model.dragPreviewDayStep : 0
         ) ?? occurrence.range
-        let dayStart = Calendar.current.startOfDay(for: model.date)
-        let dayEnd = Calendar.current.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        // Use the EXTENDED visible window so the live preview keeps tracking
+        // the finger when the dragged range crosses midnight into the leading
+        // / trailing extension area. Using the base 24h window here would
+        // make `calendarAdjustedOccurrenceRange` snap the block back to its
+        // original position the moment the preview fully crosses midnight,
+        // and the block then disappears off-screen (extended scroll is far
+        // from the original canvas y). Resize stays clipped to the base day
+        // window since resized blocks cannot legitimately cross midnight.
+        let visibleStart = calendarTimelineVisibleStart(
+            containing: model.date,
+            leadingExtendedHours: model.leadingExtendedHours
+        )
+        let visibleEnd = calendarTimelineVisibleEnd(
+            containing: model.date,
+            trailingExtendedHours: model.trailingExtendedHours
+        )
+        let baseDayStart = Calendar.current.startOfDay(for: model.date)
+        let baseDayEnd = Calendar.current.date(byAdding: .day, value: 1, to: baseDayStart) ?? baseDayStart
         let adjusted: Event.TimeRange
         if session.mode == .move {
             adjusted = calendarAdjustedOccurrenceRange(
@@ -2017,8 +2048,8 @@ final class DayLayerHostView: UIView {
                 draggingOriginalRange: session.originalRange,
                 dragMode: session.mode,
                 previewRange: preview,
-                dayStart: dayStart,
-                dayEnd: dayEnd
+                dayStart: visibleStart,
+                dayEnd: visibleEnd
             ) ?? occurrence.range
         } else {
             // Resize: `calendarAdjustedOccurrenceRange` honors the preview only
@@ -2030,8 +2061,8 @@ final class DayLayerHostView: UIView {
             // shrinks to nothing as the edges meet). Do NOT fall back to
             // `occurrence.range` there — that flashes the block at its ORIGINAL
             // height for one frame as the dragged edge crosses the anchor.
-            let clippedStart = max(preview.start, dayStart)
-            let clippedEnd = min(preview.end, dayEnd)
+            let clippedStart = max(preview.start, baseDayStart)
+            let clippedEnd = min(preview.end, baseDayEnd)
             adjusted = Event.TimeRange(start: clippedStart, end: max(clippedStart, clippedEnd))
         }
         return CalendarLayout.EventOccurrence(

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -4801,7 +4801,10 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 }
                 let mode = currentMode
                 let didMove = hasMovedAfterLongPress
-                finalizeTouchInteraction()
+                // Defer preview clear (and skip the immediate STEP 5 paint
+                // below) for committing move releases. See `finalizeTouchInteraction`.
+                let isCommittingMoveRelease = forward && didMove && mode == .move
+                finalizeTouchInteraction(deferPreviewClear: isCommittingMoveRelease)
                 if forward && didMove {
                     switch mode {
                     case .move:
@@ -4832,7 +4835,16 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
                 // Clear the observed scratchpad (G-28 onDragTerminal consumer).
                 calendarResetSharedEventDragStateIfPresent()
                 eventSession = nil
-                host.renderLiveDragFrame()
+                // For committing move releases, skip the immediate paint: the
+                // layer tree's last drag frame (preview at finger + source
+                // hidden) is the correct visual to persist until SwiftUI's
+                // next render lands the committed range. Painting here with
+                // the still-stale model would flash the source at its OLD
+                // canvas position. (#55 release flicker; see
+                // `finalizeTouchInteraction(deferPreviewClear:)`)
+                if !isCommittingMoveRelease {
+                    host.renderLiveDragFrame()
+                }
                 return
             }
             // Pure long-press (no move past 8pt): resolve without commit (G-29).
@@ -5674,7 +5686,7 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         disabledScrollGestures.removeAll()
     }
 
-    private func finalizeTouchInteraction() {
+    private func finalizeTouchInteraction(deferPreviewClear: Bool = false) {
         stopAutoScroll()
         (activeGesture as? TracingLongPressGesture)?.isDragPromoted = false
         restoreScrollPanGestures()
@@ -5699,7 +5711,19 @@ final class CalendarDayGestureController: NSObject, UIGestureRecognizerDelegate 
         lastSnappedColumnCenterX = nil
         lastChipSnapFingerprint = nil
         lastChipSnapSize = nil
-        clearInGridPreview()
+        // Move-commit release defers the preview clear so the layer tree's
+        // last drag frame (preview at finger, source opacity 0) persists
+        // until SwiftUI re-renders with the committed range. Then render()'s
+        // synthesizedPreview dedup against the new model occurrence removes
+        // the preview layer atomically with the source layer appearing at
+        // its new position. Without this defer, the immediate clear paints
+        // a 1-frame "source at OLD position, opacity 1" flicker because
+        // `activeEventSession` already turned nil (hasPromotedManipulation
+        // flips false earlier in this method) but model still has the old
+        // occurrence range. (#55 release flicker)
+        if !deferPreviewClear {
+            clearInGridPreview()
+        }
     }
 
     // MARK: Per-hit capability + bounds (mirror TimelineDayView.eventBlock)

--- a/Done/Views/Calendar/Components/Timeline/Event/EventBlock.swift
+++ b/Done/Views/Calendar/Components/Timeline/Event/EventBlock.swift
@@ -1757,9 +1757,6 @@ struct EventBlockDragGesture: UIViewRepresentable {
             // ScrollPosition.scrollTo writes (opposite directions: user wants
             // up, animator compensates down). Resumed once animator completes.
             if parent.liveBoundaryExtensionAnimating?.value == true {
-                if autoScrollVelocityY != 0 {
-                    NSLog("[#55ext] EventBlock suppress autoScrollVelY (was %.1f)", autoScrollVelocityY)
-                }
                 autoScrollVelocityY = 0
             }
 

--- a/Done/Views/Calendar/Components/Timeline/Event/EventBlock.swift
+++ b/Done/Views/Calendar/Components/Timeline/Event/EventBlock.swift
@@ -1204,6 +1204,9 @@ struct EventBlockDragGesture: UIViewRepresentable {
     var snapSize: CGFloat // Points per 15-minute snap interval (must be set from hourHeight / 4)
     var horizontalAutoScrollEdgeInset: CGFloat = calendarHorizontalAutoScrollEdgeInsetDefault
     var verticalAutoScrollEdgeInset: CGFloat = calendarVerticalAutoScrollEdgeInsetDefault
+    /// When non-nil and `value == true`, vertical auto-scroll is suppressed
+    /// so it doesn't fight the boundary-extension OPEN spring animator (#55).
+    var liveBoundaryExtensionAnimating: CalendarBoundaryExtensionAnimatingBox? = nil
     var maxAutoScrollSpeed: CGFloat = calendarMaxAutoScrollSpeedDefault // pt/s
     var horizontalAutoScrollUnitStep: CGFloat = 0
     var usesHorizontalBoundaryPaging: Bool = false
@@ -1748,6 +1751,17 @@ struct EventBlockDragGesture: UIViewRepresentable {
                     : 0
             }
             autoScrollVelocityY = autoScrollVelocity(for: verticalScrollView, axis: .vertical)
+            // #55: suppress vertical auto-scroll while the boundary-extension
+            // open animator is running. Auto-scroll's per-frame
+            // setContentOffset writes would fight the animator's per-frame
+            // ScrollPosition.scrollTo writes (opposite directions: user wants
+            // up, animator compensates down). Resumed once animator completes.
+            if parent.liveBoundaryExtensionAnimating?.value == true {
+                if autoScrollVelocityY != 0 {
+                    NSLog("[#55ext] EventBlock suppress autoScrollVelY (was %.1f)", autoScrollVelocityY)
+                }
+                autoScrollVelocityY = 0
+            }
 
             // Keep the display link alive while the finger sits in the
             // horizontal edge zone during boundary paging — velocities are
@@ -2202,6 +2216,10 @@ struct EventBlock: View {
     // invalidate this view, so pinch-driven hourHeight writes no longer
     // re-evaluate EventBlock.body.  Read at drag/resize time only.
     let liveHourHeight: CalendarHourHeightBox
+    /// Shared flag; when true, the EventBlockDragGesture suppresses vertical
+    /// auto-scroll so it doesn't fight a SwiftUI-side scroll animator
+    /// (#55 boundary-extension open transition).
+    var liveBoundaryExtensionAnimating: CalendarBoundaryExtensionAnimatingBox? = nil
     // When true, the EventBlockDragGesture overlay is skipped.  Pinch and
     // drag are mutually exclusive at the iOS gesture-system level (two
     // fingers vs. single-finger long-press), so the gesture's worth nothing
@@ -2983,6 +3001,7 @@ struct EventBlock: View {
                         EventBlockDragGesture(
                             verticalEdgeInset: showsResizeHandles ? 0 : 6,
                             snapSize: snapSize,
+                            liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
                             horizontalAutoScrollUnitStep: dragPreviewDayStep,
                             usesHorizontalBoundaryPaging: dayColumnStep <= 0 && dragPreviewDayStep > 0,
                             verticalDragBounds: verticalDragBounds,

--- a/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
@@ -607,14 +607,32 @@ func calendarResolveAxisMarkerPresentation(
     )
 
     // Wrap-around markers (#53 B follow-on). When the live range extends
-    // past the anchor day in either direction, also compute the marker Y
-    // positions anchored to the ADJACENT day so the column-top / column-
-    // bottom view of the other half also shows a consistent pair of
-    // start/end pills.
-    let anchorDayStart = calendar.startOfDay(for: mappingState.anchorDate)
-    let anchorDayEnd = calendar.date(byAdding: .day, value: 1, to: anchorDayStart) ?? anchorDayStart
-    let extendsForward = mappingState.range.end > anchorDayEnd
-    let extendsBackward = mappingState.range.start < anchorDayStart
+    // past the anchor's VISIBLE window in either direction, also compute
+    // marker Y positions anchored to the ADJACENT day so the column-top /
+    // column-bottom view of the other half also shows a consistent pair
+    // of start/end pills.
+    //
+    // Use the EXTENDED visible window (not the base 24h day) so single-day
+    // drag past midnight INTO the leading/trailing extension area does NOT
+    // emit a duplicate pair: the extension area IS the cross-midnight
+    // representation in single-day mode, and a wrap anchored to the
+    // adjacent day would draw the second pair at a hour-of-day-aligned Y
+    // that visually collides with the base 24h area (e.g. "yesterday 10:00"
+    // wrapping to the same Y as "today 10:00"). Multi-day never opens
+    // extensions, so this widening only changes behavior for the
+    // single-day extended case. (#55 follow-on)
+    let visibleAnchorStart = calendarTimelineVisibleStart(
+        containing: mappingState.anchorDate,
+        leadingExtendedHours: leadingExtendedHours,
+        calendar: calendar
+    )
+    let visibleAnchorEnd = calendarTimelineVisibleEnd(
+        containing: mappingState.anchorDate,
+        trailingExtendedHours: trailingExtendedHours,
+        calendar: calendar
+    )
+    let extendsForward = mappingState.range.end > visibleAnchorEnd
+    let extendsBackward = mappingState.range.start < visibleAnchorStart
     let wrapAnchor: Date?
     if extendsForward {
         wrapAnchor = calendar.date(byAdding: .day, value: 1, to: mappingState.anchorDate)

--- a/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
@@ -32,6 +32,18 @@ final class CalendarHourHeightBox {
     }
 }
 
+/// Shared ref-type flag indicating the boundary-extension OPEN animator is
+/// running (#55). EventBlock's vertical auto-scroll suppresses Y velocity
+/// while this is true so the animator's scrollTo writes don't fight with
+/// per-frame setContentOffset writes from the auto-scroll display link.
+@MainActor
+final class CalendarBoundaryExtensionAnimatingBox {
+    var value: Bool
+    init(_ initialValue: Bool = false) {
+        self.value = initialValue
+    }
+}
+
 enum TimelineEditMappingSource: Equatable {
     case focused
     case moveDrag

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1199,12 +1199,11 @@ struct TimelinePagerView: View {
     /// `selectedDayOffset` changes. Used by follow-event-across-midnight so
     /// its math-equivalent atomic swap is invisible (no horizontal slide).
     var suppressDayColumnHorizontalAnimation: Bool = false
-    /// #55 follow-on: opacity multiplier (applied via `.mask`) on the
-    /// LEADING + TRAILING extension bands of each day column. 0 = bands
-    /// fully visible, 1 = fully transparent. The follow-event rebounce
-    /// drives this post-swap so the previous day's remnant fades while
-    /// it's pushed out of the viewport.
-    var extensionFadeProgress: CGFloat = 0
+    /// #55 follow-on: per-side opacity multiplier (applied via `.mask`) on the
+    /// extension bands. 0 = solid, 1 = transparent. Leading (top) and trailing
+    /// (bottom) are independent so one can dissolve without touching the other.
+    var leadingFadeProgress: CGFloat = 0
+    var trailingFadeProgress: CGFloat = 0
     var isDayOffsetFrozen: Bool = false
     let daysCount: Int
     let mode: PageMode
@@ -1655,7 +1654,8 @@ struct TimelinePagerView: View {
                     trailingExtendedHours: boundaryExtensionHours.trailing,
                     mode: mode,
                     editMappingPresentation: editMappingPresentation,
-                    extensionFadeProgress: extensionFadeProgress
+                    leadingFadeProgress: leadingFadeProgress,
+                    trailingFadeProgress: trailingFadeProgress
                 )
                 .id(effectiveSlotMinutes)
                 .transition(.opacity)
@@ -2434,13 +2434,14 @@ struct TimelinePagerView: View {
         )
         let _ = {
             guard offset == selectedDayOffset,
-                  boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0 || extensionFadeProgress > 0
+                  boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0
+                    || leadingFadeProgress > 0 || trailingFadeProgress > 0
             else { return }
             let line = String(
-                format: "[#fade] dayView offset=%d ext=(l=%d,t=%d) fade=%.2f occ=%d baseOcc=%d",
+                format: "[#fade] dayView offset=%d ext=(l=%d,t=%d) fadeL=%.2f fadeT=%.2f occ=%d baseOcc=%d",
                 offset,
                 boundaryExtensionHours.leading, boundaryExtensionHours.trailing,
-                extensionFadeProgress,
+                leadingFadeProgress, trailingFadeProgress,
                 dayOccurrences.count,
                 occurrencesForOffset(offset).count
             )
@@ -2577,7 +2578,6 @@ struct TimelinePagerView: View {
     private func extensionFadeMask() -> some View {
         let leading = boundaryExtensionHours.leading
         let trailing = boundaryExtensionHours.trailing
-        let bandAlpha = 1 - extensionFadeProgress
         let boundaryBuffer: CGFloat = 2
         let leadingBuf: CGFloat = leading > 0 ? boundaryBuffer : 0
         let trailingBuf: CGFloat = trailing > 0 ? boundaryBuffer : 0
@@ -2586,7 +2586,7 @@ struct TimelinePagerView: View {
             if leading > 0 {
                 Color.white
                     .frame(height: max(0, CGFloat(leading) * hourHeight - leadingBuf))
-                    .opacity(bandAlpha)
+                    .opacity(1 - leadingFadeProgress)
             }
             Color.white.frame(
                 height: CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
@@ -2595,7 +2595,7 @@ struct TimelinePagerView: View {
             if trailing > 0 {
                 Color.white
                     .frame(height: max(0, CGFloat(trailing) * hourHeight - trailingBuf))
-                    .opacity(bandAlpha)
+                    .opacity(1 - trailingFadeProgress)
             }
             Color.white
         }
@@ -2723,11 +2723,11 @@ private struct TimeAxisLabels: View {
     let trailingExtendedHours: Int
     let mode: PageMode
     var editMappingPresentation: TimelineAxisMarkerPresentation? = nil
-    /// #55 follow-on: band-fade opacity (0 = bands solid, 1 = transparent).
-    /// Applied ONLY to the hour-label column — the axis markers and the
-    /// current-time legend stay fully opaque (they're live indicators, not
-    /// part of the leaving day).
-    var extensionFadeProgress: CGFloat = 0
+    /// #55 follow-on: per-side band-fade opacity (0 = solid, 1 = transparent),
+    /// applied ONLY to the hour-label column — axis markers + current-time
+    /// legend stay fully opaque. Leading/trailing independent.
+    var leadingFadeProgress: CGFloat = 0
+    var trailingFadeProgress: CGFloat = 0
 
     private var slotHeight: CGFloat {
         hourHeight * CGFloat(slotMinutes) / 60
@@ -2804,7 +2804,6 @@ private struct TimeAxisLabels: View {
     /// whole mask is opaque white → no effect (the resting state).
     @ViewBuilder
     private func bandFadeMask() -> some View {
-        let bandAlpha = 1 - extensionFadeProgress
         let buffer: CGFloat = 8
         let leadingBuf: CGFloat = leadingExtendedHours > 0 ? buffer : 0
         let trailingBuf: CGFloat = trailingExtendedHours > 0 ? buffer : 0
@@ -2813,7 +2812,7 @@ private struct TimeAxisLabels: View {
             if leadingExtendedHours > 0 {
                 Color.white
                     .frame(height: max(0, CGFloat(leadingExtendedHours) * hourHeight - leadingBuf))
-                    .opacity(bandAlpha)
+                    .opacity(1 - leadingFadeProgress)
             }
             Color.white.frame(
                 height: CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
@@ -2822,7 +2821,7 @@ private struct TimeAxisLabels: View {
             if trailingExtendedHours > 0 {
                 Color.white
                     .frame(height: max(0, CGFloat(trailingExtendedHours) * hourHeight - trailingBuf))
-                    .opacity(bandAlpha)
+                    .opacity(1 - trailingFadeProgress)
             }
             Color.white
         }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -431,9 +431,6 @@ func calendarDragSourceDayOffset(
     return calendar.dateComponents([.day], from: today, to: eventDay).day
 }
 
-/// Dedup cache for the [#fade] diagnostic log — print only on change.
-@MainActor var calendarFadeLogLastLine: String = ""
-
 /// Equatable gate controlled solely by scroll state.
 /// - Scrolling: `==` uses (offset, shouldRender) → blocks body re-eval
 /// - Not scrolling: `==` returns false → all updates propagate
@@ -1313,8 +1310,6 @@ struct TimelinePagerView: View {
            verticalScrollY < 1,
            dragState.dragOffset.y < -hourHeight {
             result.leading = calendarTimelineMaximumBoundaryExtensionHours
-            NSLog("[#55ext] TRIGGER proactive open leading=12 scrollY=%.2f dragOffsetY=%.2f hourHeight=%.2f source=%@",
-                  verticalScrollY, dragState.dragOffset.y, hourHeight, String(describing: state.source))
         }
 
         return result
@@ -1601,28 +1596,7 @@ struct TimelinePagerView: View {
             onBoundaryExtensionStateChange?(rawBoundaryExtensionState)
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
-            NSLog("[#55ext] rawState→callback leading=%d trailing=%d source=%@",
-                  newValue.leadingHours, newValue.trailingHours, String(describing: newValue.source))
             onBoundaryExtensionStateChange?(newValue)
-        }
-        .onChange(of: boundaryExtensionHours.leading) { oldValue, newValue in
-            NSLog("[#55ext] LEADING propagated old=%d new=%d (effective) totalH=%.2f",
-                  oldValue, newValue, totalHeight)
-        }
-        .onChange(of: totalHeight) { oldValue, newValue in
-            if boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0 {
-                NSLog("[#55ext] totalHeight changed %.2f → %.2f leading=%d",
-                      oldValue, newValue, boundaryExtensionHours.leading)
-            }
-        }
-        .onChange(of: dragState.dragOffset.y) { oldValue, newValue in
-            if boundaryExtensionHours.leading > 0, abs(newValue - oldValue) > 0.5 {
-                NSLog("[#55ext] dragOffsetY %.2f → %.2f scrollY=%.2f leading=%d",
-                      oldValue, newValue, verticalScrollY, boundaryExtensionHours.leading)
-            }
-        }
-        .onChange(of: boundaryExtensionVisualYOffset) { oldValue, newValue in
-            NSLog("[#55ext] visualYOffset %.2f → %.2f", oldValue, newValue)
         }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mirror of TimelineDayView's handler: mark the parent as
@@ -2432,24 +2406,6 @@ struct TimelinePagerView: View {
             trailingExtendedHours: occurrenceExtensionHoursForDrag.trailing,
             occurrencesForOffset: occurrencesForOffset
         )
-        let _ = {
-            guard offset == selectedDayOffset,
-                  boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0
-                    || leadingFadeProgress > 0 || trailingFadeProgress > 0
-            else { return }
-            let line = String(
-                format: "[#fade] dayView offset=%d ext=(l=%d,t=%d) fadeL=%.2f fadeT=%.2f occ=%d baseOcc=%d",
-                offset,
-                boundaryExtensionHours.leading, boundaryExtensionHours.trailing,
-                leadingFadeProgress, trailingFadeProgress,
-                dayOccurrences.count,
-                occurrencesForOffset(offset).count
-            )
-            if line != calendarFadeLogLastLine {
-                calendarFadeLogLastLine = line
-                NSLog("%@", line)
-            }
-        }()
 
         if useCALayerTimeline {
             // CALayer rewrite S1–S4: full per-event visual fidelity + grid /

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -240,13 +240,12 @@ func calendarIsMoveDragActive(
     draggingEventID != nil && dragMode == .move
 }
 
-// Extracted for regression tests: boundary-extension reflow should not animate
-// while a move-drag is actively crossing day boundaries. SwiftUI's
-// `ScrollPosition.scrollTo` ignores ambient `withAnimation` (iOS 26: it always
-// snaps), so animating `leading` while scroll snaps produces visible content
-// drift during the spring. Keep both INSTANT during drag — they snap together
-// in lockstep, visible content stays glued. Outside drag, the spring is fine
-// because no scroll compensation runs concurrently.
+// Extracted for regression tests: boundary-extension reflow does not animate
+// during drag. SwiftUI animating `leading` would interpolate event canvas
+// rows over the spring, fighting our CADisplayLink animator that drives
+// scroll + `.offset` together in lockstep (#55). The visual "unfold" comes
+// entirely from the offset modifier, not from animating `leading` itself.
+// Outside drag, the spring is fine because no animator path is engaged.
 func calendarShouldAnimateTimelineBoundaryExtension(
     isMoveDragActive: Bool,
     isCreationDragActive: Bool,
@@ -1177,6 +1176,12 @@ struct TimelinePagerView: View {
     // other deep callee that only needs to read the live value) can do so
     // without taking it as a per-frame-invalidating stored property.
     let liveHourHeight: CalendarHourHeightBox
+    /// Suppress flag for EventBlock vertical auto-scroll while the
+    /// boundary-extension OPEN animator is running (#55).
+    let liveBoundaryExtensionAnimating: CalendarBoundaryExtensionAnimatingBox
+    /// #55: visual y-offset applied to timeline content during OPEN animation
+    /// so events stay glued to finger while scroll catches up. Default 0.
+    var boundaryExtensionVisualYOffset: CGFloat = 0
     var isDayOffsetFrozen: Bool = false
     let daysCount: Int
     let mode: PageMode
@@ -1286,6 +1291,8 @@ struct TimelinePagerView: View {
            verticalScrollY < 1,
            dragState.dragOffset.y < -hourHeight {
             result.leading = calendarTimelineMaximumBoundaryExtensionHours
+            NSLog("[#55ext] TRIGGER proactive open leading=12 scrollY=%.2f dragOffsetY=%.2f hourHeight=%.2f source=%@",
+                  verticalScrollY, dragState.dragOffset.y, hourHeight, String(describing: state.source))
         }
 
         return result
@@ -1558,6 +1565,11 @@ struct TimelinePagerView: View {
             .padding(.horizontal, timelineEdgePadding)
             .scaleEffect(x: rangePinchVisualScale, y: rangePinchVisualScaleY, anchor: .center)
             .simultaneousGesture(rangePinchGesture)
+            // #55: visual offset cancels the leading-snap canvas-row jump so
+            // dragged events stay glued to the finger. Driven by the
+            // CADisplayLink animator in CalendarPageView, animates from
+            // -delta → 0 over 0.28s in lockstep with scrollTo. Idle = 0.
+            .offset(y: boundaryExtensionVisualYOffset)
             .animation(boundaryExtensionAnimation, value: boundaryExtensionHours.leading)
             .animation(boundaryExtensionAnimation, value: boundaryExtensionHours.trailing)
         }
@@ -1566,7 +1578,28 @@ struct TimelinePagerView: View {
             onBoundaryExtensionStateChange?(rawBoundaryExtensionState)
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
+            NSLog("[#55ext] rawState→callback leading=%d trailing=%d source=%@",
+                  newValue.leadingHours, newValue.trailingHours, String(describing: newValue.source))
             onBoundaryExtensionStateChange?(newValue)
+        }
+        .onChange(of: boundaryExtensionHours.leading) { oldValue, newValue in
+            NSLog("[#55ext] LEADING propagated old=%d new=%d (effective) totalH=%.2f",
+                  oldValue, newValue, totalHeight)
+        }
+        .onChange(of: totalHeight) { oldValue, newValue in
+            if boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0 {
+                NSLog("[#55ext] totalHeight changed %.2f → %.2f leading=%d",
+                      oldValue, newValue, boundaryExtensionHours.leading)
+            }
+        }
+        .onChange(of: dragState.dragOffset.y) { oldValue, newValue in
+            if boundaryExtensionHours.leading > 0, abs(newValue - oldValue) > 0.5 {
+                NSLog("[#55ext] dragOffsetY %.2f → %.2f scrollY=%.2f leading=%d",
+                      oldValue, newValue, verticalScrollY, boundaryExtensionHours.leading)
+            }
+        }
+        .onChange(of: boundaryExtensionVisualYOffset) { oldValue, newValue in
+            NSLog("[#55ext] visualYOffset %.2f → %.2f", oldValue, newValue)
         }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mirror of TimelineDayView's handler: mark the parent as
@@ -2433,6 +2466,8 @@ struct TimelinePagerView: View {
             headerHeight: headerHeight,
             hourHeight: hourHeight,
             liveHourHeight: liveHourHeight,
+            liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
+            boundaryExtensionVisualYOffset: boundaryExtensionVisualYOffset,
             slotMinutes: effectiveSlotMinutes,
             eventHorizontalInset: eventHorizontalInset,
             showEventText: showEventText,
@@ -3158,6 +3193,8 @@ private struct TimelineDayView: View {
     // Reference passed down to EventBlock so the deep callee can read live
     // hourHeight without re-evaluating its body on every pinch frame.
     let liveHourHeight: CalendarHourHeightBox
+    let liveBoundaryExtensionAnimating: CalendarBoundaryExtensionAnimatingBox
+    var boundaryExtensionVisualYOffset: CGFloat = 0
     let slotMinutes: Int
     let eventHorizontalInset: CGFloat
     let showEventText: Bool
@@ -5116,6 +5153,7 @@ private struct TimelineDayView: View {
             boundPeople: calendarEventStore.people(for: event.peopleIDs ?? []),
             style: blockStyle,
             liveHourHeight: liveHourHeight,
+            liveBoundaryExtensionAnimating: liveBoundaryExtensionAnimating,
             isPinchActive: isPinchActive,
             dayColumnStep: dayColumnStep,
             dragPreviewDayStep: dragPreviewDayStep,

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -246,12 +246,22 @@ func calendarIsMoveDragActive(
 // scroll + `.offset` together in lockstep (#55). The visual "unfold" comes
 // entirely from the offset modifier, not from animating `leading` itself.
 // Outside drag, the spring is fine because no animator path is engaged.
+//
+// Same suppression applies during the follow-event-across-midnight re-
+// anchor (#55): when the atomic swap flips `leading` (0↔12), SwiftUI's
+// `.animation(boundaryExtensionAnimation, value: leading)` would
+// interpolate every event's canvas y over 0.28s while our
+// CADisplayLink already snapped scrollY in lockstep with the swap →
+// events visibly drift for 0.28s. Forward direction surfaces this
+// because it flips `leading` (visibleStart shifts 12h); backward flips
+// `trailing` (visibleStart unchanged) so events stay put.
 func calendarShouldAnimateTimelineBoundaryExtension(
     isMoveDragActive: Bool,
     isCreationDragActive: Bool,
-    reduceMotion: Bool
+    reduceMotion: Bool,
+    isFollowEventActive: Bool = false
 ) -> Bool {
-    !reduceMotion && !isMoveDragActive && !isCreationDragActive
+    !reduceMotion && !isMoveDragActive && !isCreationDragActive && !isFollowEventActive
 }
 
 // Extracted for regression tests: when leading boundary extension toggles during
@@ -1366,7 +1376,8 @@ struct TimelinePagerView: View {
         guard calendarShouldAnimateTimelineBoundaryExtension(
             isMoveDragActive: isMoveDragActive,
             isCreationDragActive: isCreationDragActive,
-            reduceMotion: accessibilityReduceMotion
+            reduceMotion: accessibilityReduceMotion,
+            isFollowEventActive: suppressDayColumnHorizontalAnimation
         ) else {
             return nil
         }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1182,6 +1182,10 @@ struct TimelinePagerView: View {
     /// #55: visual y-offset applied to timeline content during OPEN animation
     /// so events stay glued to finger while scroll catches up. Default 0.
     var boundaryExtensionVisualYOffset: CGFloat = 0
+    /// #55: when true, skip the day-column horizontal swipe animation when
+    /// `selectedDayOffset` changes. Used by follow-event-across-midnight so
+    /// its math-equivalent atomic swap is invisible (no horizontal slide).
+    var suppressDayColumnHorizontalAnimation: Bool = false
     var isDayOffsetFrozen: Bool = false
     let daysCount: Int
     let mode: PageMode
@@ -2036,7 +2040,7 @@ struct TimelinePagerView: View {
                         "leadingOffset": "\(clampedLeading)"
                     ]
                 )
-                if accessibilityReduceMotion {
+                if accessibilityReduceMotion || suppressDayColumnHorizontalAnimation {
                     scrollProxy.scrollTo(clampedLeading, anchor: .leading)
                 } else {
                     withAnimation(.interactiveSpring(response: 0.36, dampingFraction: 0.9, blendDuration: 0.12)) {

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2899,8 +2899,14 @@ private struct TimeAxisLabels: View {
         let minute = normalizedTotalMinutes % 60
 
         guard minute == 0 else { return "" }
+        // Use the REAL (signed) offset for the now-legend collision, NOT the
+        // mod-24h normalized value — otherwise a label in the leading/trailing
+        // extension that shares an hour-of-day with `now` (e.g. yesterday's 4pm
+        // when now is 4pm) collides at the same normalized minute and gets
+        // hidden too, even though it sits 24h away on screen. The real offset
+        // makes only the physically-overlapping base-day label hide. (#55)
         if calendarShouldHideLegendHourLabel(
-            legendTotalMinutes: normalizedTotalMinutes,
+            legendTotalMinutes: totalMinutes,
             nowTotalMinutes: totalMinutesSinceMidnight(for: now),
             hourHeight: hourHeight
         ) {

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -431,6 +431,9 @@ func calendarDragSourceDayOffset(
     return calendar.dateComponents([.day], from: today, to: eventDay).day
 }
 
+/// Dedup cache for the [#fade] diagnostic log — print only on change.
+@MainActor var calendarFadeLogLastLine: String = ""
+
 /// Equatable gate controlled solely by scroll state.
 /// - Scrolling: `==` uses (offset, shouldRender) → blocks body re-eval
 /// - Not scrolling: `==` returns false → all updates propagate
@@ -1196,6 +1199,12 @@ struct TimelinePagerView: View {
     /// `selectedDayOffset` changes. Used by follow-event-across-midnight so
     /// its math-equivalent atomic swap is invisible (no horizontal slide).
     var suppressDayColumnHorizontalAnimation: Bool = false
+    /// #55 follow-on: opacity multiplier (applied via `.mask`) on the
+    /// LEADING + TRAILING extension bands of each day column. 0 = bands
+    /// fully visible, 1 = fully transparent. The follow-event rebounce
+    /// drives this post-swap so the previous day's remnant fades while
+    /// it's pushed out of the viewport.
+    var extensionFadeProgress: CGFloat = 0
     var isDayOffsetFrozen: Bool = false
     let daysCount: Int
     let mode: PageMode
@@ -1650,6 +1659,13 @@ struct TimelinePagerView: View {
                 .id(effectiveSlotMinutes)
                 .transition(.opacity)
                 .frame(height: timelineHeight, alignment: .top)
+                // Fade the extension-band HOUR LABELS in lockstep with the
+                // band grid/events (same mask, same vertical segments). The
+                // axis is a sibling of the day columns, so the per-column
+                // mask doesn't reach it — without this, yesterday's late-hour
+                // labels (21:00, 22:00…) stay solid and snap away at collapse
+                // while the band fades. (#55 follow-on)
+                .mask { extensionFadeMask() }
             }
         }
     }
@@ -2422,6 +2438,23 @@ struct TimelinePagerView: View {
             trailingExtendedHours: occurrenceExtensionHoursForDrag.trailing,
             occurrencesForOffset: occurrencesForOffset
         )
+        let _ = {
+            guard offset == selectedDayOffset,
+                  boundaryExtensionHours.leading > 0 || boundaryExtensionHours.trailing > 0 || extensionFadeProgress > 0
+            else { return }
+            let line = String(
+                format: "[#fade] dayView offset=%d ext=(l=%d,t=%d) fade=%.2f occ=%d baseOcc=%d",
+                offset,
+                boundaryExtensionHours.leading, boundaryExtensionHours.trailing,
+                extensionFadeProgress,
+                dayOccurrences.count,
+                occurrencesForOffset(offset).count
+            )
+            if line != calendarFadeLogLastLine {
+                calendarFadeLogLastLine = line
+                NSLog("%@", line)
+            }
+        }()
 
         if useCALayerTimeline {
             // CALayer rewrite S1–S4: full per-event visual fidelity + grid /
@@ -2473,6 +2506,7 @@ struct TimelinePagerView: View {
                 onVisibleTimelineFrameChange: onVisibleTimelineFrameChange
             )
             .frame(width: dayWidth, height: timelineHeight, alignment: .top)
+            .mask { extensionFadeMask() }
         } else {
             TimelineDayView(
             date: date,
@@ -2535,7 +2569,49 @@ struct TimelinePagerView: View {
                 }
             }
         }
+        .mask { extensionFadeMask() }
         }
+    }
+
+    /// Alpha mask for the follow-event band fade: header + base 24h fully
+    /// opaque, the extension band(s) at `1 - extensionFadeProgress`. The
+    /// day-boundary hour line sits exactly on the band↔base seam and mask
+    /// anti-aliasing would sample the 1pt line at ~50% alpha — so the base
+    /// segment overhangs 2pt into each band side to keep the midnight line
+    /// fully opaque while the band fades.
+    @ViewBuilder
+    private func extensionFadeMask() -> some View {
+        let leading = boundaryExtensionHours.leading
+        let trailing = boundaryExtensionHours.trailing
+        let bandAlpha = 1 - extensionFadeProgress
+        let boundaryBuffer: CGFloat = 2
+        let leadingBuf: CGFloat = leading > 0 ? boundaryBuffer : 0
+        let trailingBuf: CGFloat = trailing > 0 ? boundaryBuffer : 0
+        VStack(spacing: 0) {
+            Color.white.frame(height: headerHeight)
+            if leading > 0 {
+                Color.white
+                    .frame(height: max(0, CGFloat(leading) * hourHeight - leadingBuf))
+                    .opacity(bandAlpha)
+            }
+            Color.white.frame(
+                height: CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
+                    + leadingBuf + trailingBuf
+            )
+            if trailing > 0 {
+                Color.white
+                    .frame(height: max(0, CGFloat(trailing) * hourHeight - trailingBuf))
+                    .opacity(bandAlpha)
+            }
+            Color.white
+        }
+        // Fill the masked view's FULL width (not a fixed column width):
+        // the time-axis labels are right-aligned and intrinsically wider
+        // than the 26pt label column, so a leading-anchored fixed-width
+        // mask clipped their right-side glyphs. maxWidth: .infinity makes
+        // the white columns span whatever the masked bounds are — correct
+        // for both the day columns and the axis. (#55 follow-on)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     // MARK: - Helpers

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1654,18 +1654,12 @@ struct TimelinePagerView: View {
                     leadingExtendedHours: boundaryExtensionHours.leading,
                     trailingExtendedHours: boundaryExtensionHours.trailing,
                     mode: mode,
-                    editMappingPresentation: editMappingPresentation
+                    editMappingPresentation: editMappingPresentation,
+                    extensionFadeProgress: extensionFadeProgress
                 )
                 .id(effectiveSlotMinutes)
                 .transition(.opacity)
                 .frame(height: timelineHeight, alignment: .top)
-                // Fade the extension-band HOUR LABELS in lockstep with the
-                // band grid/events (same mask, same vertical segments). The
-                // axis is a sibling of the day columns, so the per-column
-                // mask doesn't reach it — without this, yesterday's late-hour
-                // labels (21:00, 22:00…) stay solid and snap away at collapse
-                // while the band fades. (#55 follow-on)
-                .mask { extensionFadeMask() }
             }
         }
     }
@@ -2729,6 +2723,11 @@ private struct TimeAxisLabels: View {
     let trailingExtendedHours: Int
     let mode: PageMode
     var editMappingPresentation: TimelineAxisMarkerPresentation? = nil
+    /// #55 follow-on: band-fade opacity (0 = bands solid, 1 = transparent).
+    /// Applied ONLY to the hour-label column — the axis markers and the
+    /// current-time legend stay fully opaque (they're live indicators, not
+    /// part of the leaving day).
+    var extensionFadeProgress: CGFloat = 0
 
     private var slotHeight: CGFloat {
         hourHeight * CGFloat(slotMinutes) / 60
@@ -2770,6 +2769,10 @@ private struct TimeAxisLabels: View {
                             .frame(height: slotHeight, alignment: .top)
                     }
                 }
+                // Fade ONLY the hour labels with the leaving band. Markers +
+                // now-legend (later ZStack children) are intentionally outside
+                // this mask, so they stay fully opaque. (#55 follow-on)
+                .mask { bandFadeMask() }
 
                 Text(currentTimeText(for: now))
                     .font(.system(size: 9, weight: .bold).monospacedDigit())
@@ -2789,6 +2792,41 @@ private struct TimeAxisLabels: View {
         }
         .allowsHitTesting(false)
         .accessibilityHidden(true)
+    }
+
+    /// Alpha mask for the hour-label column during the follow-event band fade.
+    /// header + base 24h opaque, extension band(s) at `1 - extensionFadeProgress`.
+    /// Unlike the day-column mask (which protects a 1pt midnight LINE with a 2pt
+    /// overhang), the axis carries a ~12pt-tall hour LABEL centred on the
+    /// boundary line, so the base segment overhangs a half-label-height (8pt)
+    /// into each band — keeping the midnight "0:00" label fully opaque while
+    /// the band's interior hours fade. When `extensionFadeProgress == 0` the
+    /// whole mask is opaque white → no effect (the resting state).
+    @ViewBuilder
+    private func bandFadeMask() -> some View {
+        let bandAlpha = 1 - extensionFadeProgress
+        let buffer: CGFloat = 8
+        let leadingBuf: CGFloat = leadingExtendedHours > 0 ? buffer : 0
+        let trailingBuf: CGFloat = trailingExtendedHours > 0 ? buffer : 0
+        VStack(spacing: 0) {
+            Color.white.frame(height: headerHeight)
+            if leadingExtendedHours > 0 {
+                Color.white
+                    .frame(height: max(0, CGFloat(leadingExtendedHours) * hourHeight - leadingBuf))
+                    .opacity(bandAlpha)
+            }
+            Color.white.frame(
+                height: CGFloat(calendarTimelineBaseVisibleHours) * hourHeight
+                    + leadingBuf + trailingBuf
+            )
+            if trailingExtendedHours > 0 {
+                Color.white
+                    .frame(height: max(0, CGFloat(trailingExtendedHours) * hourHeight - trailingBuf))
+                    .opacity(bandAlpha)
+            }
+            Color.white
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
     }
 
     @ViewBuilder

--- a/DoneTests/CalendarDragLogicTests.swift
+++ b/DoneTests/CalendarDragLogicTests.swift
@@ -538,6 +538,9 @@ final class CalendarDragLogicTests: XCTestCase {
                 reduceMotion: false
             )
         )
+        // Move-drag suppresses SwiftUI's leading spring; the OPEN animation
+        // is driven externally by a CADisplayLink that updates scrollTo and
+        // a visual y-offset modifier in lockstep (#55).
         XCTAssertFalse(
             calendarShouldAnimateTimelineBoundaryExtension(
                 isMoveDragActive: true,


### PR DESCRIPTION
## Summary
Boundary-extension (#55) work for the day-view timeline, plus the polish around it.

- **Cross-midnight follow-event** — dragging/resizing an event across midnight re-anchors the view to the new day with a continuous-spring settle; the leaving day exits via a mask fade (scoped to hour labels so the axis marker / midnight line stay crisp); the header date tracks the finger/viewport during the extended-view drag and snaps on re-anchor.
- **Same-day extension abandon** — opening a boundary extension but releasing *without* crossing midnight now elastically settles back to the base day (rebounce, ζ=0.78 curve). During the drag a two-stage, per-side, finger-driven dissolve dims the band (Stage 1 distance, floored) and fully fades it as the midnight line nears the viewport edge (Stage 2 position). The now-label axis avoidance no longer hides the same hour inside the extension.

## Notes
- The terminal collapse can't be made fully flash-free: a vanilla SwiftUI `ScrollView` can't atomically co-commit a `contentSize` change and a `scrollTo`. Same-day ships an **opacity-dip cover** (fade out → instant collapse while invisible → fade in; pre/post content is identical); cross-midnight accepts a 1-frame residual. The offset-"glue" workaround was tried and reverted (it jitters — UIKit contentOffset vs SwiftUI .offset don't co-commit per frame). Real fix (UIKit-owned scroll / continuous canvas) tracked in **#57**, to fold into the CALayer timeline rewrite (#14).

## Test plan
- [ ] Drag event across midnight (down AND up) → view follows to the new day, old day fades, no clipping
- [ ] Resize-top across midnight → same follow behavior, not clipped to base day
- [ ] Open leading / trailing extension, drag back without crossing, release → elastic settle to base day; collapse has no sustained jitter
- [ ] Trigger both leading+trailing, then abandon → no detach-from-finger, no double-open
- [ ] Header date tracks correctly through the extended-view drag
- [ ] min-pinch and normal zoom both behave

🤖 Generated with [Claude Code](https://claude.com/claude-code)