### PR TITLE
perf(timeline): lift resolvedDragEditMapping body deps via cache + sub-view (#77)

### DIFF
--- a/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
@@ -679,6 +679,75 @@ func calendarResolveAxisMarkerPresentation(
     )
 }
 
+/// Free-function form of `TimelinePagerView.resolvedDragEditMapping` —
+/// reads only its arguments, so it can be called from a child sub-view
+/// without dragging the parent's `dragState.dragOffset` observation back
+/// up into `TimelinePagerView.body`. (#77)
+func calendarResolvedDragEditMapping(
+    draggingEventID: UUID?,
+    draggingOriginalRange: Event.TimeRange?,
+    dragOffset: DragOffset,
+    dragMode: EventDragMode,
+    dayColumnStep: CGFloat,
+    hourHeight: CGFloat,
+    calendar: Calendar = .current
+) -> (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
+    guard draggingEventID != nil else { return nil }
+    guard let range = calendarResolvedDragEditRange(
+        draggingOriginalRange: draggingOriginalRange,
+        dragOffset: dragOffset,
+        dragMode: dragMode,
+        hourHeight: hourHeight,
+        dayColumnStep: dayColumnStep,
+        calendar: calendar
+    ) else { return nil }
+
+    let source: TimelineEditMappingSource
+    switch dragMode {
+    case .move:
+        source = .moveDrag
+    case .resizeTop:
+        source = .resizeTop
+    case .resizeBottom:
+        source = .resizeBottom
+    }
+
+    // For move drag, use the vertical-only range (no day shift) so the
+    // time marker and boundary extension track the source day column.
+    let effectiveRange: Event.TimeRange
+    if source == .moveDrag, let originalRange = draggingOriginalRange, hourHeight > 0 {
+        let rawOffsetSeconds = TimeInterval(dragOffset.y / hourHeight * 3600)
+        let snappedOffset = calendarPreviewOffsetSeconds(
+            rawOffsetSeconds: rawOffsetSeconds,
+            range: originalRange,
+            snapIntervalSeconds: 15 * 60,
+            calendar: calendar
+        )
+        effectiveRange = Event.TimeRange(
+            start: originalRange.start.addingTimeInterval(snappedOffset),
+            end: originalRange.end.addingTimeInterval(snappedOffset)
+        )
+    } else {
+        effectiveRange = range
+    }
+
+    // For move drag, anchor to the source day so the time marker
+    // Y aligns with the vertical-only range (no day shift mismatch).
+    let anchorDate: Date
+    if source == .moveDrag, let originalRange = draggingOriginalRange {
+        anchorDate = calendar.startOfDay(for: originalRange.start)
+    } else {
+        anchorDate = calendarResolvedDragAnchorDate(
+            draggingOriginalRange: draggingOriginalRange,
+            dragOffset: dragOffset,
+            dragMode: dragMode,
+            dayColumnStep: dayColumnStep,
+            calendar: calendar
+        ) ?? effectiveRange.start
+    }
+    return (source, anchorDate, effectiveRange)
+}
+
 private func calendarAxisMarkerTimeText(for date: Date) -> String {
     calendarAxisMarkerFormatter.string(from: date)
 }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1272,14 +1272,29 @@ struct TimelinePagerView: View {
             focused: resolvedFocusedEditMapping
         )
     }
-    private var boundaryExtensionMappingState: TimelineEditMappingState? {
-        return calendarResolveBoundaryExtensionMappingState(
+
+    /// Computes the boundary-extension mapping state from the current drag /
+    /// creation source. Reads `resolvedDragEditMapping` (which reads
+    /// `dragState.dragOffset`); to avoid registering body-scope dependencies
+    /// on `dragOffset`, this MUST be called only from `.onChange` handlers /
+    /// modifier closures, never from body. Body-scope readers use the
+    /// `@State`-latched `cachedRawBoundaryExtensionState` via the
+    /// `rawBoundaryExtensionState` computed below. (#77)
+    private func computeBoundaryExtensionMappingState() -> TimelineEditMappingState? {
+        calendarResolveBoundaryExtensionMappingState(
             creation: resolvedCreationEditMapping,
             drag: resolvedDragEditMapping
         )
     }
-    private var rawBoundaryExtensionHours: (leading: Int, trailing: Int) {
-        var result = calendarTimelineBoundaryExtensionHours(mappingState: boundaryExtensionMappingState)
+
+    /// Computes the raw boundary extension hours from the current drag /
+    /// creation source. Reads `dragState.dragOffset` transitively; MUST be
+    /// called only from `.onChange` handlers / modifier closures, never from
+    /// body. Body-scope readers use `cachedRawBoundaryExtensionState`. (#77)
+    private func computeRawBoundaryExtensionHours(
+        mappingState: TimelineEditMappingState?
+    ) -> (leading: Int, trailing: Int) {
+        var result = calendarTimelineBoundaryExtensionHours(mappingState: mappingState)
 
         // Cross-day event fix: when the scroll has hit the top boundary
         // (can't go further up) and the user is actively dragging upward,
@@ -1305,7 +1320,7 @@ struct TimelinePagerView: View {
         // latch is updated by an `.onChange(of: dragState.dragOffset.y)`
         // handler whose body-scope is just the modifier closure, not
         // `TimelineView.body`. (#75)
-        if let state = boundaryExtensionMappingState,
+        if let state = mappingState,
            state.source == .moveDrag || state.source == .resizeTop,
            result.leading == 0,
            proactiveLeadingExtensionLatch {
@@ -1334,21 +1349,47 @@ struct TimelinePagerView: View {
         }
     }
 
+    /// Body-scope reader for the raw boundary extension state. Returns the
+    /// `@State`-latched cached value so body does NOT observe `dragOffset`
+    /// transitively. Refreshed via `refreshCachedRawBoundaryExtensionState()`
+    /// from `.onChange` handlers that watch every input the underlying compute
+    /// reads. (#77)
     private var rawBoundaryExtensionState: TimelineBoundaryExtensionState {
+        cachedRawBoundaryExtensionState
+    }
+
+    /// Pure compute: produces the raw boundary extension state from the
+    /// current drag / creation source. Called ONLY from `.onChange` handlers
+    /// (via `refreshCachedRawBoundaryExtensionState`); the body-scope reader
+    /// reads the cache. (#77)
+    private func computeRawBoundaryExtensionState() -> TimelineBoundaryExtensionState {
+        let mappingState = computeBoundaryExtensionMappingState()
+        let hours = computeRawBoundaryExtensionHours(mappingState: mappingState)
         let anchorOffset: Int? = {
-            guard let date = boundaryExtensionMappingState?.anchorDate else { return nil }
+            guard let date = mappingState?.anchorDate else { return nil }
             let calendar = Calendar.current
             let today = calendar.startOfDay(for: Date())
             let anchor = calendar.startOfDay(for: date)
             return calendar.dateComponents([.day], from: today, to: anchor).day
         }()
         return TimelineBoundaryExtensionState(
-            leadingHours: rawBoundaryExtensionHours.leading,
-            trailingHours: rawBoundaryExtensionHours.trailing,
-            source: boundaryExtensionMappingState?.source,
+            leadingHours: hours.leading,
+            trailingHours: hours.trailing,
+            source: mappingState?.source,
             anchorDayOffset: anchorOffset
         )
     }
+
+    /// Recompute the cached raw boundary extension state. Writes the new
+    /// value only when it differs from the cache, so body re-evals at most
+    /// once per actual transition (not per drag frame). (#77)
+    private func refreshCachedRawBoundaryExtensionState() {
+        let next = computeRawBoundaryExtensionState()
+        if next != cachedRawBoundaryExtensionState {
+            cachedRawBoundaryExtensionState = next
+        }
+    }
+
     private var effectiveBoundaryExtensionState: TimelineBoundaryExtensionState {
         boundaryExtensionStateOverride ?? rawBoundaryExtensionState
     }
@@ -1438,6 +1479,19 @@ struct TimelinePagerView: View {
     /// onChange site, not body. Cleared on drag end via the existing
     /// `dragState.draggingEventID` onChange.
     @State private var proactiveLeadingExtensionLatch: Bool = false
+
+    /// Cached raw boundary-extension state (#77). Body reads this via
+    /// `rawBoundaryExtensionState`; refreshed from `.onChange` handlers
+    /// (`refreshCachedRawBoundaryExtensionState`) that watch every input
+    /// the underlying compute reads (drag offset / drag session fields /
+    /// hourHeight / proactive latch / creation source). Body re-evals only
+    /// when this value actually changes — at most a couple of times per
+    /// drag (when the mapped range crosses the midnight predicate) — not
+    /// per drag frame. This breaks the `boundaryExtensionHours →
+    /// boundaryExtensionMappingState → resolvedDragEditMapping →
+    /// dragState.dragOffset` body-dependency edge that #76's latch did not
+    /// reach.
+    @State private var cachedRawBoundaryExtensionState: TimelineBoundaryExtensionState = .none
 
     private var occurrenceExtensionHoursForDrag: (leading: Int, trailing: Int) {
         let isMoveDragActive = calendarIsMoveDragActive(
@@ -1628,6 +1682,14 @@ struct TimelinePagerView: View {
         }
         .frame(height: totalHeight, alignment: .top)
         .onAppear {
+            // #77: seed the cached raw boundary state from the live compute so
+            // first-render reads (`rawBoundaryExtensionState`, `boundaryExtensionHours`,
+            // etc.) see the correct value rather than `.none` until the first
+            // dragOffset change. Initial cache value `.none` is correct when no
+            // drag / creation is active (the common case at appear), but if the
+            // pager is re-shown mid-flow the live compute might already be
+            // non-none.
+            refreshCachedRawBoundaryExtensionState()
             onBoundaryExtensionStateChange?(rawBoundaryExtensionState)
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
@@ -2059,6 +2121,10 @@ struct TimelinePagerView: View {
                 emitHorizontalScrollProgress(latestHorizontalContentOffsetX)
             }
             .onChange(of: selectedDayOffset) { _, newValue in
+                // #77: selectedDayOffset feeds resolvedCreationEditMapping →
+                // boundary state. Refresh the cache so creation drags that
+                // span a day pivot stay in sync.
+                refreshCachedRawBoundaryExtensionState()
                 if isUserScrollUpdating {
                     isUserScrollUpdating = false
                     return
@@ -2240,6 +2306,13 @@ struct TimelinePagerView: View {
             }
             .onChange(of: dragState.draggingEventID) { oldValue, newValue in
                 if newValue != nil && oldValue == nil {
+                    // #77: refresh the cache BEFORE reading
+                    // `boundaryExtensionHours` so the frozen snapshot reflects
+                    // the new drag's starting state, not the previous drag's
+                    // residue. The cache compute reads the live drag fields,
+                    // so calling refresh here picks up whatever the new drag
+                    // started from.
+                    refreshCachedRawBoundaryExtensionState()
                     frozenOccurrenceExtensionLeading = boundaryExtensionHours.leading
                     frozenOccurrenceExtensionTrailing = boundaryExtensionHours.trailing
                 }
@@ -2255,6 +2328,11 @@ struct TimelinePagerView: View {
                 if newValue != nil {
                     creationPreviewByDay.removeAll()
                 }
+                // #77: drag end / re-engage needs a cache refresh so the
+                // boundary state collapses back to none (or re-opens for a
+                // fresh drag) without waiting on a subsequent dragOffset
+                // write.
+                refreshCachedRawBoundaryExtensionState()
                 calendarDebugLog(
                     "timeline.dragSession.changed",
                     fields: [
@@ -2269,7 +2347,7 @@ struct TimelinePagerView: View {
                     ]
                 )
             }
-            .onChange(of: dragState.dragOffset.y) { _, newY in
+            .onChange(of: dragState.dragOffset) { _, newOffset in
                 // Mirror of the #53 single-day proactive leading-extension
                 // condition that USED to live inside `rawBoundaryExtensionHours`.
                 // Moving the dragOffset.y read out here keeps `TimelineView.body`
@@ -2277,7 +2355,37 @@ struct TimelinePagerView: View {
                 // body on every drag frame. The handler is a modifier closure —
                 // its dragOffset observation does NOT register a body-level
                 // dependency. (#75)
-                updateProactiveLeadingExtensionLatch(dragOffsetY: newY)
+                updateProactiveLeadingExtensionLatch(dragOffsetY: newOffset.y)
+                // Refresh the cached raw boundary extension state. The compute
+                // reads `resolvedDragEditMapping` (which reads `dragOffset`);
+                // doing it here keeps the read inside an onChange closure
+                // instead of body. Cache writes only on actual transitions, so
+                // body re-evals a couple of times per drag (predicate
+                // boundary crossings) rather than every frame. (#77)
+                refreshCachedRawBoundaryExtensionState()
+            }
+            // #77 — every input the boundary-state compute reads (besides
+            // dragOffset, handled above; and proactive latch, handled by its
+            // own onChange below) must trigger a cache refresh so body stays
+            // in sync. These all change at discrete moments (drag begin/end,
+            // mode flip, day step, hourHeight, creation drag), not per frame.
+            .onChange(of: dragState.dragMode) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: dragState.dayColumnStep) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: hourHeight) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: proactiveLeadingExtensionLatch) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: creationPreviewByDay) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: previewCreation?.id) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
             }
             .onChange(of: verticalScrollY) { _, _ in
                 // If the scroll moves away from the top boundary while the

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1265,13 +1265,11 @@ struct TimelinePagerView: View {
             safetyFloor: calendarTimelineHourHeightMin
         )
     }
-    private var editMappingState: TimelineEditMappingState? {
-        calendarResolveEditMappingState(
-            creation: resolvedCreationEditMapping,
-            drag: resolvedDragEditMapping,
-            focused: resolvedFocusedEditMapping
-        )
-    }
+    // `editMappingState` / `editMappingPresentation` moved into
+    // `TimelineAxisDragOverlay` (the body of `timeAxis()`'s sub-view). Both
+    // read `dragState.dragOffset` transitively, so keeping them as
+    // body-scope computeds here would re-register the per-frame body
+    // dependency that #77 deletes. (#77)
 
     /// Computes the boundary-extension mapping state from the current drag /
     /// creation source. Reads `resolvedDragEditMapping` (which reads
@@ -1554,57 +1552,14 @@ struct TimelinePagerView: View {
     }
 
     private var resolvedDragEditMapping: (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
-        guard dragState.draggingEventID != nil else { return nil }
-        guard let range = calendarResolvedDragEditRange(
+        calendarResolvedDragEditMapping(
+            draggingEventID: dragState.draggingEventID,
             draggingOriginalRange: dragState.draggingOriginalRange,
             dragOffset: dragState.dragOffset,
             dragMode: dragState.dragMode,
-            hourHeight: hourHeight,
-            dayColumnStep: dragState.dayColumnStep
-        ) else { return nil }
-
-        let source: TimelineEditMappingSource
-        switch dragState.dragMode {
-        case .move:
-            source = .moveDrag
-        case .resizeTop:
-            source = .resizeTop
-        case .resizeBottom:
-            source = .resizeBottom
-        }
-
-        // For move drag, use the vertical-only range (no day shift) so the
-        // time marker and boundary extension track the source day column.
-        let effectiveRange: Event.TimeRange
-        if source == .moveDrag, let originalRange = dragState.draggingOriginalRange, hourHeight > 0 {
-            let rawOffsetSeconds = TimeInterval(dragState.dragOffset.y / hourHeight * 3600)
-            let snappedOffset = calendarPreviewOffsetSeconds(
-                rawOffsetSeconds: rawOffsetSeconds,
-                range: originalRange,
-                snapIntervalSeconds: 15 * 60
-            )
-            effectiveRange = Event.TimeRange(
-                start: originalRange.start.addingTimeInterval(snappedOffset),
-                end: originalRange.end.addingTimeInterval(snappedOffset)
-            )
-        } else {
-            effectiveRange = range
-        }
-
-        // For move drag, anchor to the source day so the time marker
-        // Y aligns with the vertical-only range (no day shift mismatch).
-        let anchorDate: Date
-        if source == .moveDrag, let originalRange = dragState.draggingOriginalRange {
-            anchorDate = Calendar.current.startOfDay(for: originalRange.start)
-        } else {
-            anchorDate = calendarResolvedDragAnchorDate(
-                draggingOriginalRange: dragState.draggingOriginalRange,
-                dragOffset: dragState.dragOffset,
-                dragMode: dragState.dragMode,
-                dayColumnStep: dragState.dayColumnStep
-            ) ?? effectiveRange.start
-        }
-        return (source, anchorDate, effectiveRange)
+            dayColumnStep: dragState.dayColumnStep,
+            hourHeight: hourHeight
+        )
     }
 
     private var resolvedFocusedEditMapping: (date: Date, range: Event.TimeRange)? {
@@ -1617,39 +1572,6 @@ struct TimelinePagerView: View {
             visibleOffsets: visibleOffsets,
             occurrencesForOffset: occurrencesForOffset
         )
-    }
-
-    private var editMappingPresentation: TimelineAxisMarkerPresentation? {
-        // Hide time marker during vertical auto-scroll — it reappears
-        // once the user returns to normal (snapping) drag territory.
-        if editMappingState?.source == .moveDrag,
-           dragState.isHorizontalEdgeDragging || dragState.isHorizontalAutoScrolling {
-            return nil
-        }
-        guard var presentation = calendarResolveAxisMarkerPresentation(
-            mappingState: editMappingState,
-            headerHeight: headerHeight,
-            hourHeight: hourHeight,
-            leadingExtendedHours: boundaryExtensionHours.leading,
-            trailingExtendedHours: boundaryExtensionHours.trailing
-        ) else { return nil }
-
-        // Use the event's theme color from drag state, focused state, or creation
-        if let draggingEvent = dragState.draggingEvent {
-            presentation.color = CalendarLayout.eventColor(for: draggingEvent)
-        } else if let focusedEventID {
-            let visibleOffsets = Array(visibleOffsetsRange(centeredRange: centeredOffsetsRange()))
-            for offset in visibleOffsets {
-                if let match = occurrencesForOffset(offset).first(where: { $0.event.id == focusedEventID }) {
-                    presentation.color = CalendarLayout.eventColor(for: match.event)
-                    break
-                }
-            }
-        } else if editMappingState?.source == .creation {
-            presentation.color = calendarCurrentTimeIndicatorColor()
-        }
-
-        return presentation
     }
 
     var body: some View {
@@ -1708,50 +1630,49 @@ struct TimelinePagerView: View {
 
     // MARK: - Time Axis
 
-    @ViewBuilder
-    private func timeAxis() -> some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 0) {
-                if allDayHeight > 0 {
-                    Color.clear.frame(height: allDayHeight)
-                }
-                if useCALayerAxisMarkers {
-                    TimeAxisLayerHost(
-                        anchorDate: dayDate(forOffset: selectedDayOffset),
-                        headerHeight: headerHeight,
-                        hourHeight: hourHeight,
-                        slotMinutes: effectiveSlotMinutes,
-                        leadingExtendedHours: boundaryExtensionHours.leading,
-                        trailingExtendedHours: boundaryExtensionHours.trailing,
-                        mode: mode,
-                        editMappingPresentation: editMappingPresentation,
-                        leadingFadeProgress: leadingFadeProgress,
-                        trailingFadeProgress: trailingFadeProgress,
-                        isSingleDay: isSingleDay
-                    )
-                    .id(effectiveSlotMinutes)
-                    .transition(.opacity)
-                    .frame(height: timelineHeight, alignment: .top)
-                } else {
-                    TimeAxisLabels(
-                        anchorDate: dayDate(forOffset: selectedDayOffset),
-                        headerHeight: headerHeight,
-                        hourHeight: hourHeight,
-                        slotMinutes: effectiveSlotMinutes,
-                        leadingExtendedHours: boundaryExtensionHours.leading,
-                        trailingExtendedHours: boundaryExtensionHours.trailing,
-                        mode: mode,
-                        editMappingPresentation: editMappingPresentation,
-                        leadingFadeProgress: leadingFadeProgress,
-                        trailingFadeProgress: trailingFadeProgress,
-                        isSingleDay: isSingleDay
-                    )
-                    .id(effectiveSlotMinutes)
-                    .transition(.opacity)
-                    .frame(height: timelineHeight, alignment: .top)
-                }
+    /// Pre-resolves the focused-event tint color for `TimelineAxisDragOverlay`.
+    /// Walks visible occurrences to find the focused event and returns its
+    /// theme color. Reads `focusedEventID` + visible offsets + occurrencesForOffset
+    /// from body scope — none of those depend on `dragState.dragOffset`, so
+    /// these reads don't reintroduce a per-frame body dependency. (#77)
+    private var resolvedFocusedEventColor: Color? {
+        guard let focusedEventID else { return nil }
+        let visibleOffsets = Array(visibleOffsetsRange(centeredRange: centeredOffsetsRange()))
+        for offset in visibleOffsets {
+            if let match = occurrencesForOffset(offset).first(where: { $0.event.id == focusedEventID }) {
+                return CalendarLayout.eventColor(for: match.event)
             }
         }
+        return nil
+    }
+
+    @ViewBuilder
+    private func timeAxis() -> some View {
+        // #77: extracted into a sub-view so the parent body no longer reads
+        // `editMappingPresentation` (which transitively reads
+        // `dragState.dragOffset` via `resolvedDragEditMapping`). The sub-view's
+        // body still re-evaluates per drag frame — that compute can't be
+        // elided, only relocated — but the parent's no longer does.
+        TimelineAxisDragOverlay(
+            useCALayerAxisMarkers: useCALayerAxisMarkers,
+            allDayHeight: allDayHeight,
+            timelineHeight: timelineHeight,
+            anchorDate: dayDate(forOffset: selectedDayOffset),
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            effectiveSlotMinutes: effectiveSlotMinutes,
+            leadingExtendedHours: boundaryExtensionHours.leading,
+            trailingExtendedHours: boundaryExtensionHours.trailing,
+            mode: mode,
+            leadingFadeProgress: leadingFadeProgress,
+            trailingFadeProgress: trailingFadeProgress,
+            isSingleDay: isSingleDay,
+            dragState: dragState,
+            resolvedCreationEditMapping: resolvedCreationEditMapping,
+            resolvedFocusedEditMapping: resolvedFocusedEditMapping,
+            hasFocusedEvent: focusedEventID != nil,
+            focusedEventColor: resolvedFocusedEventColor
+        )
     }
 
     private let rangePinchBoundaryThreshold: CGFloat = 0.04
@@ -2785,6 +2706,146 @@ struct TimelinePagerView: View {
         }
     }
 
+}
+
+// MARK: - Time Axis Drag Overlay
+
+/// Sub-view that owns the per-drag-frame `editMappingPresentation` compute
+/// + axis rendering. Extracted from `TimelinePagerView.timeAxis()` so that
+/// `TimelinePagerView.body` no longer reads `dragState.dragOffset`
+/// transitively (the read happens INSIDE this sub-view's body, which
+/// re-evaluates per frame; the parent's does NOT).
+///
+/// Together with the `cachedRawBoundaryExtensionState` latch on the parent,
+/// this is the structural completion of the #75 → #76 → #77 arc: with both
+/// landed, the parent's `body` observes only discrete drag-session
+/// transitions (`draggingEventID`, `dragMode`, …) instead of every drag-frame
+/// `dragOffset` write. The per-frame cost survives — but it's bounded to this
+/// small sub-view's body, not the entire `TimelinePagerView` body. (#77)
+private struct TimelineAxisDragOverlay: View {
+    // Static axis chrome inputs (mirror of `timeAxis()`'s call into
+    // TimeAxisLayerHost / TimeAxisLabels).
+    let useCALayerAxisMarkers: Bool
+    let allDayHeight: CGFloat
+    let timelineHeight: CGFloat
+    let anchorDate: Date
+    let headerHeight: CGFloat
+    let hourHeight: CGFloat
+    let effectiveSlotMinutes: Int
+    let leadingExtendedHours: Int
+    let trailingExtendedHours: Int
+    let mode: PageMode
+    let leadingFadeProgress: CGFloat
+    let trailingFadeProgress: CGFloat
+    let isSingleDay: Bool
+
+    // Mapping inputs. `dragState` is read for `dragOffset` etc. inside this
+    // sub-view's body — that's the whole point of the extraction. The
+    // creation / focused mappings are precomputed by the parent (they don't
+    // depend on `dragOffset` so the parent computing them doesn't register
+    // a parent-body dep).
+    let dragState: EventDragState
+    let resolvedCreationEditMapping: (date: Date, range: Event.TimeRange)?
+    let resolvedFocusedEditMapping: (date: Date, range: Event.TimeRange)?
+    /// Whether a focused event is currently selected — gates the focused-event
+    /// color tint inside `editMappingPresentation`. Precomputed by parent.
+    let hasFocusedEvent: Bool
+    /// Pre-resolved focused-event tint color. Parent walks visible occurrences
+    /// to find the focused event's theme color, so the sub-view doesn't have
+    /// to take `occurrencesForOffset` + visible-offsets as input (which would
+    /// pull in more parent state).
+    let focusedEventColor: Color?
+
+    private var resolvedDragEditMapping: (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
+        calendarResolvedDragEditMapping(
+            draggingEventID: dragState.draggingEventID,
+            draggingOriginalRange: dragState.draggingOriginalRange,
+            dragOffset: dragState.dragOffset,
+            dragMode: dragState.dragMode,
+            dayColumnStep: dragState.dayColumnStep,
+            hourHeight: hourHeight
+        )
+    }
+
+    private var editMappingState: TimelineEditMappingState? {
+        calendarResolveEditMappingState(
+            creation: resolvedCreationEditMapping,
+            drag: resolvedDragEditMapping,
+            focused: resolvedFocusedEditMapping
+        )
+    }
+
+    private var editMappingPresentation: TimelineAxisMarkerPresentation? {
+        // Hide time marker during vertical auto-scroll — it reappears
+        // once the user returns to normal (snapping) drag territory.
+        if editMappingState?.source == .moveDrag,
+           dragState.isHorizontalEdgeDragging || dragState.isHorizontalAutoScrolling {
+            return nil
+        }
+        guard var presentation = calendarResolveAxisMarkerPresentation(
+            mappingState: editMappingState,
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            leadingExtendedHours: leadingExtendedHours,
+            trailingExtendedHours: trailingExtendedHours
+        ) else { return nil }
+
+        // Use the event's theme color from drag state, focused state, or creation
+        if let draggingEvent = dragState.draggingEvent {
+            presentation.color = CalendarLayout.eventColor(for: draggingEvent)
+        } else if hasFocusedEvent, let focusedEventColor {
+            presentation.color = focusedEventColor
+        } else if editMappingState?.source == .creation {
+            presentation.color = calendarCurrentTimeIndicatorColor()
+        }
+
+        return presentation
+    }
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 0) {
+                if allDayHeight > 0 {
+                    Color.clear.frame(height: allDayHeight)
+                }
+                if useCALayerAxisMarkers {
+                    TimeAxisLayerHost(
+                        anchorDate: anchorDate,
+                        headerHeight: headerHeight,
+                        hourHeight: hourHeight,
+                        slotMinutes: effectiveSlotMinutes,
+                        leadingExtendedHours: leadingExtendedHours,
+                        trailingExtendedHours: trailingExtendedHours,
+                        mode: mode,
+                        editMappingPresentation: editMappingPresentation,
+                        leadingFadeProgress: leadingFadeProgress,
+                        trailingFadeProgress: trailingFadeProgress,
+                        isSingleDay: isSingleDay
+                    )
+                    .id(effectiveSlotMinutes)
+                    .transition(.opacity)
+                    .frame(height: timelineHeight, alignment: .top)
+                } else {
+                    TimeAxisLabels(
+                        anchorDate: anchorDate,
+                        headerHeight: headerHeight,
+                        hourHeight: hourHeight,
+                        slotMinutes: effectiveSlotMinutes,
+                        leadingExtendedHours: leadingExtendedHours,
+                        trailingExtendedHours: trailingExtendedHours,
+                        mode: mode,
+                        editMappingPresentation: editMappingPresentation,
+                        leadingFadeProgress: leadingFadeProgress,
+                        trailingFadeProgress: trailingFadeProgress,
+                        isSingleDay: isSingleDay
+                    )
+                    .id(effectiveSlotMinutes)
+                    .transition(.opacity)
+                    .frame(height: timelineHeight, alignment: .top)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - Time Axis Labels


### PR DESCRIPTION
## Summary

Structural follow-on to #75/#76. Lifts the second body-scope reader the
#76 audit identified — `resolvedDragEditMapping` — so `TimelinePagerView.body`
no longer observes `dragState.dragOffset` per drag frame.

Two readers, two shapes:

1. **`boundaryExtensionHours` chain** (read by body via `.animation`,
   `frame(height:)`, `dayColumns`, `extensionFadeMask`, etc.) — latched
   into a `@State` cache, refreshed by `.onChange` handlers. Effectively
   binary state (mostly `(0, 0)`; transitions only at midnight-crossing
   predicate or proactive latch). Same shape as #76's proactive latch,
   scaled up to a struct value.

2. **`editMappingPresentation`** (read by body via `timeAxis()` to draw
   the time pill that follows the finger) — extracted into a new
   sub-view `TimelineAxisDragOverlay`. The mapped time range is
   continuously changing per frame; can't be latched. Sub-view's body
   re-evals per frame, parent's does NOT.

## Refactor shape

**Hybrid Shape 1 + caching** (per the issue's sketch).

| Reader | Shape | Why |
|---|---|---|
| Boundary state chain (`boundaryExtensionHours`, `rawBoundaryExtensionState`, ...) | `@State` cache (Shape A-style latch) | Value is effectively binary at the predicate boundary; cache writes only on actual transitions |
| `editMappingPresentation` (time pill) | Leaf-reader sub-view (Shape 1) | Continuously changing per frame; relocate the per-frame cost, don't elide it |

## File-level summary

`Done/Views/Calendar/Components/Timeline/TimelineView.swift`:
- `editMappingState`, `editMappingPresentation` body-scope computeds: **REMOVED**. Both transitively read `dragOffset`; keeping them re-registers the per-frame body dep.
- `rawBoundaryExtensionHours` (computed) → `computeRawBoundaryExtensionHours(mappingState:)` (function, called only from onChange).
- `boundaryExtensionMappingState` (computed) → `computeBoundaryExtensionMappingState()` (function, called only from onChange).
- `rawBoundaryExtensionState` (computed) → reads new `@State cachedRawBoundaryExtensionState`. The compute path is `computeRawBoundaryExtensionState()` (function).
- `refreshCachedRawBoundaryExtensionState()` — write-if-changed helper, called from `.onChange` handlers covering every input the compute reads (`dragState.dragOffset/dragMode/dayColumnStep/draggingEventID`, `hourHeight`, `proactiveLeadingExtensionLatch`, `creationPreviewByDay`, `previewCreation?.id`, `selectedDayOffset`).
- `resolvedDragEditMapping` (parent's) → now delegates to a free helper, called only from the cache-refresh path.
- New `private struct TimelineAxisDragOverlay` — owns `editMappingState` + `editMappingPresentation` + axis rendering (TimeAxisLayerHost / TimeAxisLabels). The per-frame compute lives here.
- `timeAxis()` body simplified to just host the sub-view.
- New `resolvedFocusedEventColor` — parent walks visible occurrences once for the focused-event tint, passes a `Color?` to the sub-view (so the sub-view doesn't need `occurrencesForOffset` itself).

`Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift`:
- New free function `calendarResolvedDragEditMapping(...)` — extracted from `TimelinePagerView.resolvedDragEditMapping` so both the parent (cache-refresh path) and the new sub-view can call it without code duplication.

## Verification status

**Deferred.** Same limitation #76 documented: manual sim-mouse drags don't reproduce sustained per-frame touch events, and I don't have a UI-test harness driving real touches. Did NOT commit instrumentation noise (no `_printChanges` adds, no body-eval counter overlay).

Code-level reasoning (post-refactor parent body's reads of `dragState`):
- ❌ `dragState.dragOffset` — gone from body scope. Reads exist in: (a) `.onChange` closures [not body-tracked], (b) `TimelineAxisDragOverlay.body` [child, not parent], (c) `resolvedDragEditMapping` / `computeBoundaryExtensionMappingState` / `computeRawBoundaryExtensionHours` [only called from `.onChange` handlers].
- ✅ `dragState.draggingEventID` / `dragMode` / `dayColumnStep` / `draggingOriginalRange` / `isHorizontalEdgeDragging` / `isHorizontalAutoScrolling` / `draggingEvent` — still read from body, but these are discrete (drag begin/end, mode flip, etc.), NOT per-frame.

So body should re-eval only on discrete drag-session transitions, not per drag frame. Reviewer with running device can confirm via `Self._printChanges()` at body entry.

Pre-existing test failures on `king-of-rubbish-bin` confirmed unchanged:
- `testLeadingBoundaryExtensionRemovalDoesNotSnapScrollToSpecificTime`
- `testRelationAwareOverlapLayoutSharesSlotBetweenParentAndInterrupt`

These pre-date #77 and are unrelated.

## Flag default

`AppSettingsKeys.calendarUseCALayerAxisMarkers` default stays **OFF**.

Rationale: the acceptance bar in #75 is "body does NOT re-evaluate during axis-drag frames." Code-level reasoning says this is now met, but #76 declined to flip without measurement and the same constraint applies here. The body-eval delta is the load-bearing claim for flipping the flag; flipping it without empirical confirmation would put the experimental gate up against the same blind spot.

Reviewer with a running device should A/B before flipping: drag an event on both flag states with `Self._printChanges()` at `TimelinePagerView.body` entry. If body re-evals only on `dragState.draggingEventID` transitions (drag begin/end), this PR has done its job and the flag can flip in a follow-up.

## Co-existence with #76's latch

The proactive leading-extension latch (`proactiveLeadingExtensionLatch`) is **preserved**. It encodes a different concern: the #53 single-day cross-day predicate that fires when scroll is pinned at top and finger is dragging upward. That predicate has its own update cycle (`.onChange(of: dragState.dragOffset.y)` for the trigger guards), independent of the cache-refresh path.

After #77:
- `proactiveLeadingExtensionLatch` (Bool @State) — set/cleared by the trigger guards.
- `cachedRawBoundaryExtensionState` (TimelineBoundaryExtensionState @State) — reads the latch as one input among many (drag fields, hourHeight, creation source). When the latch flips, the cache refreshes via the latch's onChange handler.

Both serve their original purposes; neither is now redundant.

## Test plan

- [ ] Single-day cross-midnight drag (#53 path): drag an event upward when scroll is pinned at top — leading extension should still open
- [ ] 3-day / week boundary extension: should NOT fire (unchanged gate inside `calendarTimelineBoundaryExtensionHours`)
- [ ] Drag end / abandon: extension closes, latch + cache clear
- [ ] Re-engage drag mid-extension: latch + cache re-engage cleanly
- [ ] Creation drag past midnight: leading/trailing extension opens during drag-create
- [ ] Focused event time pill: focused event with no active drag — pill shows event's color
- [ ] Time pill follows finger smoothly during drag (no 1-frame delay on the pill — it lives inside the sub-view's body, which DOES re-eval per frame)
- [ ] Boundary extension opens with at most 1-frame delay vs `king-of-rubbish-bin` baseline (accepted trade-off; matches #76's latch frame budget)

## Refs

- #75 — body-scope reader lift (parent)
- #76 — Option A latch (proactive trigger), landed
- #74 — CALayer axis port flag-OFF (the PR that left this prerequisite)
- #60 — CALayer axis spec
- #53 — single-day cross-midnight proactive-extension behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)