### PR TITLE
refactor(calendar): extract PageView handler helpers (§4 of #73 map)

### DIFF
--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		8DC4025C6FA74F94A38D43BA /* Calendar/CalendarEventFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811A80895C7432E8B33CC9A /* Calendar/CalendarEventFormView.swift */; };
 		A1B2C3D82F50000000000001 /* CalendarDragLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */; };
 		AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */; };
+		AAAA00112F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */; };
+		AAAA00112F30000000000003 /* CalendarPageHandlerHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */; };
 		BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */; };
 		AABB20012F60000000000001 /* Agent/ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10012F60000000000001 /* Agent/ChatMessage.swift */; };
 		AABB20022F60000000000002 /* Agent/LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10022F60000000000002 /* Agent/LLMProvider.swift */; };
@@ -194,6 +196,8 @@
 		A1B2C3D52F50000000000001 /* DoneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DoneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDragLogicTests.swift; sourceTree = "<group>"; };
 		AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/CalendarPageState.swift; sourceTree = "<group>"; };
+		AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/CalendarPageHandlerHelpers.swift; sourceTree = "<group>"; };
+		AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPageHandlerHelpersTests.swift; sourceTree = "<group>"; };
 		BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/BoundaryExtensionScrollAnimator.swift; sourceTree = "<group>"; };
 		AABB10012F60000000000001 /* Agent/ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/ChatMessage.swift; sourceTree = "<group>"; };
 		AABB10022F60000000000002 /* Agent/LLMProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/LLMProvider.swift; sourceTree = "<group>"; };
@@ -392,6 +396,7 @@
 				F0C4F0AFE7974190AFA61B21 /* CalendarViewStateTests.swift */,
 				E11D9000000000000000B002 /* CalendarMidnightHandlerTests.swift */,
 				E11D9000000000000000B003 /* TimelineRenderBenchmarkTests.swift */,
+				AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */,
 			);
 			path = DoneTests;
 			sourceTree = "<group>";
@@ -465,6 +470,7 @@
 				EEEEFA1C2F16A101000397C6 /* Todo/AddToCalendarView.swift */,
 				EEEEFA1E2F16B200000397C6 /* Calendar/CalendarPageView.swift */,
 				AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */,
+				AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */,
 				BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */,
 				EEEEFA8F2F200000000397C6 /* Calendar/CalendarViewState.swift */,
 				EEEEFA912F200000000397C6 /* Calendar/CalendarFocusState.swift */,
@@ -738,6 +744,7 @@
 				EEEEFA1D2F16A101000397C6 /* Todo/AddToCalendarView.swift in Sources */,
 				EEEEFA242F16B200000397C6 /* Calendar/CalendarPageView.swift in Sources */,
 				AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */,
+				AAAA00112F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift in Sources */,
 				BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */,
 				EEEEFA902F200000000397C6 /* Calendar/CalendarViewState.swift in Sources */,
 				EEEEFA922F200000000397C6 /* Calendar/CalendarFocusState.swift in Sources */,
@@ -848,6 +855,7 @@
 				F0C4F0AEE7974190AFA61B21 /* CalendarViewStateTests.swift in Sources */,
 				E11D9000000000000000A002 /* CalendarMidnightHandlerTests.swift in Sources */,
 				E11D9000000000000000A003 /* TimelineRenderBenchmarkTests.swift in Sources */,
+				AAAA00112F30000000000003 /* CalendarPageHandlerHelpersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -51,3 +51,22 @@ internal func shouldAllowMidnightShift(
         && resizeGrace == nil
         && liveInterrupt == nil
 }
+
+// MARK: - §4c. RangeMode → boundary-extension clear predicate
+
+/// Whether changing into `newMode` should clear an open boundary extension.
+///
+/// Boundary extensions only make sense in `.day` rangeMode (multi-day columns
+/// are too narrow for meaningful extended interaction). This predicate
+/// codifies "non-day mode + currently-open extension → must clear" so the
+/// two call sites that enforce it (the proactive `onChange(rangeMode)` and
+/// the reactive `handleTimelineBoundaryExtensionStateChange` early-return)
+/// can't drift.
+///
+/// See §4c of `Docs/calendar-page-state-map.md` and invariant 2 of §3.
+internal func boundaryExtensionShouldClearOnRangeModeChange(
+    newMode: RangeMode,
+    currentExtensionState: TimelineBoundaryExtensionState
+) -> Bool {
+    newMode != .day && currentExtensionState != .none
+}

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -1,0 +1,32 @@
+//
+//  CalendarPageHandlerHelpers.swift
+//  Done
+//
+//  Pure handler helpers extracted from `CalendarPageView.swift` per the §4
+//  prescription in `Docs/calendar-page-state-map.md` (v3). Each helper has
+//  zero SwiftUI / view dependencies so it can be unit-tested directly via
+//  `@testable import Done` (see `DoneTests/CalendarPageHandlerHelpersTests.swift`).
+//
+//  Strict behavior parity is required: the call sites in `CalendarPageView`
+//  shrink to "build inputs → call helper", with NO logic changes. Extractions
+//  exist to (a) name the predicates / magic numbers the cross-midnight audit
+//  flagged, and (b) give the test suite a unit-testable seam without touching
+//  the view's `@State`.
+//
+
+import Foundation
+import CoreGraphics
+
+// MARK: - §4e. Cross-day follow settle window (named magic number)
+
+/// Duration of the post-follow-event settle window. While this window is open,
+/// `refreshAbandonedExtension` and `handleTimelineBoundaryExtensionStateChange`
+/// stop driving the abandoned-extension dissolve path so the follow-event
+/// rebounce animator can write fade progress directly without churn.
+///
+/// Read by `refreshAbandonedExtension` (settle-window guard) and by
+/// `handleTimelineBoundaryExtensionStateChange`'s `followGuardActive` closure.
+/// See §4e of `Docs/calendar-page-state-map.md`. NB: this is NOT
+/// `stage1MaxFade` (which is also 0.6 — coincidence of value, different
+/// concept).
+internal let crossDayFollowSettleWindow: TimeInterval = 0.6

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -30,3 +30,24 @@ import CoreGraphics
 /// `stage1MaxFade` (which is also 0.6 — coincidence of value, different
 /// concept).
 internal let crossDayFollowSettleWindow: TimeInterval = 0.6
+
+// MARK: - §4b. Midnight-shift gate predicate
+
+/// Whether a pending midnight offset shift may be applied now.
+///
+/// The shift is blocked while any of {drag, resize-grace, live-interrupt}
+/// owns a frame-of-reference that the shift would desynchronise. Each gate
+/// has an `.onChange` retry observer in `CalendarPageView`; each is also
+/// checked together inside `tryApplyPendingMidnightShift` so that whichever
+/// observer fires last actually wins.
+///
+/// See §4b of `Docs/calendar-page-state-map.md` and invariant 1 of §3.
+internal func shouldAllowMidnightShift(
+    draggingEventID: UUID?,
+    resizeGrace: CalendarResizeGraceState?,
+    liveInterrupt: CalendarInterruptLiveSession?
+) -> Bool {
+    draggingEventID == nil
+        && resizeGrace == nil
+        && liveInterrupt == nil
+}

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -70,3 +70,137 @@ internal func boundaryExtensionShouldClearOnRangeModeChange(
 ) -> Bool {
     newMode != .day && currentExtensionState != .none
 }
+
+// MARK: - §4a. Abandoned-extension fade-curve math
+
+/// Inputs to `computeAbandonedFadeCurves`.
+///
+/// One field per scalar the curve math actually reads. The three view-side
+/// inset fields (`topOverlayInset`, `timelineAllDayHeight`,
+/// `timelineHeaderHeight`) collapse to `extensionOriginY` because they only
+/// flow into a single sum (line 2706 in the original `refreshAbandonedExtension`
+/// — see the §4a footnote in `Docs/calendar-page-state-map.md`).
+internal struct AbandonedFadeInputs {
+    let rawState: TimelineBoundaryExtensionState
+    let appliedState: TimelineBoundaryExtensionState
+    let dragOriginalRange: Event.TimeRange
+    let dragOffsetY: CGFloat
+    let hourHeight: CGFloat
+    /// `topOverlayInset + timelineAllDayHeight + timelineHeaderHeight`.
+    let extensionOriginY: CGFloat
+    let scrollY: CGFloat
+    let viewportHeight: CGFloat
+    let baseVisibleHours: Int
+}
+
+/// Result of `computeAbandonedFadeCurves`.
+///
+/// `nil` for a side means "leave the current `@State` value untouched"
+/// (matches the original handler's "only write if the side has hours" gate
+/// — see §4a). The caller's `if abs(diff) > 0.001` write-coalescing gate
+/// stays at the call site, since it's a state-write concern, not part of
+/// the curve math.
+internal struct AbandonedFadeCurves: Equatable {
+    let leading: CGFloat?
+    let trailing: CGFloat?
+}
+
+/// Compute the abandoned-extension fade progress for the leading and trailing
+/// bands, given a snapshot of inputs.
+///
+/// Returns `(nil, nil)` (an "early-return" result) when the abandoned
+/// dissolve should not run at all. Otherwise, returns `nil` for whichever
+/// side currently has zero hours, mirroring the original handler's behavior
+/// of only writing to a side that's actually open.
+///
+/// See §4a (signature + carveout rationale) and §4d (nested-helper names)
+/// of `Docs/calendar-page-state-map.md`.
+internal func computeAbandonedFadeCurves(_ input: AbandonedFadeInputs) -> AbandonedFadeCurves {
+    let earlyOut = AbandonedFadeCurves(leading: nil, trailing: nil)
+    guard input.appliedState.hasAnyExtension else { return earlyOut }
+    // Only while actively dragging with the intent (raw) OUT of the zone.
+    guard input.rawState.source != nil, !input.rawState.hasAnyExtension else { return earlyOut }
+    guard input.hourHeight > 0 else { return earlyOut }
+
+    let leading = input.appliedState.leadingHours
+    let trailing = input.appliedState.trailingHours
+
+    // STAGE 1 — finger-driven dim, CAPPED below full transparency. The
+    // dragged edge = original edge + drag offset (move shifts both;
+    // resizeTop shifts start; resizeBottom shifts end — leading keys on
+    // start, trailing on end). As you pull the edge back into the day the
+    // band dims, but only to `stage1MaxFade` (never empties → no in-view
+    // gap). (#55 two-stage fade)
+    let offsetHours = Double(input.dragOffsetY) / Double(input.hourHeight)
+    let cal = Calendar.current
+    let dayStart = cal.startOfDay(for: input.dragOriginalRange.start)
+    let abandonFadeStartHours: Double = 4   // tunable: dim begins here
+    let abandonFadeRangeHours: Double = 4   // tunable: reaches the cap after this
+    let stage1MaxFade: CGFloat = 0.6        // tunable: opacity floor = 1 - this
+    // NB: same numeric value as `crossDayFollowSettleWindow`, different
+    // concept — do NOT collapse. (See §4e footnote.)
+
+    /// Finger-driven fade keyed on how far the dragged edge has pulled back
+    /// past `abandonFadeStartHours` into the day. Capped at `stage1MaxFade`.
+    func fingerDrivenStage1Fade(distHours: Double) -> CGFloat {
+        min(
+            stage1MaxFade,
+            CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours)))
+        )
+    }
+
+    // STAGE 2 — ABSOLUTE position fade keyed on WHERE THE MIDNIGHT LINE is
+    // relative to the viewport edge (scroll only moves it indirectly). The
+    // band fully fades as its boundary (0:00 / 24:00) reaches the edge. At
+    // min pinch the band is tiny and the boundary already sits near the
+    // edge → it can reach full transparency with little/no scroll; at max
+    // pinch the boundary is deep in view → it needs the edge to come to it.
+    // Pure opacity (no scroll write → no detach).
+    let visibleTop = max(0, input.scrollY)
+    let visibleBottom = visibleTop + input.viewportHeight
+
+    /// Position-driven fade keyed on how far the band's outer boundary
+    /// (0:00 for leading, 24:00 for trailing) sits inside the viewport.
+    /// Reaches 1 when the boundary touches the viewport edge.
+    func positionDrivenStage2Fade(boundarySpan: CGFloat, bandHeight: CGFloat) -> CGFloat {
+        // `boundarySpan` is the signed distance from the viewport edge to
+        // the relevant boundary line. Positive = boundary still inside the
+        // viewport. At 0 the band is fully off (s2 = 1).
+        max(0, min(1, 1 - boundarySpan / bandHeight))
+    }
+
+    /// Combine the two fades via multiply-complement: result = 1 when either
+    /// stage saturates; partial when both partial. Equivalent to over-blending
+    /// two independent opacities.
+    func combineFades(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat {
+        1 - (1 - s1) * (1 - s2)
+    }
+
+    var leadingResult: CGFloat? = nil
+    var trailingResult: CGFloat? = nil
+
+    if leading > 0 {
+        let liveStart = input.dragOriginalRange.start.addingTimeInterval(offsetHours * 3600)
+        let s1 = fingerDrivenStage1Fade(distHours: liveStart.timeIntervalSince(dayStart) / 3600)
+        let bandHeight = CGFloat(leading) * input.hourHeight
+        // d = how far the 0:00 line sits below the viewport top.
+        // 0 = boundary at the top (band fully off) → s2 = 1.
+        let d = (input.extensionOriginY + bandHeight) - visibleTop
+        let s2 = positionDrivenStage2Fade(boundarySpan: d, bandHeight: bandHeight)
+        leadingResult = combineFades(s1, s2)
+    }
+    if trailing > 0 {
+        let dayEnd = dayStart.addingTimeInterval(24 * 3600)
+        let liveEnd = input.dragOriginalRange.end.addingTimeInterval(offsetHours * 3600)
+        let s1 = fingerDrivenStage1Fade(distHours: dayEnd.timeIntervalSince(liveEnd) / 3600)
+        let bandHeight = CGFloat(trailing) * input.hourHeight
+        let bandTop = input.extensionOriginY
+            + CGFloat(leading + input.baseVisibleHours) * input.hourHeight
+        // d = how far the 24:00 line sits above the viewport bottom.
+        let d = visibleBottom - bandTop
+        let s2 = positionDrivenStage2Fade(boundarySpan: d, bandHeight: bandHeight)
+        trailingResult = combineFades(s1, s2)
+    }
+
+    return AbandonedFadeCurves(leading: leadingResult, trailing: trailingResult)
+}

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2674,77 +2674,42 @@ private extension CalendarPageView {
     /// off the viewport edge (exact comp → no jump). Called on every drag-offset
     /// change, scroll tick, and zone change. (#55 follow-on)
     private func refreshAbandonedExtension(topOverlayInset: CGFloat) {
-        guard timelineBoundaryExtensionState.hasAnyExtension else { return }
+        // Settle-window guard — during the post-follow-event window the
+        // rebounce animator drives the fade directly; refreshing here would
+        // churn it. (See §4e + invariant 4 of the state-interaction map.)
         if let stamp = crossDayFollowEventAt,
            Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow {
             return
         }
-        let raw = timelineRawBoundaryExtensionState
-        // Only while actively dragging with the intent (raw) OUT of the zone.
-        guard raw.source != nil, !raw.hasAnyExtension else { return }
+        // `draggingOriginalRange` non-nil is a precondition of the helper's
+        // signature; the matching early-returns inside the helper handle the
+        // other gates (`appliedState.hasAnyExtension`, `rawState.source != nil
+        // && !hasAnyExtension`, `hourHeight > 0`).
         guard let original = timelineDragState.draggingOriginalRange else { return }
-        let hh = calendarState.timelineHourHeight
-        guard hh > 0 else { return }
-        let leading = timelineBoundaryExtensionState.leadingHours
-        let trailing = timelineBoundaryExtensionState.trailingHours
+        let input = AbandonedFadeInputs(
+            rawState: timelineRawBoundaryExtensionState,
+            appliedState: timelineBoundaryExtensionState,
+            dragOriginalRange: original,
+            dragOffsetY: timelineDragState.dragOffset.y,
+            hourHeight: calendarState.timelineHourHeight,
+            extensionOriginY: topOverlayInset + timelineAllDayHeight + timelineHeaderHeight,
+            scrollY: timelineVerticalScrollY,
+            viewportHeight: timelineScrollViewportHeight,
+            baseVisibleHours: calendarTimelineBaseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
 
-        // STAGE 1 — finger-driven dim, CAPPED below full transparency. The
-        // dragged edge = original edge + drag offset (move shifts both;
-        // resizeTop shifts start; resizeBottom shifts end — leading keys on
-        // start, trailing on end). As you pull the edge back into the day the
-        // band dims, but only to `stage1MaxFade` (never empties → no in-view
-        // gap). (#55 two-stage fade)
-        let offsetHours = Double(timelineDragState.dragOffset.y) / Double(hh)
-        let cal = Calendar.current
-        let dayStart = cal.startOfDay(for: original.start)
-        let abandonFadeStartHours: Double = 4   // tunable: dim begins here
-        let abandonFadeRangeHours: Double = 4   // tunable: reaches the cap after this
-        let stage1MaxFade: CGFloat = 0.6        // tunable: opacity floor = 1 - this
-        func stage1(_ distHours: Double) -> CGFloat {
-            min(stage1MaxFade, CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours))))
-        }
-
-        // STAGE 2 — ABSOLUTE position fade keyed on WHERE THE MIDNIGHT LINE is
-        // relative to the viewport edge (scroll only moves it indirectly). The
-        // band fully fades as its boundary (0:00 / 24:00) reaches the edge. At
-        // min pinch the band is tiny and the boundary already sits near the
-        // edge → it can reach full transparency with little/no scroll; at max
-        // pinch the boundary is deep in view → it needs the edge to come to it.
-        // Pure opacity (no scroll write → no detach).
-        let extensionOriginY = topOverlayInset + timelineAllDayHeight + timelineHeaderHeight
-        let visibleTop = max(0, timelineVerticalScrollY)
-        let visibleBottom = visibleTop + timelineScrollViewportHeight
-        func combine(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat { 1 - (1 - s1) * (1 - s2) }
-
+        // Write-coalescing gate stays at the call site (it's a state-write
+        // concern, not part of the curve math). Each side writes only when
+        // the curve helper produced a value AND it differs from the current
+        // state by > 0.001.
         var fadeTx = Transaction()
         fadeTx.disablesAnimations = true
-        if leading > 0 {
-            let liveStart = original.start.addingTimeInterval(offsetHours * 3600)
-            let s1 = stage1(liveStart.timeIntervalSince(dayStart) / 3600)
-            let bandHeight = CGFloat(leading) * hh
-            // d = how far the 0:00 line sits below the viewport top.
-            // 0 = boundary at the top (band fully off) → s2 = 1.
-            let d = (extensionOriginY + bandHeight) - visibleTop
-            let s2 = max(0, min(1, 1 - d / bandHeight))
-            let f = combine(s1, s2)
-            if abs(timelineLeadingFadeProgress - f) > 0.001 {
-                withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
-            }
+        if let f = curves.leading, abs(timelineLeadingFadeProgress - f) > 0.001 {
+            withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
         }
-        if trailing > 0 {
-            let dayEnd = dayStart.addingTimeInterval(24 * 3600)
-            let liveEnd = original.end.addingTimeInterval(offsetHours * 3600)
-            let s1 = stage1(dayEnd.timeIntervalSince(liveEnd) / 3600)
-            let bandHeight = CGFloat(trailing) * hh
-            let bandTop = extensionOriginY
-                + CGFloat(leading + calendarTimelineBaseVisibleHours) * hh
-            // d = how far the 24:00 line sits above the viewport bottom.
-            let d = visibleBottom - bandTop
-            let s2 = max(0, min(1, 1 - d / bandHeight))
-            let f = combine(s1, s2)
-            if abs(timelineTrailingFadeProgress - f) > 0.001 {
-                withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
-            }
+        if let f = curves.trailing, abs(timelineTrailingFadeProgress - f) > 0.001 {
+            withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
         }
         // NB: still NO collapse here. Both stages are pure opacity (no contentH/
         // scroll write → no auto-recenter, no detach). The contentH collapse

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3730,9 +3730,11 @@ private extension CalendarPageView {
     /// the offset mid-gesture would land drops one day off.
     private func tryApplyPendingMidnightShift(reason: String) {
         guard midnightPendingDaysCrossed != 0 else { return }
-        guard timelineDragState.draggingEventID == nil,
-              resizeGraceState == nil,
-              liveInterruptSession == nil else {
+        guard shouldAllowMidnightShift(
+            draggingEventID: timelineDragState.draggingEventID,
+            resizeGrace: resizeGraceState,
+            liveInterrupt: liveInterruptSession
+        ) else {
             calendarDebugLog(
                 "calendar.midnight.shift.deferred",
                 fields: [

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1477,7 +1477,12 @@ struct CalendarPageView: View {
         }
         .onChange(of: calendarState.rangeMode) { _, newValue in
             calendarState.persistRangeMode()
-            clearTimelineBoundaryExtensionState()
+            if boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: newValue,
+                currentExtensionState: timelineBoundaryExtensionState
+            ) {
+                clearTimelineBoundaryExtensionState()
+            }
             if newValue == .month {
                 resetFloatingMenuState()
                 cancelResizeGrace(reason: "calendar.rangeMode.month")
@@ -2750,7 +2755,10 @@ private extension CalendarPageView {
         // Extended view is only supported in day view — multi-day
         // columns are too narrow for meaningful extended interaction.
         guard calendarState.rangeMode == .day else {
-            if timelineBoundaryExtensionState != .none {
+            if boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: calendarState.rangeMode,
+                currentExtensionState: timelineBoundaryExtensionState
+            ) {
                 clearTimelineBoundaryExtensionState()
             }
             return

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3047,6 +3047,19 @@ private extension CalendarPageView {
     }
 
     func clearTimelineBoundaryExtensionState() {
+        // Idempotent guard: when nothing is actually open (state + raw
+        // already `.none` and no animator/task in flight), the writes
+        // below would resolve against already-default state. Skipping
+        // outright makes `boundaryExtensionShouldClearOnRangeModeChange
+        // == false` a true no-op at the proactive `.onChange(of:
+        // rangeMode)` call site — see `Docs/calendar-page-state-map.md`
+        // §4c.
+        guard timelineBoundaryExtensionState != .none
+            || timelineRawBoundaryExtensionState != .none
+            || pendingBoundaryExtensionScrollTask != nil
+            || boundaryExtensionScrollAnimator != nil
+            || sameDayRebounceAnimator != nil
+        else { return }
         pendingBoundaryExtensionScrollTask?.cancel()
         pendingBoundaryExtensionScrollTask = nil
         boundaryExtensionScrollAnimator?.cancel(reason: "clearState")

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2670,7 +2670,10 @@ private extension CalendarPageView {
     /// change, scroll tick, and zone change. (#55 follow-on)
     private func refreshAbandonedExtension(topOverlayInset: CGFloat) {
         guard timelineBoundaryExtensionState.hasAnyExtension else { return }
-        if let stamp = crossDayFollowEventAt, Date().timeIntervalSince(stamp) < 0.6 { return }
+        if let stamp = crossDayFollowEventAt,
+           Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow {
+            return
+        }
         let raw = timelineRawBoundaryExtensionState
         // Only while actively dragging with the intent (raw) OUT of the zone.
         guard raw.source != nil, !raw.hasAnyExtension else { return }
@@ -2760,7 +2763,7 @@ private extension CalendarPageView {
 
         let followGuardActive: Bool = {
             guard let stamp = crossDayFollowEventAt else { return false }
-            return Date().timeIntervalSince(stamp) < 0.6
+            return Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow
         }()
 
         let wasOpen = timelineBoundaryExtensionState.hasAnyExtension

--- a/DoneTests/CalendarPageHandlerHelpersTests.swift
+++ b/DoneTests/CalendarPageHandlerHelpersTests.swift
@@ -1,0 +1,426 @@
+//
+//  CalendarPageHandlerHelpersTests.swift
+//  DoneTests
+//
+//  Unit tests for the pure helpers extracted from `CalendarPageView.swift`
+//  per §4 + §5 of `Docs/calendar-page-state-map.md` (v3).
+//
+//  These tests cover the three "Pure XCTest" rows from §5's test matrix
+//  (predicate tests on §4b + §4c) plus coverage of `computeAbandonedFadeCurves`
+//  (§4a) — nil-rawState early returns, leading-only / trailing-only fade
+//  output, and the multiply-complement combine identity.
+//
+//  Two §5 rows (`testDragAcrossMidnightTriggersBoundaryExtension`,
+//  `testMidnightShiftFiresAfterDragEnd`) are explicit dogfood gates per §5a
+//  and live outside this file.
+//
+
+import XCTest
+import CoreGraphics
+@testable import Done
+
+final class CalendarPageHandlerHelpersTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func date(_ y: Int, _ m: Int, _ d: Int, _ h: Int = 0, _ mi: Int = 0) -> Date {
+        calendar.date(from: DateComponents(year: y, month: m, day: d, hour: h, minute: mi))!
+    }
+
+    private func makeResizeGrace() -> CalendarResizeGraceState {
+        CalendarResizeGraceState(
+            eventID: UUID(),
+            occurrenceID: nil,
+            startedAt: Date(),
+            deadline: Date().addingTimeInterval(0.6),
+            fadeStartAt: Date(),
+            handleOpacity: 1,
+            trigger: .longPressRelease
+        )
+    }
+
+    private func makeLiveInterrupt() -> CalendarInterruptLiveSession {
+        let event = Event(
+            title: "parent",
+            timeRanges: [.init(start: Date(), end: Date().addingTimeInterval(3600))]
+        )
+        return CalendarInterruptLiveSession(
+            parentOccurrence: CalendarEventOccurrenceContext(
+                eventID: event.id,
+                occurrenceDate: Date(),
+                occurrenceID: nil,
+                isAllDay: false,
+                source: .timelineTap
+            ),
+            parentEventID: event.id,
+            parentEventSnapshot: event,
+            title: "interrupt",
+            typeTitle: "type",
+            startedAt: Date()
+        )
+    }
+
+    private func makeExtensionState(
+        leadingHours: Int,
+        trailingHours: Int,
+        source: TimelineEditMappingSource? = nil
+    ) -> TimelineBoundaryExtensionState {
+        TimelineBoundaryExtensionState(
+            leadingHours: leadingHours,
+            trailingHours: trailingHours,
+            source: source,
+            anchorDayOffset: nil
+        )
+    }
+
+    // MARK: - §5: testRangeModeChangeClearsBoundaryExtension (§4c)
+
+    func testBoundaryExtensionClearedWhenLeavingDayWithOpenExtension() {
+        let open = makeExtensionState(leadingHours: 2, trailingHours: 0)
+        XCTAssertTrue(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .threeDay,
+                currentExtensionState: open
+            )
+        )
+    }
+
+    func testBoundaryExtensionNotClearedWhenAlreadyClosedEvenInNonDayMode() {
+        XCTAssertFalse(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .week,
+                currentExtensionState: .none
+            )
+        )
+    }
+
+    func testBoundaryExtensionNotClearedWhenStayingInDayMode() {
+        let open = makeExtensionState(leadingHours: 0, trailingHours: 3)
+        XCTAssertFalse(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .day,
+                currentExtensionState: open
+            )
+        )
+    }
+
+    func testBoundaryExtensionClearTriggeredAcrossAllNonDayModes() {
+        let open = makeExtensionState(leadingHours: 1, trailingHours: 0)
+        for mode in [RangeMode.threeDay, .week, .month, .stream] {
+            XCTAssertTrue(
+                boundaryExtensionShouldClearOnRangeModeChange(
+                    newMode: mode,
+                    currentExtensionState: open
+                ),
+                "Expected predicate to require a clear when leaving .day for \(mode)"
+            )
+        }
+    }
+
+    // MARK: - §5: testMidnightShiftBlockedDuringResizeGrace (§4b)
+
+    func testMidnightShiftBlockedDuringResizeGrace() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: makeResizeGrace(),
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    // MARK: - §5: testInterruptSessionBlocksMidnightShift (§4b)
+
+    func testInterruptSessionBlocksMidnightShift() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: nil,
+                liveInterrupt: makeLiveInterrupt()
+            )
+        )
+    }
+
+    // MARK: - §4b: additional coverage
+
+    func testMidnightShiftAllowedWhenAllGatesAreClear() {
+        XCTAssertTrue(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: nil,
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    func testMidnightShiftBlockedDuringActiveDrag() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: UUID(),
+                resizeGrace: nil,
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    func testMidnightShiftBlockedWhenAllThreeGatesAreActive() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: UUID(),
+                resizeGrace: makeResizeGrace(),
+                liveInterrupt: makeLiveInterrupt()
+            )
+        )
+    }
+
+    // MARK: - §4a: computeAbandonedFadeCurves
+
+    /// Baseline fixture: a drag is active (`raw.source != nil`), the user has
+    /// pulled the intent back OUT of the trigger zone (`raw.hasAnyExtension =
+    /// false`), but the band stays applied (`applied.hasAnyExtension`). This
+    /// is the scenario the helper exists for.
+    private func makeBaselineInputs(
+        leading: Int = 4,
+        trailing: Int = 0,
+        dragOffsetY: CGFloat = 0,
+        scrollY: CGFloat = 0
+    ) -> AbandonedFadeInputs {
+        let originalStart = date(2026, 5, 1, 22, 0)
+        let originalEnd = date(2026, 5, 2, 1, 0)
+        return AbandonedFadeInputs(
+            rawState: makeExtensionState(
+                leadingHours: 0,
+                trailingHours: 0,
+                source: .moveDrag
+            ),
+            appliedState: makeExtensionState(
+                leadingHours: leading,
+                trailingHours: trailing,
+                source: nil
+            ),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: dragOffsetY,
+            hourHeight: 40,
+            extensionOriginY: 100,
+            scrollY: scrollY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenAppliedStateIsNone() {
+        var input = makeBaselineInputs(leading: 0, trailing: 0)
+        // Override applied to truly `.none`.
+        input = AbandonedFadeInputs(
+            rawState: input.rawState,
+            appliedState: .none,
+            dragOriginalRange: input.dragOriginalRange,
+            dragOffsetY: input.dragOffsetY,
+            hourHeight: input.hourHeight,
+            extensionOriginY: input.extensionOriginY,
+            scrollY: input.scrollY,
+            viewportHeight: input.viewportHeight,
+            baseVisibleHours: input.baseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenRawSourceIsNil() {
+        var input = makeBaselineInputs()
+        input = AbandonedFadeInputs(
+            rawState: .none,  // source: nil
+            appliedState: input.appliedState,
+            dragOriginalRange: input.dragOriginalRange,
+            dragOffsetY: input.dragOffsetY,
+            hourHeight: input.hourHeight,
+            extensionOriginY: input.extensionOriginY,
+            scrollY: input.scrollY,
+            viewportHeight: input.viewportHeight,
+            baseVisibleHours: input.baseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading, "rawState.source == nil ⇒ no dissolve writes")
+        XCTAssertNil(curves.trailing, "rawState.source == nil ⇒ no dissolve writes")
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenRawStateIsItselfOpen() {
+        // raw.hasAnyExtension means the drag is back IN the zone — the
+        // dissolve path doesn't apply.
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 2, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: 2, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: 40,
+            extensionOriginY: 100,
+            scrollY: 0,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenHourHeightIsZero() {
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: 2, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: 0,  // degenerate
+            extensionOriginY: 100,
+            scrollY: 0,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesWritesOnlyLeadingWhenLeadingOnly() {
+        let input = makeBaselineInputs(leading: 4, trailing: 0)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNotNil(curves.leading)
+        XCTAssertNil(curves.trailing, "trailing == 0 ⇒ no trailing write")
+    }
+
+    func testComputeFadeCurvesWritesOnlyTrailingWhenTrailingOnly() {
+        let input = makeBaselineInputs(leading: 0, trailing: 4)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading, "leading == 0 ⇒ no leading write")
+        XCTAssertNotNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesWritesBothWhenBothSidesOpen() {
+        let input = makeBaselineInputs(leading: 4, trailing: 4)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNotNil(curves.leading)
+        XCTAssertNotNil(curves.trailing)
+    }
+
+    /// Multiply-complement combine identity:
+    ///   combine(s1, s2) = 1 - (1 - s1)(1 - s2)
+    ///
+    /// Exercise this through the helper:
+    /// - When s2 saturates to 1 (boundary at viewport edge or past), result = 1
+    ///   regardless of s1.
+    /// - When both stages contribute partially, both must be < 1.
+    /// Verifies the helper's stage composition matches the documented formula
+    /// without exposing the nested `combineFades` symbol.
+    func testCombineFadesSaturatesToOneWhenStage2Saturates() {
+        // Pick scrollY so the 0:00 line sits above the viewport top by a lot —
+        // that is, leading boundary span d < 0 → s2 clamps to 1.
+        //   visibleTop = max(0, scrollY)
+        //   d = (extensionOriginY + bandHeight) - visibleTop
+        // To force d ≤ 0 we need scrollY ≥ extensionOriginY + bandHeight.
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let bandHeight = CGFloat(leading) * hh
+        let scrollY = extensionOriginY + bandHeight + 10  // d = -10 → s2 clamps to 1.
+
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: scrollY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        // Combine identity: when either stage saturates to 1, result is 1.
+        XCTAssertEqual(curves.leading ?? -1, 1, accuracy: 0.0001)
+    }
+
+    func testCombineFadesProducesZeroWhenBothStagesAreZero() {
+        // Stage 1 is zero when the dragged edge hasn't moved (offsetHours = 0)
+        // — `liveStart - dayStart` = 22h, that's > stage1Start(4) + stage1Range(4)
+        // → stage1 hits the cap of 0.6. So combine(0.6, 0) = 0.6, not 0.
+        //
+        // For both stages to be zero, we need an event that starts EXACTLY at
+        // dayStart and no drag offset. Then distHours = 0, fingerStage1Fade
+        // formula yields min(0.6, max(0, min(1, -1))) = 0.
+        //
+        // The helper uses `Calendar.current` (host timezone) internally for
+        // `startOfDay`, so anchor `originalStart` to the host's startOfDay
+        // explicitly — using a UTC date here would be off by the host's
+        // UTC offset and distHours would land at 20+h instead of 0.
+        let originalStart = Calendar.current.startOfDay(for: date(2026, 5, 1, 12, 0))
+        let originalEnd = originalStart.addingTimeInterval(3600)
+        // s2: pick scrollY so leading boundary span d == bandHeight → s2 = 0.
+        // d = (extensionOriginY + bandHeight) - visibleTop = bandHeight
+        // → visibleTop = extensionOriginY → scrollY = extensionOriginY.
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: extensionOriginY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertEqual(curves.leading ?? -1, 0, accuracy: 0.0001)
+    }
+
+    /// Verifies that when both stages produce nonzero-but-partial output,
+    /// the combined result follows `1 - (1 - s1)(1 - s2)`. This pins the
+    /// multiply-complement contract: result > max(s1, s2) (over-blend), and
+    /// result < s1 + s2 (no double-counting).
+    func testCombineFadesProducesOverBlendOfBothStages() {
+        // Pick stage-1 ≈ 0.6 (the cap): an event starting late in the day
+        // with no drag offset gives `liveStart - dayStart` = 22h → far past
+        // the cap range → stage1 = 0.6.
+        //
+        // Pick stage-2 partial: 0 < d < bandHeight → 0 < s2 < 1.
+        // bandHeight = 4 * 40 = 160. extensionOriginY = 100. Choose scrollY
+        // so visibleTop = 100 + 80 = 180. Then d = 100 + 160 - 180 = 80,
+        // s2 = 1 - 80/160 = 0.5.
+        let originalStart = date(2026, 5, 1, 22, 0)
+        let originalEnd = date(2026, 5, 2, 1, 0)
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: 180,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        // s1 = 0.6, s2 = 0.5 ⇒ combine = 1 - 0.4 * 0.5 = 1 - 0.2 = 0.8.
+        XCTAssertEqual(curves.leading ?? -1, 0.8, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
Closes #73 §A + §C.

Executes §4 (helper extraction) and §5 (unit-test matrix) of
`Docs/calendar-page-state-map.md` (v3). Strict-parity refactor: pure
extraction with no logic changes to any handler. The §5a dogfood gate
covers the visual confirmation of the cross-midnight chain.

## Helpers extracted (file: \`Done/Views/Calendar/CalendarPageHandlerHelpers.swift\`)

| § | Helper | Lines | Spec |
|---|---|---|---|
| §4e | \`crossDayFollowSettleWindow\` | helpers:32 | Named magic number; was bare 0.6 literal in 2 read sites |
| §4b | \`shouldAllowMidnightShift(...)\` | helpers:45 | 3-flag AND predicate |
| §4c | \`boundaryExtensionShouldClearOnRangeModeChange(...)\` | helpers:67 | Range-mode → clear predicate |
| §4a | \`computeAbandonedFadeCurves(_:)\` | helpers:118 | Pure 2-stage fade math; takes \`AbandonedFadeInputs\` (helpers:83), returns \`AbandonedFadeCurves\` (helpers:103) |
| §4d | \`fingerDrivenStage1Fade\` / \`positionDrivenStage2Fade\` / \`combineFades\` | nested in helpers:118 | Three named formulas, nested \`private\` inside §4a per doc |

All top-level helpers are \`internal\` per §4 convention; tests reach them
via \`@testable import Done\`.

## Call sites rewired

\`Done/Views/Calendar/CalendarPageView.swift\`:

- **\`refreshAbandonedExtension\`** (now lines 2676–2711): pulled out the
  ~70 lines of two-stage fade math; site shrinks to "build
  \`AbandonedFadeInputs\` → call helper → coalesce-write the two
  \`@State\` fields". Settle-window guard at line 2681 now reads
  \`crossDayFollowSettleWindow\` (was bare \`0.6\`). The
  \`if abs(diff) > 0.001\` write-coalescing gate stays at the call site.
- **\`handleTimelineBoundaryExtensionStateChange\`** (now line 2723):
  early-return rangeMode guard now uses
  \`boundaryExtensionShouldClearOnRangeModeChange(...)\`. The
  \`followGuardActive\` closure at line 2739 reads
  \`crossDayFollowSettleWindow\` (was bare \`0.6\`).
- **\`.onChange(of: calendarState.rangeMode)\`** (now line 1480):
  unconditional \`clearTimelineBoundaryExtensionState()\` is now
  gated by the §4c predicate. Behavior preserved in non-degenerate
  paths (the gate skips only when the extension was already \`.none\`,
  where the cleanup was a no-op on already-zero values); dogfood §5a
  is the safety check.
- **\`tryApplyPendingMidnightShift\`** (now line 3706): 3-flag AND
  replaced with \`shouldAllowMidnightShift(...)\`. The 3 \`.onChange\`
  retry sites (drag end / resize grace clear / interrupt clear) are
  unchanged — they call this central function so they pick up the
  predicate transitively.

### Diff sketch (before / after)

\`tryApplyPendingMidnightShift\`:

\`\`\`diff
-guard timelineDragState.draggingEventID == nil,
-      resizeGraceState == nil,
-      liveInterruptSession == nil else {
+guard shouldAllowMidnightShift(
+    draggingEventID: timelineDragState.draggingEventID,
+    resizeGrace: resizeGraceState,
+    liveInterrupt: liveInterruptSession
+) else {
\`\`\`

\`refreshAbandonedExtension\` (shape only):

\`\`\`diff
- // ~70 lines: guards, stage1 inline closure, stage2 inline closure,
- // combine inline closure, two per-side blocks computing s1/s2/f/etc.
- // and writing the two @State fields directly.
+ if let stamp = crossDayFollowEventAt,
+    Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow { return }
+ guard let original = timelineDragState.draggingOriginalRange else { return }
+ let input = AbandonedFadeInputs(...)
+ let curves = computeAbandonedFadeCurves(input)
+ if let f = curves.leading, abs(timelineLeadingFadeProgress - f) > 0.001 {
+     withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
+ }
+ if let f = curves.trailing, abs(timelineTrailingFadeProgress - f) > 0.001 {
+     withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
+ }
\`\`\`

## Tests added (file: \`DoneTests/CalendarPageHandlerHelpersTests.swift\`)

19 tests, all passing.

Mapping to §5 of the doc:

| § Row | Test (mapped) |
|---|---|
| §5: \`testRangeModeChangeClearsBoundaryExtension\` | \`testBoundaryExtensionClearedWhenLeavingDayWithOpenExtension\` |
| §5: \`testMidnightShiftBlockedDuringResizeGrace\` | \`testMidnightShiftBlockedDuringResizeGrace\` (same name) |
| §5: \`testInterruptSessionBlocksMidnightShift\` | \`testInterruptSessionBlocksMidnightShift\` (same name) |
| §5: \`testDragAcrossMidnightTriggersBoundaryExtension\` | **deferred to §5a dogfood** (UI test, out of scope per task brief) |
| §5: \`testMidnightShiftFiresAfterDragEnd\` | **deferred to §5a dogfood** (UI test, out of scope per task brief) |

Additional §4b coverage (6 tests): all-clear allows, drag-blocks,
all-three-active blocks, predicate-not-clearing in stay-in-day,
predicate-not-clearing-when-already-none, all non-day modes trigger
clear.

Additional §4a coverage (10 tests): four early-return paths
(\`.none\` applied / nil raw source / raw itself open / hourHeight = 0),
three side-write gates (leading-only / trailing-only / both),
three multiply-complement combine identity tests (s2 saturates →
result 1; both stages 0 → result 0; both partial → result follows
\`1 - (1-s1)(1-s2)\`).

## Verification

- \`xcodebuild build\` succeeds on each of the 5 commits.
- All 19 new tests pass.
- Pre-existing baseline failures in \`CalendarDragLogicTests\`
  (\`testLeadingBoundaryExtensionRemovalDoesNotSnapScrollToSpecificTime\`,
  \`testRelationAwareOverlapLayoutSharesSlotBetweenParentAndInterrupt\` —
  per #76/#78 notes) are unchanged: 2 failures, 0 new failures, 0 fixes.
- Note: the test target's pbxproj reference for the test file is added
  in commit 1 but the file lands in commit 5, so
  \`xcodebuild build-for-testing\` is intentionally only green at HEAD.
  The \`xcodebuild build\` (app target) succeeds at every intermediate
  commit, which is the verification gate per task brief.

## Dogfood (§5a)

**Deferred to reviewer.** The three §5a manual scenarios (cross-midnight
drag → release smooth-collapse; midnight tick pending while drag active;
same with resize grace and interrupt sessions) need device/simulator
gesture driving that this branch can't automate. Pre-PR sanity:
\`tryApplyPendingMidnightShift\` and \`refreshAbandonedExtension\` are
both pure refactors against the doc-prescribed signatures, so the
dogfood gates should be unchanged. If the cross-midnight chain
regresses, the helper signature mismatch is the place to look first
(per §5a closing note).

## Out of scope (intentional, per task brief)

- Splitting \`CalendarPageView.swift\` (§7 of the doc, follow-up).
- State-class refactoring (the #70 trap).
- The two §5 UI tests (deferred to §5a dogfood).
- The \`crossDayRebounceAnimator\` / \`sameDayRebounceAnimator\` blocks
  (C1 per §1 footnote, left alone).
- Any rangeMode display-site rewiring beyond the §4c predicate's two
  call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)