### PR TITLE
fix(calendar): force equalSplit in mini-day overlap layout

### DIFF
--- a/Done/Views/Calendar/CalendarEventDetailView.swift
+++ b/Done/Views/Calendar/CalendarEventDetailView.swift
@@ -1325,7 +1325,10 @@ private extension CalendarEventDetailView {
                     // Event blocks (sibling + focused) laid out per overlap slots
                     GeometryReader { geo in
                         let areaWidth = geo.size.width
-                        let focusedSlot = layout.slots[layout.focusedID] ?? .default
+                        let focusedSlot = layout.slots[layout.focusedID] ?? {
+                            assertionFailure("miniDayLayout must produce a slot for focusedID")
+                            return .default
+                        }()
                         let focusedX = focusedSlot.xOffsetFraction * areaWidth
                         let focusedWidth = max(8, focusedSlot.widthFraction * areaWidth - 1)
 
@@ -1341,7 +1344,10 @@ private extension CalendarEventDetailView {
                             ForEach(layout.others) { occ in
                                 miniDayOtherEventBlock(
                                     occurrence: occ,
-                                    slot: layout.slots[occ.id] ?? .default,
+                                    slot: layout.slots[occ.id] ?? {
+                                        assertionFailure("miniDayLayout must produce a slot for sibling occurrence")
+                                        return .default
+                                    }(),
                                     areaWidth: areaWidth,
                                     windowStart: windowStart,
                                     windowEnd: windowEnd,
@@ -1546,8 +1552,9 @@ private extension CalendarEventDetailView {
     }
 
     /// Builds the data the mini timeline needs to render sibling events
-    /// alongside the focused event using the same column-packing logic the
-    /// outer calendar uses.
+    /// alongside the focused event using the same column-packing primitive
+    /// as the outer calendar, but pinned to `.equalSplit` since the mini-day
+    /// renderer doesn't honor `coverRanges`. See `OverlapMode` doc.
     private func miniDayLayout(
         focusedEvent: Event,
         focusedRange: Event.TimeRange,
@@ -1610,9 +1617,7 @@ private extension CalendarEventDetailView {
             return CalendarLayout.EventOccurrence(id: synthID, event: focusedEvent, range: focusedRange)
         }()
 
-        // Force equalSplit: mini-day is a contextual preview, not a compound-shape
-        // renderer. Stack-peek's host pick would full-width the focused block and
-        // swallow siblings since miniDayEventBlockVisual doesn't honor coverRanges.
+        // Pinned to .equalSplit: see OverlapMode doc.
         let slots = CalendarLayout.overlapLayout(
             for: [focusedOccurrence] + others,
             visibleStart: windowStart,

--- a/Done/Views/Calendar/CalendarEventDetailView.swift
+++ b/Done/Views/Calendar/CalendarEventDetailView.swift
@@ -1610,10 +1610,14 @@ private extension CalendarEventDetailView {
             return CalendarLayout.EventOccurrence(id: synthID, event: focusedEvent, range: focusedRange)
         }()
 
+        // Force equalSplit: mini-day is a contextual preview, not a compound-shape
+        // renderer. Stack-peek's host pick would full-width the focused block and
+        // swallow siblings since miniDayEventBlockVisual doesn't honor coverRanges.
         let slots = CalendarLayout.overlapLayout(
             for: [focusedOccurrence] + others,
             visibleStart: windowStart,
-            visibleEnd: windowEnd
+            visibleEnd: windowEnd,
+            mode: .equalSplit
         )
 
         return MiniDayLayout(focusedID: focusedOccurrence.id, others: others, slots: slots)

--- a/Done/Views/Calendar/CalendarLayout.swift
+++ b/Done/Views/Calendar/CalendarLayout.swift
@@ -366,6 +366,15 @@ enum CalendarLayout {
     /// callers pass it during MOVE/RESIZE/drag-create flows so the per-frame
     /// mode + host-pick decisions can't flip mid-drag (the dual-pass
     /// disagreement bug and the host-identity flip on resize).
+    ///
+    /// `.equalSplit` is ALSO the contract for preview-style renderers that
+    /// don't honor `coverRanges` — e.g. the mini-day timeline in the event
+    /// detail view, the daily share card, and the focus event flow.
+    /// Callers whose render path consumes only `widthFraction` /
+    /// `xOffsetFraction` MUST pass `.equalSplit`; otherwise `.auto` may
+    /// pick stack-peek and return a host slot with `widthFraction = 1.0`
+    /// whose sibling time-ranges are encoded in `coverRanges` — those
+    /// siblings would then render fully covered by the host.
     enum OverlapMode {
         case auto
         case equalSplit

--- a/Done/Views/Calendar/Components/CalendarDailyShareCard.swift
+++ b/Done/Views/Calendar/Components/CalendarDailyShareCard.swift
@@ -204,7 +204,9 @@ struct CalendarDailyShareCard: View {
     /// equal-split column layout so overlapping events sit side-by-side
     /// instead of stacking on top of each other.
     private var overlapSlots: [String: CalendarLayout.EventOverlapSlot] {
-        CalendarLayout.overlapLayout(for: occurrences, on: date)
+        // Pinned to .equalSplit: see OverlapMode doc — calendarEventBlock
+        // reads only widthFraction/xOffsetFraction/zIndex, never coverRanges.
+        CalendarLayout.overlapLayout(for: occurrences, on: date, mode: .equalSplit)
     }
 
     /// Visible hour range. We crop to the active band [earliest-1, latest+1]

--- a/Done/Views/Focus/FocusEventFlowView.swift
+++ b/Done/Views/Focus/FocusEventFlowView.swift
@@ -58,10 +58,13 @@ struct FocusEventFlowView: View {
 
             // Exclude embedded interrupts from overlap layout
             let overlapCandidates = allOccurrences.filter { !embeddedIDs.contains($0.id) }
+            // Pinned to .equalSplit: see OverlapMode doc — this preview renderer
+            // reads only widthFraction/xOffsetFraction, never coverRanges.
             let overlapSlots = CalendarLayout.overlapLayout(
                 for: overlapCandidates,
                 on: now,
-                calendar: calendar
+                calendar: calendar,
+                mode: .equalSplit
             )
 
             let hours = hourMarkers(from: windowStart, to: windowEnd)

--- a/DoneTests/CalendarOverlapAdaptiveTests.swift
+++ b/DoneTests/CalendarOverlapAdaptiveTests.swift
@@ -454,6 +454,60 @@ final class CalendarOverlapLayoutTests: XCTestCase {
                        "under .equalSplit (else the 50% canvas snap bug #1 fires)")
     }
 
+    /// User-reported mini-day repro (PR #67 follow-up): focused 8h45m event
+    /// + parallel 8h30m event + parallel 5h30m todo. Column-height ratio
+    /// (8h45m : 5h30m ≈ 1.59) would trip the stack-peek gate under `.auto`,
+    /// returning a host slot with `widthFraction = 1.0` and the siblings
+    /// encoded in `coverRanges`. Preview-style renderers (mini-day, share
+    /// card, focus event flow) only read `widthFraction`/`xOffsetFraction`
+    /// so the siblings would render fully covered by the host. With
+    /// `.equalSplit` every occurrence must receive a peer slot.
+    func testMiniDayLikeUnevenClusterEqualSplits() {
+        let focused = occ("focused", "2026-05-05T08:00:00Z", "2026-05-05T16:45:00Z") // 8h45m
+        let parallel = occ("parallel", "2026-05-05T08:30:00Z", "2026-05-05T17:00:00Z") // 8h30m
+        let todo = occ("todo", "2026-05-05T09:00:00Z", "2026-05-05T14:30:00Z") // 5h30m
+
+        let slots = CalendarLayout.overlapLayout(
+            for: [focused, parallel, todo],
+            visibleStart: visibleStart,
+            visibleEnd: visibleEnd,
+            calendar: calendar,
+            mode: .equalSplit
+        )
+
+        // 1. All 3 occurrences receive a slot.
+        for id in ["focused", "parallel", "todo"] {
+            XCTAssertNotNil(slots[id], "\(id) must receive a slot under .equalSplit")
+        }
+
+        // 2. widthFraction sums to <= 1.0 — every block fits in the canvas.
+        let widthSum = ["focused", "parallel", "todo"]
+            .map { slots[$0]!.widthFraction }
+            .reduce(0, +)
+        XCTAssertLessThanOrEqual(widthSum, 1.0 + 0.001,
+                                 "widthFractions must sum to <= 1.0 (each ~1/3), got \(widthSum)")
+
+        // 3. xOffsetFraction values are non-overlapping (no two slots share x range).
+        let ordered = ["focused", "parallel", "todo"]
+            .map { (id: $0, slot: slots[$0]!) }
+            .sorted { $0.slot.xOffsetFraction < $1.slot.xOffsetFraction }
+        for i in 0..<(ordered.count - 1) {
+            let lhs = ordered[i].slot
+            let rhs = ordered[i + 1].slot
+            XCTAssertLessThanOrEqual(lhs.xOffsetFraction + lhs.widthFraction,
+                                     rhs.xOffsetFraction + 0.001,
+                                     "\(ordered[i].id) [\(lhs.xOffsetFraction), " +
+                                     "\(lhs.xOffsetFraction + lhs.widthFraction)] overlaps " +
+                                     "\(ordered[i + 1].id) at \(rhs.xOffsetFraction)")
+        }
+
+        // 4. All slots have empty coverRanges — stack-peek bypassed.
+        for id in ["focused", "parallel", "todo"] {
+            XCTAssertTrue(slots[id]!.coverRanges.isEmpty,
+                          "\(id) must have empty coverRanges under .equalSplit")
+        }
+    }
+
     /// `mode: .auto` is the documented default and must produce identical
     /// output to a call that omits the parameter — protects callers that
     /// haven't been updated yet from a silent behavior shift.


### PR DESCRIPTION
## Summary

Detail-page mini-day timeline was inheriting `overlapLayout`'s default `.auto` mode. When the cluster's column-time ratio crosses 1.5 (e.g. focused 8h45 + parallel event 8h30 + parallel todo 5h30 → ratio 8.75/5.5 ≈ 1.59), the layout falls into stack-peek and picks the longest group as host — handing the focused event a full-width slot + `coverRanges` describing where siblings sit.

The main calendar renders that host as a compound (cutout) shape so siblings show through. `miniDayEventBlockVisual` is a plain rounded rect that **ignores `coverRanges`** — combined with the ZStack order (siblings first, focused on top), the focused block fully covered its siblings → user saw only the focused event.

## Why `.equalSplit` and not the compound-shape port

A focused tradeoff analysis (recorded in branch discussion) compared:
- **Port compound rendering to mini-day** — ~120 lines of `coverRanges → visibleSegments` geometry helper + a SwiftUI Shape mirror of `EventBlock`'s compound machinery. New test surface.
- **Force `.equalSplit`** — 1-line change at the call site.

Conclusion: mini-day is a contextual preview, not a pixel-faithful main-calendar replica. Equal-width columns guarantee the focused event is always visible at its 1/N slice; it stays distinguished by the existing `isFocused: true` styling (heavier fill / stroke / time-row). The compound-shape rendering debt isn't justified for a preview surface.

## Repro before fix

Focused event 13:45–22:30 + parallel event 14:00–22:30 + parallel todo 15:00–20:30 → mini-day shows ONLY the focused block. The "Parallel with" text rows in the section below still listed both — so the data was there, it just rendered invisibly under the focused block.

## Test plan

- [ ] Visual: open the detail page of an event with at least 2 parallel events/todos whose duration ratio against the focused exceeds 1.5. Confirm all events render side-by-side in equal-width columns (focused distinguished by heavier styling).
- [ ] Regression: detail page of an event with NO parallels — focused still renders full-width as before.
- [ ] Regression: detail page of an event with one short parallel todo (ratio below 1.5) — previously equal-split, still equal-split.
- [ ] Cross-day events (focused range spans midnight) — overlap window still computes from the expanded window, not snapped to day boundaries.