### PR TITLE
perf(timeline): latch proactive cross-day extension trigger (#75 partial)

### DIFF
--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1295,16 +1295,45 @@ struct TimelinePagerView: View {
         // boundary (`< 1pt`), so the extension only opens when the user
         // is literally at the edge and out of room to scroll. (#53
         // single-day follow-on)
+        //
+        // The trigger predicate used to read `dragState.dragOffset.y` here
+        // directly. That read made `TimelineView.body` an observer of
+        // dragOffset (the chain `rawBoundaryExtensionHours` → … →
+        // `boundaryExtensionHours.leading` is reached from body), so every
+        // drag-frame write to dragOffset invalidated body. Reading the
+        // pre-computed latch instead breaks that dependency edge — the
+        // latch is updated by an `.onChange(of: dragState.dragOffset.y)`
+        // handler whose body-scope is just the modifier closure, not
+        // `TimelineView.body`. (#75)
         if let state = boundaryExtensionMappingState,
            state.source == .moveDrag || state.source == .resizeTop,
            result.leading == 0,
-           verticalScrollY < 1,
-           dragState.dragOffset.y < -hourHeight {
+           proactiveLeadingExtensionLatch {
             result.leading = calendarTimelineMaximumBoundaryExtensionHours
         }
 
         return result
     }
+
+    /// Recomputes the proactive leading-extension latch (see
+    /// `proactiveLeadingExtensionLatch`'s doc-comment). Called by the
+    /// `dragOffset.y` and `verticalScrollY` onChange handlers in body. The
+    /// guards (active drag, dragOffset.y < -hourHeight, scroll pinned at
+    /// top) mirror exactly the predicate that used to live inside
+    /// `rawBoundaryExtensionHours` — moved out so body stops observing
+    /// `dragState.dragOffset`. (#75)
+    private func updateProactiveLeadingExtensionLatch(dragOffsetY: CGFloat) {
+        let isDraggingActive = dragState.draggingEventID != nil
+        let isUpwardPastHourThreshold = hourHeight > 0 && dragOffsetY < -hourHeight
+        let isScrollPinnedAtTop = verticalScrollY < 1
+        let shouldLatch = isDraggingActive
+            && isUpwardPastHourThreshold
+            && isScrollPinnedAtTop
+        if proactiveLeadingExtensionLatch != shouldLatch {
+            proactiveLeadingExtensionLatch = shouldLatch
+        }
+    }
+
     private var rawBoundaryExtensionState: TimelineBoundaryExtensionState {
         let anchorOffset: Int? = {
             guard let date = boundaryExtensionMappingState?.anchorDate else { return nil }
@@ -1392,6 +1421,23 @@ struct TimelinePagerView: View {
     /// This keeps the EventBlock tree stable while the visible timeline expands.
     @State private var frozenOccurrenceExtensionLeading: Int = 0
     @State private var frozenOccurrenceExtensionTrailing: Int = 0
+
+    /// Imperative latch for the #53 single-day proactive leading-extension
+    /// trigger. The condition (scroll-pinned-at-top + finger dragging upward)
+    /// used to be evaluated inside `rawBoundaryExtensionHours` by reading
+    /// `dragState.dragOffset.y` directly. That made `TimelineView.body` an
+    /// observer of `dragOffset`, so every drag-frame write to dragOffset
+    /// invalidated body — the dominant residual SwiftUI cost on the CALayer
+    /// renderer's drag path (#75 / #74's "Body-scope reader audit").
+    ///
+    /// The latch is set/cleared by an `.onChange(of: dragState.dragOffset.y)`
+    /// handler scoped to the body modifier chain. The handler observes
+    /// dragOffset there (which is fine — that observation does NOT register a
+    /// body-level dependency), and `rawBoundaryExtensionHours` reads the
+    /// latch instead. The result: drag-frame writes invalidate only the
+    /// onChange site, not body. Cleared on drag end via the existing
+    /// `dragState.draggingEventID` onChange.
+    @State private var proactiveLeadingExtensionLatch: Bool = false
 
     private var occurrenceExtensionHoursForDrag: (leading: Int, trailing: Int) {
         let isMoveDragActive = calendarIsMoveDragActive(
@@ -2197,6 +2243,12 @@ struct TimelinePagerView: View {
                     frozenOccurrenceExtensionLeading = boundaryExtensionHours.leading
                     frozenOccurrenceExtensionTrailing = boundaryExtensionHours.trailing
                 }
+                // Clear the proactive leading-extension latch when a drag
+                // session ends or hands off, so a re-engaged drag starts
+                // from a clean state. (#75)
+                if newValue == nil {
+                    proactiveLeadingExtensionLatch = false
+                }
                 // New drag sessions must start from a clean auto-scroll transition state.
                 previousHorizontalAutoScrolling = dragState.isHorizontalAutoScrolling
                 pendingSnapAfterAutoScrollStop = false
@@ -2216,6 +2268,24 @@ struct TimelinePagerView: View {
                         "isHorizontalEdgeDragging": "\(dragState.isHorizontalEdgeDragging)"
                     ]
                 )
+            }
+            .onChange(of: dragState.dragOffset.y) { _, newY in
+                // Mirror of the #53 single-day proactive leading-extension
+                // condition that USED to live inside `rawBoundaryExtensionHours`.
+                // Moving the dragOffset.y read out here keeps `TimelineView.body`
+                // from observing dragOffset directly, which would invalidate
+                // body on every drag frame. The handler is a modifier closure —
+                // its dragOffset observation does NOT register a body-level
+                // dependency. (#75)
+                updateProactiveLeadingExtensionLatch(dragOffsetY: newY)
+            }
+            .onChange(of: verticalScrollY) { _, _ in
+                // If the scroll moves away from the top boundary while the
+                // latch is set, clear it. `verticalScrollY` is a prop, so a
+                // change here implies a parent re-init (body has already
+                // re-evaluated anyway). This onChange is just to keep the
+                // latch in sync with the scroll-pinned-at-top guard. (#75)
+                updateProactiveLeadingExtensionLatch(dragOffsetY: dragState.dragOffset.y)
             }
             .onChange(of: dragState.isHorizontalAutoScrolling) { _, isAutoScrolling in
                 let shouldSnap = calendarShouldSnapImmediatelyAfterHorizontalAutoScrollStop(


### PR DESCRIPTION
## Summary

Implements Option A from #75: lifts the `#53` single-day proactive
leading-extension trigger's `dragState.dragOffset.y` read out of
`rawBoundaryExtensionHours` and into an imperative `@State` latch driven
by `.onChange(of: dragState.dragOffset.y)`. Goal: stop one of the
`TimelineView.body` ↔ `dragState.dragOffset` dependency edges so body
re-evaluates less per drag frame, as the prerequisite for flipping
`AppSettingsKeys.calendarUseCALayerAxisMarkers` default ON.

## The chain

**Before (issue #75 diagram):**
```
TimelineView.body
  └── .animation(value: boundaryExtensionHours.leading) TimelineView.swift:1580
boundaryExtensionHours
  └── effectiveBoundaryExtensionState
        └── rawBoundaryExtensionState
              └── rawBoundaryExtensionHours
                    └── reads dragState.dragOffset.y   line 1302
```

**After:**
```
TimelineView.body
  └── .onChange(of: dragState.dragOffset.y) { updateProactiveLeadingExtensionLatch }
TimelineView.body
  └── .animation(value: boundaryExtensionHours.leading)
boundaryExtensionHours
  └── effectiveBoundaryExtensionState
        └── rawBoundaryExtensionState
              └── rawBoundaryExtensionHours
                    └── reads proactiveLeadingExtensionLatch (@State Bool)
```

The `.onChange` modifier observes `dragOffset.y` from its closure
scope — that observation does NOT register a body-level dependency. The
latch is a plain `@State Bool` that only invalidates body when it
toggles (i.e. only when the proactive trigger crosses its predicate
boundary, not every drag frame).

Latch lifecycle:
- Recomputed on `.onChange(of: dragState.dragOffset.y)`
- Recomputed on `.onChange(of: verticalScrollY)` (covers scroll-away
  while finger is paused)
- Cleared on drag-session end via the existing
  `.onChange(of: dragState.draggingEventID)` handler

Semantic parity preserved: same four guards (active drag, source kind
`.moveDrag`/`.resizeTop`, `result.leading == 0`,
`dragOffset.y < -hourHeight`, `verticalScrollY < 1`), split between the
body-scope predicate (source / `result.leading`) and the latch (the
per-frame motion signals).

## Option taken

Option A (imperative latch). Strictly the smaller surgery the issue
proposed.

## Second body-scope reader found — filed as #77

A code audit found `resolvedDragEditMapping`
(`TimelineView.swift:1501-1554`) reads `dragState.dragOffset.y` (line
1526), `dragState.dragOffset` (lines 1506, 1548), and the other drag
substates. This function is body-reachable through:
- `editMappingState` → `editMappingPresentation` → `timeAxis()` (body)
- `boundaryExtensionMappingState` → `rawBoundaryExtensionHours` → `boundaryExtensionHours` (body)

So `TimelineView.body` STILL observes `dragState.dragOffset` per drag
frame even with this patch landed. The `resolvedDragEditMapping`
function's job — producing a live mapped time range that slides per
frame — fundamentally couples it to dragOffset, so unlike the proactive
trigger this can't be reduced to a binary latch. Lifting it requires
Option B from #75: move the chain into a dedicated child view so the
parent body no longer touches it.

That follow-up is filed as **#77** to keep this PR scoped to the
proactive-trigger surgery the issue diagrammed. With #77 also landed,
body should stop observing dragOffset and the flag can flip.

## Verification

**Not run.** Tried to instrument with a `TimelineBodyEvalCounter` +
`Self._printChanges()` and capture log_stream output from the booted
simulator. Manual sim-mouse drags don't produce sustained per-frame
touch events comparable to real-device drag, and I couldn't reliably
A/B without a UI-test harness driving real touches. Backed out the
instrumentation rather than committing noisy numbers.

Code-level reasoning (above) shows the line-1302 read is removed;
`resolvedDragEditMapping` remains as the load-bearing residual reader.
Reviewer with running device can measure with `_printChanges()` at body
entry or a body-eval counter.

Pre-existing test failures on `king-of-rubbish-bin` confirmed
(`testLeadingBoundaryExtensionRemovalDoesNotSnapScrollToSpecificTime`,
`testRelationAwareOverlapLayoutSharesSlotBetweenParentAndInterrupt`) —
my change does not affect them.

## Flag default

`AppSettingsKeys.calendarUseCALayerAxisMarkers` default stays **OFF**.

Rationale: the acceptance bar in #75 is "body does NOT re-evaluate
during axis-drag frames." With `resolvedDragEditMapping` still
body-observing dragOffset, that bar is not met. Flipping the flag now
would change which renderer draws but would not cash in the body-eval
savings the port was supposed to enable. The flip waits on #77.

## Test plan

- [ ] Single-day cross-midnight drag: drag an event upward when scroll
  is pinned at top — proactive leading-extension should still fire as
  on `king-of-rubbish-bin`
- [ ] 3-day + week range mode drag: boundary extension should NOT fire
  (this gate lives in `calendarTimelineBoundaryExtensionHours` not in
  the latch — verify no regression)
- [ ] Drag end: extension closes and the latch should clear
  (`.onChange(of: dragState.draggingEventID)` handler)
- [ ] Re-engage drag mid-extension: lift finger, re-press, re-drag up —
  latch should re-set
- [ ] Scroll away from top during drag (autoscroll fires): latch should
  clear via `.onChange(of: verticalScrollY)`

## Refs

- #75 — body-scope reader lift (parent)
- #77 — Option B follow-up for `resolvedDragEditMapping`
- #74 — CALayer axis port flag-OFF (the PR that left this prerequisite)
- #60 — CALayer axis spec
- #53 — single-day cross-midnight proactive-extension behavior (the
  trigger we're preserving)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>