### PR TITLE
feat(focus): CALayer FocusEventFlowView port (#72)

### DIFF
--- a/Docs/calendar-page-state-map.md
+++ b/Docs/calendar-page-state-map.md
@@ -1,0 +1,515 @@
+# Calendar Page — State-Interaction Map
+
+> **Draft v3** — first cut for issue [#73]. The goal is to make the *implicit*
+> coupling between PageView's ~80 `@State` flags *visible* enough that the next
+> cross-midnight / boundary-extension PR reviewer can see what a one-line change
+> actually touches.
+>
+> This is the artifact the #53/#55/#56/#58/#59 chain was missing.
+>
+> **Changelog**
+>
+> *v0 → v1:* carved C1a "Cross-day follow settle" out of C1; renamed the 0.6s
+> magic number to `crossDayFollowSettleWindow`; resolved the test-seam question
+> (helper XCTest + 2 UI tests deferred to dogfood).
+>
+> *v1 → v2 (adversarial review):* reframed the C1 / C1a carve to code-path
+> locality (lifecycle was a useful intuition, not the criterion); recorded a
+> C1a → C2 fade-progress write edge (rebounce animator block writes C2's fade);
+> fixed `RangeMode` (v1 invented a `CalendarRangeMode` type that doesn't exist);
+> corrected §2c onChange-site line numbers; tightened `AbandonedFadeInputs`;
+> noted helper visibility + `@testable` requirement.
+>
+> *v2 → v3 (second adversarial review):* **dropped `fadeInBoundaryExtension`
+> (line 2643) from C1a — it's C2-internal, called from
+> `handleTimelineBoundaryExtensionStateChange` (line 2781). v2 overcorrected
+> by attributing it to C1a's rebounce block; the only true C1a → C2 fade-write
+> edge is the rebounce animator block at lines 4318–94.** Tightened §1a's
+> "Written by" cell for fade-progress (line-precise C2 write sites);
+> disambiguated §4d helpers as nested-private inside §4a's helper; collapsed
+> §3 graph's three arrowheads (C1a → C2) to a labeled pair; clarified §3
+> invariant 1's "C5 ∧ C5" with role subscripts.
+
+## Scope
+
+`Done/Views/Calendar/CalendarPageView.swift` (4941 LOC). Sister doc:
+[`docs/calayer-rewrite/05-state-dataflow-contract.md`](./calayer-rewrite/05-state-dataflow-contract.md)
+maps the SwiftUI↔CALayer **boundary**; this doc maps **PageView-internal**
+state coupling that lives above that boundary.
+
+## How to read this doc
+
+If you are about to touch a handler in PageView and want to know what else it
+reads, jump to §2 and look up the handler name. If you are about to touch a
+`@State` flag and want to know who reads it, jump to §1 and follow the
+`Touched-by` column. If you are wondering why three onChange observers all call
+the same function, see §3.
+
+---
+
+## 1. State, grouped by concern
+
+The 80-ish `@State` declarations in `CalendarPageView` (lines 1031–1193) split
+into **9 concerns + 1 sub-concern**. Most concerns are internally cohesive; the
+**6 starred** concerns are the ones that interact across the cross-midnight /
+boundary-extension codepaths and are the load-bearing surface for this doc.
+
+| # | Concern | Written by | Owns | Decl. lines |
+|---|---|---|---|---|
+| C1★ | Drag (per-frame + post-gesture rebounce) | EventBlock gestures (per-frame `timelineDragState`); rebounce animators driven by abandon-release **and** by follow-event commit | `timelineDragState`, `crossDayRebounceAnimator`, `sameDayRebounceAnimator` | 1099, 1127, 1133 |
+| C1a★ | Follow-event commit settling state | the follow-event commit code path (`CalendarPageView.swift:4234-4398`) | `crossDayFollowEventAt`, `pendingFollowEventDayOverride`, `suppressDayColumnHorizontalAnimation` | 1140, 1155, 1147 |
+| C2★ | Boundary extension | C2 handlers (`fadeInBoundaryExtension` at 2649-50/2655-56, `refreshAbandonedExtension` at 2722/2737, `handleStateChange`'s re-engage branch at 2788-89, `apply/clearTimelineBoundaryExtensionState`); fade-progress *also* written by C1a's rebounce animator block (4318-94) | `timelineBoundaryExtensionState`, `timelineRawBoundaryExtensionState`, `boundaryExtensionVisualYOffset`, `timelineLeadingFadeProgress`, `timelineTrailingFadeProgress`, `pendingBoundaryExtensionScrollTask`, `boundaryExtensionScrollAnimator` | 1101, 1102, 1056, 1164, 1165, 1116, 1121 |
+| C3★ | Range mode (host side) | range-mode picker UI; dayRange via expansion helpers | `calendarState.rangeMode` (NOT @State here — `@Observable` on `calendarState`), `dayRange` | 1045 + external |
+| C4★ | Midnight shift | `handleClockMaybeChanged`; drained by `tryApplyPendingMidnightShift` | `midnightLastKnownStartOfDay`, `midnightPendingDaysCrossed` | 1189, 1193 |
+| C5★ | Resize / live-interrupt gates | resize-grace begin/cancel; interrupt session begin/end | `resizeGraceState`, `resizeGraceOccurrenceContext`, `resizeGraceFadeTask`, `resizeGraceExpiryTask`, `liveInterruptSession` | 1082–1085, 1075 |
+| C6 | Routing / sheets | flow-driven | `selectedEventDetailRoute`, `selectedEventChatOccurrence`, `selectedEventForEdit`, `isShowingDatePicker`, `isShowingAgent`, `isShowingSearch`, `isShowingShare`, `eventShareContext`, `pendingInterruptComposer`, `pendingCreateTimeRange`, `pendingRecurrenceEdit`, `recurrenceEditScope`, `showRecurrenceScopeDialog`, `showLongPressDeleteConfirm` | 1057–1077 |
+| C7 | Long-press / floating menu | press-driven | `floatingMenuAnchor`, `floatingMenuOccurrence`, `floatingMenuInteractive`, `floatingMenuActivationTask`, `floatingMenuActivationToken` | 1060–1064 |
+| C8 | Scroll viewport | scroll observers | `timelineVerticalScrollY`, `timelineScrollViewportHeight`, `verticalScrollPosition`, `isVerticallyScrolling`, `timelineVisibleDayFrameGlobal`, `lastTimelineTopOverlayInset`, `lastDynamicPinchMinInputs`, `timelineCollapseDim` | 1093, 1103, 1100, 1114, 1115, 1108, 1109, 1170 |
+| C9 | Caches / lifecycle | data-driven (store mutations, day-change, dayRange expansion) | `occurrencesCache`, `allDayOccurrencesCache`, `maxAllDayCountCache`, `progressiveCacheTask`, `hasAppearedOnce`, `needsScrollToNow`, `timerRefreshCancellable`, `capturedPageGeometry` | 1042–1044, 1171, 1097, 1098, 1079, 1179 |
+
+> **Why split C1 → C1 + C1a? — code-path locality, not lifecycle.** The three
+> C1a flags are written by a single code block: the follow-event commit code
+> path (`CalendarPageView.swift:4234-4398`). The C1 rebounce animators are
+> written by *two* paths — that same follow-event commit code AND the
+> abandon-release rebounce path. So even though all of {C1 rebounce, C1a flags}
+> are "post-gesture" lifecycle-wise (a useful intuition v1 leaned on), only the
+> C1a flags are *code-path-co-local*. The split keeps C1a clean: every C1a
+> flag → same writer block → same reader contract. If a future PR adds a new
+> "post-follow-event settle" flag, the §1 table says where it goes.
+
+> **Why 6 stars?** Each starred concern has at least one flag in the §1a
+> cross-concern read table below. C6-C9 don't (they churn for different
+> reasons: UX flows, perf) and are out of scope for this doc.
+
+> **Note on C2 fade progress** (`timelineLeadingFadeProgress`,
+> `timelineTrailingFadeProgress`): consumed downstream as prop-driven opacity
+> by `TimelinePagerView` (CalendarPageView.swift:3269/3270) and from there by
+> `TimeAxisLayerView` and `TimelineView` — pure SwiftUI prop pass-through, no
+> back-channel write from those consumers. But the values **are written by a
+> cross-concern actor**: C1a's rebounce animator block writes them at
+> `CalendarPageView.swift:4318–94` (the follow-event settle path). That edge
+> is the §1a fade-progress row + the §3 "C1a writes fade" edge — v0 and v1
+> missed it; v2 overstated it (it incorrectly attributed C2's own
+> `fadeInBoundaryExtension` to C1a); v3 has it precisely.
+
+### 1a. Cross-concern reader: each ★-state at a glance
+
+| State (concern) | Written by | Read by handlers across other concerns |
+|---|---|---|
+| `timelineDragState.dragOffset` (C1) | EventBlock gestures (UIKit side) | `refreshAbandonedExtension` (C2), `handleClockMaybeChanged`→`tryApplyPendingMidnightShift` (C4) |
+| `timelineDragState.draggingEventID` (C1) | EventBlock gesture begin/end | `tryApplyPendingMidnightShift` gate (C4), `handleTimelineBoundaryExtensionStateChange`'s read of `crossDayFollowEventAt` window (C2) |
+| `timelineDragState.draggingOriginalRange` (C1) | EventBlock begin | `refreshAbandonedExtension` core math (C2) |
+| `crossDayFollowEventAt` (C1a) | follow-event commit code path (lines 4310, 4344) | `refreshAbandonedExtension` **settle-window guard** (C2; line 2673), `handleTimelineBoundaryExtensionStateChange`'s `followGuardActive` closure (C2; line 2762). Both reads are "settle is in progress — sit out", NOT "drag is in progress — sit out". |
+| `timelineLeadingFadeProgress` / `timelineTrailingFadeProgress` (C2) | C2 itself: `refreshAbandonedExtension` (lines 2722, 2737), `fadeInBoundaryExtension` (lines 2649-50, 2655-56), `handleStateChange`'s re-engage branch (lines 2788-89), `applyTimelineBoundaryExtensionState` / `clearTimelineBoundaryExtensionState`. **Also by C1a's rebounce animator block** (lines 4318–94) — when the follow-event commit fires, the C1a path drives the fade directly during settle. | `refreshAbandonedExtension` self-coalescing reads (`if abs(diff) > 0.001`) + outbound to `TimelinePagerView` (lines 3269/3270 → `TimeAxisLayerView` opacity, `TimelineView` opacity). No back-channel write from consumers. |
+| `timelineBoundaryExtensionState` (C2) | `applyTimelineBoundaryExtensionState`, `clearTimelineBoundaryExtensionState` | `refreshAbandonedExtension` (self, but also reads `.leadingHours`/`.trailingHours` for fade math), `handleTimelineBoundaryExtensionStateChange`'s `wasOpen` check, `onChange(rangeMode)` clear (C3) |
+| `timelineRawBoundaryExtensionState` (C2) | `handleTimelineBoundaryExtensionStateChange` | `refreshAbandonedExtension` *intent gate* (C2 self-read, but conceptually a sub-flag) |
+| `calendarState.rangeMode` (C3) | range-mode picker UI | `handleTimelineBoundaryExtensionStateChange` early-return guard (C2), many display sites in body |
+| `dayRange` (C3) | `expandDayRangeForMonthContext`, `expandDayRangeToInclude`, `calendarExpandedDayRange` | `rebuildOccurrencesCacheIncremental` (C9), `tryApplyPendingMidnightShift`→`rebuildOccurrencesCache` (C4→C9) |
+| `midnightPendingDaysCrossed` (C4) | `handleClockMaybeChanged` accumulate, `tryApplyPendingMidnightShift` zero | `tryApplyPendingMidnightShift` |
+| `resizeGraceState` (C5) | `beginResizeGrace`, `cancelResizeGrace` | `tryApplyPendingMidnightShift` gate (C4), `onChange(rangeMode)` cancel (C3) |
+| `liveInterruptSession` (C5) | interrupt session begin/end | `tryApplyPendingMidnightShift` gate (C4) |
+
+> Read this table sideways: the rows where "Read by" lists **more than one
+> other concern** are the rows the cross-midnight audit flagged. **Twelve
+> flags** out of ~80 carry the cross-concern coupling (drag scratchpad
+> counted as three rows for its sub-fields).
+>
+> `pendingFollowEventDayOverride` (C1a) and `suppressDayColumnHorizontalAnimation`
+> (C1a) are NOT in this table — they're written by C1a's commit block and
+> read only by display logic (the former) or as `TimelinePagerView` prop output
+> (the latter). C1a-owned + downstream-only. (Distinct from the fade-progress
+> row above, where C1a writes a flag *owned by C2* — that's the real
+> cross-concern edge.)
+
+---
+
+## 2. Handlers that fuse concerns
+
+Below: the three handlers #73 names, plus a fourth (`handleClockMaybeChanged`)
+the audit reads as one logical step with `tryApplyPendingMidnightShift`.
+
+### 2a. `refreshAbandonedExtension(topOverlayInset:)` — lines 2671–2744
+
+**Touches:** C2 (read+write fade progress), C2 (read raw + retained extension state),
+C1 (read original drag range, drag offset), **C1a (settle-window guard on
+`crossDayFollowEventAt`)**, C8 (read scroll Y + viewport height + overlay inset).
+
+**Reads (12):** `timelineBoundaryExtensionState`, `crossDayFollowEventAt`,
+`timelineRawBoundaryExtensionState`, `timelineDragState.draggingOriginalRange`,
+`calendarState.timelineHourHeight`, `timelineDragState.dragOffset`,
+`timelineAllDayHeight` (env-derived), `timelineHeaderHeight`,
+`timelineVerticalScrollY`, `timelineScrollViewportHeight`,
+`timelineLeadingFadeProgress`, `timelineTrailingFadeProgress`.
+
+**Writes (2):** `timelineLeadingFadeProgress`, `timelineTrailingFadeProgress`.
+
+**Called from (3 sites):**
+1. `handleTimelineBoundaryExtensionStateChange` line 2796 (state-leave branch).
+2. `.onChange(of: timelineDragState.dragOffset)` line 3207 (every drag frame).
+3. `.onChange(of: timelineVerticalScrollY)` line 3228 (every scroll tick).
+
+**Why it's painful:** the inner math (stage1 / stage2 / combine) is pure — given
+five scalars it returns two scalars — but the function reads 12 fields directly,
+so a touch to any field's name forces a re-grep through 70 lines of dispersed
+read sites. The pure inner math is the natural extraction (see §4a).
+
+### 2b. `handleTimelineBoundaryExtensionStateChange(_:)` — lines 2746 → ~3000
+
+**Touches:** C3 (rangeMode early-return), C2 (write raw + retained, apply
+extension), **C1a (followGuardActive from `crossDayFollowEventAt`)**, C2 (fade
+animations on re-engage), C2 (scroll-driven dismiss path).
+
+**Called from (1 site):** `TimelinePagerView.onBoundaryExtensionStateChange`
+callback — line 3292.
+
+**Why it's painful:** opens the rangeMode-clear early-return branch, the
+followGuard branch, the re-engage branch, AND the abandon-release rebounce
+branch, all in one function. The first guard (`rangeMode != .day` → clear) is
+itself a small predicate that lives elsewhere too (see §4c).
+
+### 2c. `tryApplyPendingMidnightShift(reason:)` — lines 3728–3758
+
+**Touches:** C4 (read+zero pending counter), C1 (gate on draggingEventID),
+C5 (gate on resizeGraceState, liveInterruptSession), C3 (write selectedDayOffset),
+C9 (rebuild caches).
+
+**Called from (4 sites)** (citing the `.onChange` observer line, not the
+call-inside-closure):
+1. `handleClockMaybeChanged` line 3721 (every minute timer + day-change).
+2. `.onChange(of: timelineDragState.draggingEventID)` line 1503.
+3. `.onChange(of: resizeGraceState == nil)` line 1508.
+4. `.onChange(of: liveInterruptSession == nil)` line 1513.
+
+**Why it's painful:** the gate is three independent flags AND'd together; each
+of the four call sites exists because one of the three gates may have just
+cleared, and we want to retry. The retry pattern (defer + retry on each gate
+clear) is what makes the four call sites feel duplicated. The gate predicate is
+the natural extraction (see §4b).
+
+### 2d. `handleClockMaybeChanged(reason:)` — lines 3704–3722
+
+Co-trigger with `tryApplyPendingMidnightShift`. Always followed by a call to it.
+
+**Reads (1):** `midnightLastKnownStartOfDay`. **Writes (2):**
+`midnightLastKnownStartOfDay`, `midnightPendingDaysCrossed`.
+
+Self-contained relative to other concerns — it only writes to C4. Listed here
+for symmetry with §2c.
+
+---
+
+## 3. State-interaction graph
+
+The relationships the audit cared about. Solid = direct read; dashed = retry/
+deferral relationship; double-line = mutual coupling.
+
+```
+                                     ┌────────────────────────────────┐
+                                     │ C3  rangeMode / dayRange       │
+                                     └────────────────────────────────┘
+                                              │              │
+                                              │ .day-only    │ on expand
+                                              ▼              ▼
+        ┌──────────────────────┐    ┌──────────────────────┐    ┌─────────────────────┐
+        │ C1  Drag             │═══▶│ C2  boundaryExtension│    │ C9  occurrencesCache │
+        │   dragOffset         │    │   raw / retained     │    │  (rebuild target)    │
+        │   draggingEventID    │    │   leading/trailing   │    └─────────────────────┘
+        │   draggingOrigRange  │    │   fade progress      │              ▲
+        │   rebounce animators │    └──────────────────────┘              │ rebuild after shift
+        └──────────────────────┘                ▲                         │
+                  │                             │                         │
+                  │                guard (settle│                         │
+                  │                window 2673  │                         │
+                  │                + 2762)      │                         │
+                  │                + writes fade│                         │
+                  │                during settle│                         │
+                  │                (4318-94)    │                         │
+                  │              ┌──────────────────────┐                 │
+                  │              │ C1a Follow-event    │                  │
+                  │              │ commit settling     │                  │
+                  │              │   crossDayFollowEventAt│               │
+                  │              │   pendingFollowDayOver │               │
+                  │              │   suppressDayColAnim   │               │
+                  │              └──────────────────────┘                 │
+                  │ retry-trigger                                         │
+                  ▼                                                       │
+        ┌──────────────────────┐                       ┌──────────────────────┐
+        │ C4  midnight pending │───────────────────────│ C5  resizeGrace /    │
+        │   counter            │  gate (all 3 clear)   │     liveInterrupt    │
+        └──────────────────────┘                       └──────────────────────┘
+                  ▲
+                  │ every tick / day-change
+                  │
+        ┌──────────────────────┐
+        │ wall clock (timer)   │
+        └──────────────────────┘
+```
+
+**Invariants the chain enforces (informal):**
+
+1. Midnight shift waits for all of {drag, resizeGrace, liveInterrupt} to clear,
+   then applies. (C4 ← C1 ∧ C5[resize] ∧ C5[interrupt].)
+2. Boundary extension is gated to `.day` rangeMode; any switch off `.day`
+   collapses it. (C2 ← C3.)
+3. Abandon fade reads the live drag offset to position the band; without an
+   active drag (no `draggingOriginalRange`), the function early-returns.
+   (C2 ← C1.)
+4. **Follow-event commit opens a `crossDayFollowSettleWindow` (0.6s) during
+   which abandoned-extension refreshes and state-change re-applies in C2 are
+   suppressed**, AND the C1a rebounce animator block (lines 4318–94) **writes
+   C2's fade progress directly** during the settle. The post-commit mirror
+   should not flash through the dismiss path. (C2 ← C1a, both as guard read
+   and as direct write.)
+
+> If a future PR breaks any of these four invariants, the integration tests in
+> §5 should catch it (modulo the dogfood gate — see §5).
+
+---
+
+## 4. Extraction candidates (the §A deliverable in #73)
+
+**Helper visibility convention:** declare top-level extracted helpers as
+`internal` (default), and access them from `DoneTests/CalendarPageHandlerHelpersTests.swift`
+via `@testable import Done`. Avoid `private` at the top level so the test file
+doesn't need same-source-file colocation. *Nested* helpers (e.g. §4d) stay
+`private` to their enclosing helper — see the §4d note.
+
+### 4a. `computeAbandonedFadeCurves(...)` → `(leading: CGFloat, trailing: CGFloat)`
+
+Pull the pure math out of `refreshAbandonedExtension`. Signature draft:
+
+```swift
+struct AbandonedFadeInputs {
+    let rawState: TimelineBoundaryExtensionState
+    let appliedState: TimelineBoundaryExtensionState
+    let dragOriginalRange: Event.TimeRange
+    let dragOffsetY: CGFloat
+    let hourHeight: CGFloat
+    let extensionOriginY: CGFloat   // = topOverlayInset + allDayHeight + headerHeight
+    let scrollY: CGFloat
+    let viewportHeight: CGFloat
+    let baseVisibleHours: Int        // calendarTimelineBaseVisibleHours
+}
+
+struct AbandonedFadeCurves {
+    let leading: CGFloat?    // nil = leave current value untouched
+    let trailing: CGFloat?
+}
+
+func computeAbandonedFadeCurves(_ input: AbandonedFadeInputs) -> AbandonedFadeCurves
+```
+
+The host call site shrinks to: build inputs → call helper → write progress
+states under a `Transaction(disablesAnimations: true)`. The host writes the
+two `@State` fields directly (still PageView-owned); the helper has no SwiftUI
+deps so it unit-tests trivially.
+
+The current per-field "if abs(diff) > 0.001" gate stays at the call site
+(it's a write-coalescing concern, not part of the curve math).
+
+> v1 had `topOverlayInset`/`timelineAllDayHeight`/`timelineHeaderHeight` as
+> three separate inputs. In `refreshAbandonedExtension` they only flow into a
+> single sum (`extensionOriginY` at line 2706). One input is right.
+
+### 4b. `shouldAllowMidnightShift(...)` → `Bool`
+
+```swift
+func shouldAllowMidnightShift(
+    draggingEventID: UUID?,
+    resizeGrace: CalendarResizeGraceState?,
+    liveInterrupt: CalendarInterruptLiveSession?
+) -> Bool {
+    draggingEventID == nil
+        && resizeGrace == nil
+        && liveInterrupt == nil
+}
+```
+
+Trivial as a predicate, but pulling it into a name lets the three onChange
+retry sites all reference *the same name*, instead of each spelling the AND
+out. The next person who adds a fourth gate (e.g. a long-press menu)
+edits one predicate, not four call sites.
+
+### 4c. `boundaryExtensionShouldClearOnRangeModeChange(...)` → `Bool`
+
+```swift
+func boundaryExtensionShouldClearOnRangeModeChange(
+    newMode: RangeMode,
+    currentExtensionState: TimelineBoundaryExtensionState
+) -> Bool {
+    newMode != .day && currentExtensionState != .none
+}
+```
+
+Two call sites today: line 2749 inside `handleTimelineBoundaryExtensionStateChange`
+(reactive — when the callback fires and we're not in day), and line 1480
+inside `.onChange(of: rangeMode)` (proactive — when day changes to non-day).
+The current logic at those two sites is *almost* the same predicate but spelled
+differently, which makes it easy to drift if someone adds a `.stream` rangeMode
+behavior later.
+
+> Type name is `RangeMode` (declared in `CalendarPageState.swift:28`), NOT
+> `CalendarRangeMode`. v1 invented the wrong name.
+
+### 4d. Name the abandon-fade two-stage math
+
+Stage 1 (`stage1`) and stage 2 (the `s2 = max(0, min(1, 1 - d / bandHeight))`
+inline expression) are both named formulas in the inline comments but have no
+function name. Suggestion: **nest these inside `computeAbandonedFadeCurves`
+(§4a)** rather than expose at file scope — they're implementation details of
+the fade-curve math, not predicates the test suite needs to reach. Because
+they nest, they stay `private`; the §4 introduction's "avoid private" applies
+to *top-level* helpers only.
+
+```swift
+func computeAbandonedFadeCurves(_ input: AbandonedFadeInputs) -> AbandonedFadeCurves {
+    func fingerDrivenStage1Fade(distHours: Double, ...) -> CGFloat { ... }
+    func positionDrivenStage2Fade(boundaryY: CGFloat, viewportEdge: CGFloat,
+                                  bandHeight: CGFloat) -> CGFloat { ... }
+    func combineFades(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat { ... }
+    // ... use the three ...
+}
+```
+
+The combine function in particular (`1 - (1-s1)*(1-s2)`) is the
+multiply-complement opacity combine and shows up nowhere else in the codebase
+(searched). Worth a name even at nested scope.
+
+### 4e. Pull `crossDayFollowSettleWindow` to a named constant
+
+Today the 0.6s settle window appears as a bare literal in two read sites:
+`refreshAbandonedExtension` line 2673 and `handleTimelineBoundaryExtensionStateChange`'s
+`followGuardActive` closure line 2762. Both check
+`Date().timeIntervalSince(stamp) < 0.6`. (NB: the `0.6` at line 2694 is
+`stage1MaxFade` for the abandon-fade curve — same number, different concept,
+do NOT collapse.) Suggestion:
+
+```swift
+internal let crossDayFollowSettleWindow: TimeInterval = 0.6
+```
+
+A single declaration at file scope, two read sites. Next time someone tunes
+the rebounce animator duration (currently 1.1s), they have one place to look
+for "what settle window does the rest of the chain assume?".
+
+---
+
+## 5. Integration test targets (the §C deliverable in #73)
+
+For each invariant in §3, a corresponding behavior-level test. The Q4
+test-seam decision: **pure XCTest where the test is really about a predicate
+extracted in §4; UI test deferred to dogfood for the two end-to-end gesture
+flows.** Rationale: this project has no existing UI test infrastructure;
+introducing it just for two tests is its own scope.
+
+Helpers are `internal` (per §4 convention); tests reach them via
+`@testable import Done`.
+
+| Test | Kind | Sets up | Asserts |
+|---|---|---|---|
+| `testDragAcrossMidnightTriggersBoundaryExtension` | **UI test — deferred to dogfood gate** | Drag event from 23:00→01:00 next day, single-day range mode | `timelineBoundaryExtensionState.trailingHours > 0` while drag active |
+| `testRangeModeChangeClearsBoundaryExtension` | **Pure XCTest** on §4c predicate | Construct `TimelineBoundaryExtensionState` open + `RangeMode = .threeDay` | `boundaryExtensionShouldClearOnRangeModeChange(newMode: .threeDay, currentExtensionState: open) == true` |
+| `testMidnightShiftBlockedDuringResizeGrace` | **Pure XCTest** on §4b predicate | resizeGrace = mock state | `shouldAllowMidnightShift(.., resizeGrace: mock, ..) == false` |
+| `testInterruptSessionBlocksMidnightShift` | **Pure XCTest** on §4b predicate | liveInterrupt = mock session | `shouldAllowMidnightShift(.., liveInterrupt: mock) == false` |
+| `testMidnightShiftFiresAfterDragEnd` | **UI test — deferred to dogfood gate** | Drag begin → set pending midnight crossed → drag end | `selectedDayOffset` shifts on the onChange tick |
+
+Constructibility verified for the three Pure XCTest rows: `RangeMode`,
+`TimelineBoundaryExtensionState`, `CalendarResizeGraceState`, and
+`CalendarInterruptLiveSession` are all memberwise-constructible value types
+on the current `king-of-rubbish-bin`.
+
+The pure helpers (§4a/b/c/d/e) also get unit tests — most are mechanical given
+the signatures. They belong in `DoneTests/CalendarPageHandlerHelpersTests.swift`.
+
+### 5a. The dogfood gate
+
+The two UI-deferred tests above MUST be exercised manually before any
+extraction-PR lands. Dogfood checklist for the extractor:
+
+1. Single-day, drag an event from 23:00 across midnight into the next day,
+   release. The trailing extension band must open, then collapse smoothly
+   without a flash (this is the #55 follow-up the chain ate twice).
+2. While a midnight tick is pending (easiest repro: simulator wall-clock
+   tick by setting device time), drag any event. The selectedDayOffset
+   shift must NOT apply until the drag ends.
+3. Same as 2 but for resize grace and live-interrupt sessions.
+
+If any extraction-PR cannot pass the dogfood gate, the helper signature is
+wrong (almost certainly losing an input that the original handler was
+implicitly reading).
+
+---
+
+## 6. Resolved questions (audit trail v0 → v3)
+
+These were `§6 Open questions` in v0; resolved across v1 + v2 + v3 revisions.
+
+1. **C8 reads C2's fade progress?** — **Resolved with nuance.** Greps confirmed
+   every fade-progress *read* is intra-C2 coalescing or downstream SwiftUI
+   prop pass-through (`TimelinePagerView` → `TimeAxisLayerView` / `TimelineView`
+   opacity). No back-channel read from those consumers. BUT the *write* side
+   was wrong in v0/v1: C1a's rebounce animator block writes the fade values
+   during settle (`CalendarPageView.swift:4318–94`). That's a real C1a → C2
+   write edge captured in §1a + §3 + invariant 4. v2 went too far in the other
+   direction and also attributed `fadeInBoundaryExtension` (line 2643) to C1a;
+   v3 corrects that — `fadeInBoundaryExtension` is C2-internal, called from
+   `handleTimelineBoundaryExtensionStateChange` (line 2781). So the doc has
+   gone through "no edge" → "edge + over-attribution" → "edge, properly scoped".
+
+2. **`crossDayFollowEventAt` 0.6s magic?** — **Resolved: name it.** v0's claim
+   that 0.6s appears "once in the dispatch chain" was incorrect — it appears in
+   exactly two read sites (`refreshAbandonedExtension` line 2673 + `followGuardActive`
+   closure line 2762). The `0.6` at line 2694 is `stage1MaxFade`, a coincidence
+   of value, NOT the same constant. Promote to `crossDayFollowSettleWindow`.
+   See §4e.
+
+3. **`pendingFollowEventDayOverride` and `suppressDayColumnHorizontalAnimation`
+   sub-concern?** — **Resolved: split C1a out, criterion is code-path
+   locality.** v1 leaned on a "lifecycle" argument (per-frame vs one-shot)
+   that didn't hold up — the rebounce animators are also post-gesture but
+   stay in C1. The honest criterion is *which writer block touches the flag*:
+   the three C1a flags are all written by `CalendarPageView.swift:4234-4398`
+   (the follow-event commit code path); rebounce animators are written by
+   that path AND by the abandon-release path, so they're not code-path-co-local
+   with C1a. Lifecycle is a useful intuition but secondary.
+
+4. **Test seam?** — **Resolved: hybrid.** 3 of 5 §5 tests collapse to pure
+   XCTest against the §4 predicates once those helpers exist. 2 of 5 are
+   end-to-end gesture flows that genuinely need a UI test harness; we defer
+   those to a dogfood gate (§5a) rather than introduce a UI test
+   infrastructure that this codebase doesn't otherwise use. Critically, **no
+   move to extract handlers into an `@Observable` coordinator class** —
+   that's the #70 trap.
+
+---
+
+## 7. Sequencing & non-goals
+
+* This doc is **prescriptive about extraction shape, descriptive about state
+  ownership**. State stays where it is. The §4 helpers are pure functions
+  that PageView calls; PageView still owns the `@State`.
+* Splitting `CalendarPageView.swift` into multiple files is **out of scope**
+  here — it's the obvious follow-up once the helpers exist, but mixing it
+  with the helper-extraction PR will hide whether the behavior actually
+  changed.
+* The integration tests in §5 are the **gate** — extraction PRs without
+  passing tests on the cross-midnight chain are landing blind. The user has
+  been bitten enough times by this chain (#53/#55/#56/#58/#59 each touched
+  it) that the test investment pays. The 2 UI-deferred tests pay their
+  insurance through dogfood (§5a), not CI.
+* The C1/C1a split is **observational** — no code moves between concerns.
+  The flags' decl. lines stay where they are; the sub-concern is purely a
+  documentation cut so §3's graph reads correctly.
+
+## Refs
+
+- Issue [#73] — the work this doc anchors.
+- Issue [#70] (closed) — the state-split proposal this doc explicitly
+  replaces. The audit reasoning lives in #73's "Background" section.
+- [`docs/calayer-rewrite/05-state-dataflow-contract.md`](./calayer-rewrite/05-state-dataflow-contract.md) — the
+  SwiftUI↔CALayer boundary contract. Read together with this doc, you get a
+  full picture of state ownership above and below the timeline boundary.
+- Memory: `feedback_bug_fix_methodology.md`, `project_calayer_timeline_render_paths.md`.
+
+[#70]: https://github.com/MaySong-Mei/Done/issues/70
+[#73]: https://github.com/MaySong-Mei/Done/issues/73

--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		EE0E5C0C2F31000000000002 /* EventStore+OccurrenceRecords.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0E5C0C2F31000000000001 /* EventStore+OccurrenceRecords.swift */; };
 		EEED1A032F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEED1A022F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift */; };
 		AXIS00012F60000000000001 /* Calendar/Components/Timeline/TimeAxisLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AXIS00022F60000000000002 /* Calendar/Components/Timeline/TimeAxisLayerView.swift */; };
+		MIDA00012F70000000000001 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIDA00022F70000000000002 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift */; };
 		EEEEFA012F14F6A7000397C6 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF2972F14F55B000397C6 /* Event.swift */; };
 		EEEEFA022F14F6A7000397C6 /* EventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF2982F14F55B000397C6 /* EventStore.swift */; };
 		EEEEFA032F14F6A7000397C6 /* Todo/EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF29A2F14F55B000397C6 /* Todo/EventCardView.swift */; };
@@ -251,6 +252,7 @@
 		EE0E5C0C2F31000000000001 /* EventStore+OccurrenceRecords.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventStore+OccurrenceRecords.swift"; sourceTree = "<group>"; };
 		EEED1A022F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/TimelineEditMapping.swift; sourceTree = "<group>"; };
 		AXIS00022F60000000000002 /* Calendar/Components/Timeline/TimeAxisLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/TimeAxisLayerView.swift; sourceTree = "<group>"; };
+		MIDA00022F70000000000002 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/MiniDayTimelineLayerView.swift; sourceTree = "<group>"; };
 		EEEEF2972F14F55B000397C6 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		EEEEF2982F14F55B000397C6 /* EventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStore.swift; sourceTree = "<group>"; };
 		EEEEF29A2F14F55B000397C6 /* Todo/EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo/EventCardView.swift; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 				CADA00022F90000000000002 /* Calendar/Components/Timeline/CalendarDayLayerView.swift */,
 				EEED1A022F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift */,
 				AXIS00022F60000000000002 /* Calendar/Components/Timeline/TimeAxisLayerView.swift */,
+				MIDA00022F70000000000002 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift */,
 				EEEEFA512F16B200000397C6 /* Calendar/Components/Timeline/Event/EventBlock.swift */,
 				DDDD00002F40000000000001 /* Calendar/Components/Timeline/Event/DiagonalHatchingPattern.swift */,
 				EEEEFA2D2F16B200000397C6 /* Calendar/Components/Timeline/TimelineMaskView.swift */,
@@ -765,6 +768,7 @@
 				CADA00012F90000000000001 /* Calendar/Components/Timeline/CalendarDayLayerView.swift in Sources */,
 				EEED1A032F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift in Sources */,
 				AXIS00012F60000000000001 /* Calendar/Components/Timeline/TimeAxisLayerView.swift in Sources */,
+				MIDA00012F70000000000001 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift in Sources */,
 				EEEEFA502F16B200000397C6 /* Calendar/Components/Timeline/Event/EventBlock.swift in Sources */,
 				DDDD00012F40000000000001 /* Calendar/Components/Timeline/Event/DiagonalHatchingPattern.swift in Sources */,
 				EEEEFA2B2F16B200000397C6 /* Calendar/Components/Timeline/TimelineMaskView.swift in Sources */,

--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		8DC4025C6FA74F94A38D43BA /* Calendar/CalendarEventFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4811A80895C7432E8B33CC9A /* Calendar/CalendarEventFormView.swift */; };
 		A1B2C3D82F50000000000001 /* CalendarDragLogicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */; };
 		AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */; };
+		AAAA00112F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */; };
+		AAAA00112F30000000000003 /* CalendarPageHandlerHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */; };
 		BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */; };
 		AABB20012F60000000000001 /* Agent/ChatMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10012F60000000000001 /* Agent/ChatMessage.swift */; };
 		AABB20022F60000000000002 /* Agent/LLMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB10022F60000000000002 /* Agent/LLMProvider.swift */; };
@@ -194,6 +196,8 @@
 		A1B2C3D52F50000000000001 /* DoneTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DoneTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B2C3D72F50000000000001 /* CalendarDragLogicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarDragLogicTests.swift; sourceTree = "<group>"; };
 		AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/CalendarPageState.swift; sourceTree = "<group>"; };
+		AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/CalendarPageHandlerHelpers.swift; sourceTree = "<group>"; };
+		AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarPageHandlerHelpersTests.swift; sourceTree = "<group>"; };
 		BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/BoundaryExtensionScrollAnimator.swift; sourceTree = "<group>"; };
 		AABB10012F60000000000001 /* Agent/ChatMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/ChatMessage.swift; sourceTree = "<group>"; };
 		AABB10022F60000000000002 /* Agent/LLMProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Agent/LLMProvider.swift; sourceTree = "<group>"; };
@@ -392,6 +396,7 @@
 				F0C4F0AFE7974190AFA61B21 /* CalendarViewStateTests.swift */,
 				E11D9000000000000000B002 /* CalendarMidnightHandlerTests.swift */,
 				E11D9000000000000000B003 /* TimelineRenderBenchmarkTests.swift */,
+				AAAA00102F30000000000003 /* CalendarPageHandlerHelpersTests.swift */,
 			);
 			path = DoneTests;
 			sourceTree = "<group>";
@@ -465,6 +470,7 @@
 				EEEEFA1C2F16A101000397C6 /* Todo/AddToCalendarView.swift */,
 				EEEEFA1E2F16B200000397C6 /* Calendar/CalendarPageView.swift */,
 				AAAA00002F30000000000001 /* Calendar/CalendarPageState.swift */,
+				AAAA00102F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift */,
 				BX55E00002F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift */,
 				EEEEFA8F2F200000000397C6 /* Calendar/CalendarViewState.swift */,
 				EEEEFA912F200000000397C6 /* Calendar/CalendarFocusState.swift */,
@@ -738,6 +744,7 @@
 				EEEEFA1D2F16A101000397C6 /* Todo/AddToCalendarView.swift in Sources */,
 				EEEEFA242F16B200000397C6 /* Calendar/CalendarPageView.swift in Sources */,
 				AAAA00012F30000000000001 /* Calendar/CalendarPageState.swift in Sources */,
+				AAAA00112F30000000000002 /* Calendar/CalendarPageHandlerHelpers.swift in Sources */,
 				BX55E00012F70000000000001 /* Calendar/BoundaryExtensionScrollAnimator.swift in Sources */,
 				EEEEFA902F200000000397C6 /* Calendar/CalendarViewState.swift in Sources */,
 				EEEEFA922F200000000397C6 /* Calendar/CalendarFocusState.swift in Sources */,
@@ -848,6 +855,7 @@
 				F0C4F0AEE7974190AFA61B21 /* CalendarViewStateTests.swift in Sources */,
 				E11D9000000000000000A002 /* CalendarMidnightHandlerTests.swift in Sources */,
 				E11D9000000000000000A003 /* TimelineRenderBenchmarkTests.swift in Sources */,
+				AAAA00112F30000000000003 /* CalendarPageHandlerHelpersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Done.xcodeproj/project.pbxproj
+++ b/Done.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		EEED1A032F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEED1A022F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift */; };
 		AXIS00012F60000000000001 /* Calendar/Components/Timeline/TimeAxisLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AXIS00022F60000000000002 /* Calendar/Components/Timeline/TimeAxisLayerView.swift */; };
 		MIDA00012F70000000000001 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MIDA00022F70000000000002 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift */; };
+		FEFL00012F72000000000001 /* Focus/FocusEventFlowLayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFL00022F72000000000002 /* Focus/FocusEventFlowLayerView.swift */; };
 		EEEEFA012F14F6A7000397C6 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF2972F14F55B000397C6 /* Event.swift */; };
 		EEEEFA022F14F6A7000397C6 /* EventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF2982F14F55B000397C6 /* EventStore.swift */; };
 		EEEEFA032F14F6A7000397C6 /* Todo/EventCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEEF29A2F14F55B000397C6 /* Todo/EventCardView.swift */; };
@@ -253,6 +254,7 @@
 		EEED1A022F29B200000397C6 /* Calendar/Components/Timeline/TimelineEditMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/TimelineEditMapping.swift; sourceTree = "<group>"; };
 		AXIS00022F60000000000002 /* Calendar/Components/Timeline/TimeAxisLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/TimeAxisLayerView.swift; sourceTree = "<group>"; };
 		MIDA00022F70000000000002 /* Calendar/Components/Timeline/MiniDayTimelineLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Calendar/Components/Timeline/MiniDayTimelineLayerView.swift; sourceTree = "<group>"; };
+		FEFL00022F72000000000002 /* Focus/FocusEventFlowLayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Focus/FocusEventFlowLayerView.swift; sourceTree = "<group>"; };
 		EEEEF2972F14F55B000397C6 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		EEEEF2982F14F55B000397C6 /* EventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventStore.swift; sourceTree = "<group>"; };
 		EEEEF29A2F14F55B000397C6 /* Todo/EventCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo/EventCardView.swift; sourceTree = "<group>"; };
@@ -531,6 +533,7 @@
 				F0C50003FE00000000000003 /* Focus/FocusModeClockView.swift */,
 				F0C50004FE00000000000004 /* Focus/FocusModeEventView.swift */,
 				F0C50005FE00000000000005 /* Focus/FocusEventFlowView.swift */,
+				FEFL00022F72000000000002 /* Focus/FocusEventFlowLayerView.swift */,
 				F0C50006FE00000000000006 /* Focus/FocusAmbientChip.swift */,
 				F0C50007FE00000000000007 /* Focus/FocusPreCreateView.swift */,
 				F0C50008FE00000000000008 /* Focus/FocusPreCreatePicker.swift */,
@@ -835,6 +838,7 @@
 				F0C51003FE00000000000003 /* Focus/FocusModeClockView.swift in Sources */,
 				F0C51004FE00000000000004 /* Focus/FocusModeEventView.swift in Sources */,
 				F0C51005FE00000000000005 /* Focus/FocusEventFlowView.swift in Sources */,
+				FEFL00012F72000000000001 /* Focus/FocusEventFlowLayerView.swift in Sources */,
 				F0C51006FE00000000000006 /* Focus/FocusAmbientChip.swift in Sources */,
 				F0C51007FE00000000000007 /* Focus/FocusPreCreateView.swift in Sources */,
 				F0C51008FE00000000000008 /* Focus/FocusPreCreatePicker.swift in Sources */,

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -114,6 +114,13 @@ enum AppSettingsKeys {
     /// the SwiftUI path remains the default until A/B verification settles.
     /// See `TimeAxisLayerView.swift` (issue #60).
     static let calendarUseCALayerAxisMarkers = "calendarUseCALayerAxisMarkers"
+    /// Experimental: when true, the event-detail mini-day timeline
+    /// (`miniDayTimelineVisual` in `CalendarEventDetailView`) is rendered
+    /// through a CALayer-backed UIView instead of the SwiftUI tree. Same
+    /// strict-parity stance as `calendarUseCALayerAxisMarkers`; the SwiftUI
+    /// path remains the default until A/B verification settles. See
+    /// `MiniDayTimelineLayerView.swift` (issue #71).
+    static let calendarUseCALayerMiniDayTimeline = "calendarUseCALayerMiniDayTimeline"
 
     // MARK: - Agent / LLM
 
@@ -189,7 +196,8 @@ enum AppSettingsKeys {
         calendarEventFontSize,
         calendarEventShowTimeBelowTitle,
         nearFutureHorizonDays,
-        focusConfirmBeforeTracking
+        focusConfirmBeforeTracking,
+        calendarUseCALayerMiniDayTimeline
     ]
 }
 

--- a/Done/ContentView.swift
+++ b/Done/ContentView.swift
@@ -121,6 +121,11 @@ enum AppSettingsKeys {
     /// path remains the default until A/B verification settles. See
     /// `MiniDayTimelineLayerView.swift` (issue #71).
     static let calendarUseCALayerMiniDayTimeline = "calendarUseCALayerMiniDayTimeline"
+    /// Experimental: when true, the landscape focus-mode event flow view
+    /// (`FocusEventFlowView`) is rendered through a CALayer-backed UIView
+    /// instead of the SwiftUI tree. Strict-parity port; default OFF until
+    /// A/B verification settles. See `FocusEventFlowLayerView.swift` (issue #72).
+    static let calendarUseCALayerFocusEventFlow = "calendarUseCALayerFocusEventFlow"
 
     // MARK: - Agent / LLM
 
@@ -197,7 +202,8 @@ enum AppSettingsKeys {
         calendarEventShowTimeBelowTitle,
         nearFutureHorizonDays,
         focusConfirmBeforeTracking,
-        calendarUseCALayerMiniDayTimeline
+        calendarUseCALayerMiniDayTimeline,
+        calendarUseCALayerFocusEventFlow
     ]
 }
 

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -554,6 +554,7 @@ struct ExperimentalSettingsView: View {
     @AppStorage(AppSettingsKeys.experimentalMultiTypeMaxCount) private var multiTypeMaxCount = 2
     @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var calayerAxisMarkers = true
     @AppStorage(AppSettingsKeys.calendarUseCALayerMiniDayTimeline) private var calayerMiniDayTimeline = false
+    @AppStorage(AppSettingsKeys.calendarUseCALayerFocusEventFlow) private var calayerFocusEventFlow = false
 
     var body: some View {
         settingsPage(L(.experimental)) {
@@ -597,6 +598,16 @@ struct ExperimentalSettingsView: View {
             settingsCard("CALayer Mini-Day Timeline") {
                 Toggle("Use CALayer mini-day timeline", isOn: $calayerMiniDayTimeline)
                 Text("Experimental: render the event-detail mini-day timeline (the compact preview above the timeline track) through CALayer instead of SwiftUI. Strict parity, no design changes. Default off.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Issue #72: CALayer-backed port of the landscape focus-mode
+            // event flow view (mini-cal showing current event ±3h). Same
+            // parity-first stance; SwiftUI path stays default until A/B.
+            settingsCard("CALayer Focus Event Flow") {
+                Toggle("Use CALayer focus event flow", isOn: $calayerFocusEventFlow)
+                Text("Experimental: render the landscape focus-mode mini-cal through CALayer instead of SwiftUI. Strict parity, no design changes. Default off.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -552,7 +552,7 @@ struct AnalysisPreferencesView: View {
 struct ExperimentalSettingsView: View {
     @AppStorage(AppSettingsKeys.experimentalMultiTypeEvents) private var multiTypeEnabled = false
     @AppStorage(AppSettingsKeys.experimentalMultiTypeMaxCount) private var multiTypeMaxCount = 2
-    @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var calayerAxisMarkers = false
+    @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var calayerAxisMarkers = true
 
     var body: some View {
         settingsPage(L(.experimental)) {

--- a/Done/Views/Agent/AgentSettingsView.swift
+++ b/Done/Views/Agent/AgentSettingsView.swift
@@ -553,6 +553,7 @@ struct ExperimentalSettingsView: View {
     @AppStorage(AppSettingsKeys.experimentalMultiTypeEvents) private var multiTypeEnabled = false
     @AppStorage(AppSettingsKeys.experimentalMultiTypeMaxCount) private var multiTypeMaxCount = 2
     @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var calayerAxisMarkers = true
+    @AppStorage(AppSettingsKeys.calendarUseCALayerMiniDayTimeline) private var calayerMiniDayTimeline = false
 
     var body: some View {
         settingsPage(L(.experimental)) {
@@ -585,6 +586,17 @@ struct ExperimentalSettingsView: View {
             settingsCard("CALayer Time Axis") {
                 Toggle("Use CALayer time axis", isOn: $calayerAxisMarkers)
                 Text("Experimental: render the calendar's time axis (hour labels, current-time legend, drag-preview pills) through CALayer instead of SwiftUI. Strict parity, no design changes. Default off.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Issue #71: CALayer-backed port of the event-detail mini-day
+            // timeline (hour grid + sibling/focused blocks + live progress
+            // fill + note markers + current-position thumb). Same parity-
+            // first stance as #60; SwiftUI path stays default until A/B.
+            settingsCard("CALayer Mini-Day Timeline") {
+                Toggle("Use CALayer mini-day timeline", isOn: $calayerMiniDayTimeline)
+                Text("Experimental: render the event-detail mini-day timeline (the compact preview above the timeline track) through CALayer instead of SwiftUI. Strict parity, no design changes. Default off.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Done/Views/Calendar/CalendarEventDetailView.swift
+++ b/Done/Views/Calendar/CalendarEventDetailView.swift
@@ -362,6 +362,11 @@ struct CalendarEventDetailView: View {
     // visibility the user has configured.
     @AppStorage(AppSettingsKeys.calendarEventFontSize) private var calendarEventFontSize: Double = Double(calendarEventTitleFontSizeDefault)
     @AppStorage(AppSettingsKeys.calendarEventShowTimeBelowTitle) private var calendarEventShowTimeBelowTitle: Bool = true
+    // Experimental: when ON, the mini-day timeline is rendered via the
+    // CALayer-backed host (`MiniDayTimelineLayerView`) instead of the
+    // SwiftUI `miniDayTimelineVisual` tree. Default OFF; flipped on only
+    // after A/B parity is verified per the #60→#74 arc. See issue #71.
+    @AppStorage(AppSettingsKeys.calendarUseCALayerMiniDayTimeline) private var useCALayerMiniDayTimeline = false
     @StateObject private var multiTypeTemplateStore = EventTypeTemplateStore()
     @State private var editSheetRequest: CalendarDetailEditSheetRequest?
     @State private var pendingRecurringAction: CalendarRecurringScopedAction?
@@ -1473,6 +1478,93 @@ private extension CalendarEventDetailView {
         }
     }
 
+    /// CALayer-backed mini-day timeline (#71). Builds the same overlap
+    /// layout + window math as `miniDayTimelineVisual`, packs it into a
+    /// `MiniDayTimelineLayerInputs` snapshot, and hands it to the UIKit
+    /// host. Wrapper preserves the chevron + tap-to-toggle from the
+    /// SwiftUI path — only the timeline visual itself swaps to CALayer.
+    private func miniDayTimelineLayerHost(
+        event: Event,
+        range: Event.TimeRange,
+        notes: [EventLogTimelineNote],
+        interruptItems: [CalendarResolvedInterruptTimelineItem]
+    ) -> some View {
+        // Window math — IDENTICAL to `miniDayTimelineVisual` so SwiftUI
+        // ↔ CALayer A/B has zero geometric drift.
+        let windowStart = range.start.addingTimeInterval(-3600)
+        let windowEnd = range.end.addingTimeInterval(3600)
+        let windowDuration = windowEnd.timeIntervalSince(windowStart)
+        let hourHeight: CGFloat = 90
+        let fullHeight = CGFloat(windowDuration / 3600) * hourHeight
+        let collapsedHeight: CGFloat = 109
+        let displayHeight = isMiniDayExpanded ? fullHeight : collapsedHeight
+
+        // Reuse the existing overlap-layout builder so the slot contract
+        // (.equalSplit, sibling filter, focused-occurrence synthesis) stays
+        // single-source. The CALayer host is a renderer, not a layout.
+        let layout = miniDayLayout(
+            focusedEvent: event,
+            focusedRange: range,
+            windowStart: windowStart,
+            windowEnd: windowEnd
+        )
+
+        // Map SwiftUI interrupt items to host-side stripes. SwiftUI's
+        // ForEach filters `editingInterruptID` out; mirror here.
+        let eventDuration = range.end.timeIntervalSince(range.start)
+        let stripes: [MiniDayTimelineLayerInputs.Stripe] = interruptItems
+            .filter { $0.childEvent.id != editingInterruptID }
+            .compactMap { item in
+                guard let clipped = item.clippedRange, eventDuration > 0 else { return nil }
+                let startFrac = clipped.start.timeIntervalSince(range.start) / eventDuration
+                let endFrac = clipped.end.timeIntervalSince(range.start) / eventDuration
+                return MiniDayTimelineLayerInputs.Stripe(
+                    id: item.childEvent.id,
+                    tint: EventTypeTemplateStore.color(for: item.childEvent.type),
+                    startFraction: startFrac,
+                    endFraction: endFrac
+                )
+            }
+
+        let baseFontSize = CGFloat(min(max(calendarEventFontSize, 9), 16))
+        let inputs = MiniDayTimelineLayerInputs(
+            focusedEvent: event,
+            focusedRange: range,
+            slots: layout.slots,
+            siblingOccurrences: layout.others,
+            focusedSlotID: layout.focusedID,
+            interruptStripes: stripes,
+            notes: notes,
+            timelineMode: timelineMode,
+            manualProgress: timelineSliderProgress,
+            windowStart: windowStart,
+            windowEnd: windowEnd,
+            hourHeight: hourHeight,
+            collapsedHeight: collapsedHeight,
+            isExpanded: isMiniDayExpanded,
+            baseFontSize: baseFontSize,
+            showTimeBelowTitle: calendarEventShowTimeBelowTitle
+        )
+
+        return VStack(spacing: 0) {
+            MiniDayTimelineLayerHost(inputs: inputs)
+                .frame(height: displayHeight)
+
+            // Chevron stays SwiftUI — non-hot-path, no benefit to porting.
+            Image(systemName: isMiniDayExpanded ? "chevron.compact.up" : "chevron.compact.down")
+                .font(.system(size: 14))
+                .foregroundStyle(.tertiary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 16)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                isMiniDayExpanded.toggle()
+            }
+        }
+    }
+
     private func miniDayHourLabels(
         windowStart: Date,
         windowDuration: TimeInterval,
@@ -2320,12 +2412,27 @@ private extension CalendarEventDetailView {
                 // overlap layout runs only when the parent body re-
                 // evaluates; the per-second tick drives only the tiny
                 // progress fill / thumb / note highlight overlays.
-                miniDayTimelineVisual(
-                    event: event,
-                    range: range,
-                    notes: trackNotes,
-                    interruptItems: interruptItems
-                )
+                //
+                // Experimental flag (#71) swaps the SwiftUI render path
+                // for a CALayer-backed host. Strict parity, no design
+                // change; the SwiftUI fallback stays the default until
+                // A/B verification settles (same arc as the #60→#74
+                // axis port).
+                if useCALayerMiniDayTimeline {
+                    miniDayTimelineLayerHost(
+                        event: event,
+                        range: range,
+                        notes: trackNotes,
+                        interruptItems: interruptItems
+                    )
+                } else {
+                    miniDayTimelineVisual(
+                        event: event,
+                        range: range,
+                        notes: trackNotes,
+                        interruptItems: interruptItems
+                    )
+                }
 
                 // The whole interactive-track + composer + merged-items block
                 // sits inside this `TimelineView(.periodic)` because several

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -51,3 +51,22 @@ internal func shouldAllowMidnightShift(
         && resizeGrace == nil
         && liveInterrupt == nil
 }
+
+// MARK: - §4c. RangeMode → boundary-extension clear predicate
+
+/// Whether changing into `newMode` should clear an open boundary extension.
+///
+/// Boundary extensions only make sense in `.day` rangeMode (multi-day columns
+/// are too narrow for meaningful extended interaction). This predicate
+/// codifies "non-day mode + currently-open extension → must clear" so the
+/// two call sites that enforce it (the proactive `onChange(rangeMode)` and
+/// the reactive `handleTimelineBoundaryExtensionStateChange` early-return)
+/// can't drift.
+///
+/// See §4c of `Docs/calendar-page-state-map.md` and invariant 2 of §3.
+internal func boundaryExtensionShouldClearOnRangeModeChange(
+    newMode: RangeMode,
+    currentExtensionState: TimelineBoundaryExtensionState
+) -> Bool {
+    newMode != .day && currentExtensionState != .none
+}

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -1,0 +1,32 @@
+//
+//  CalendarPageHandlerHelpers.swift
+//  Done
+//
+//  Pure handler helpers extracted from `CalendarPageView.swift` per the §4
+//  prescription in `Docs/calendar-page-state-map.md` (v3). Each helper has
+//  zero SwiftUI / view dependencies so it can be unit-tested directly via
+//  `@testable import Done` (see `DoneTests/CalendarPageHandlerHelpersTests.swift`).
+//
+//  Strict behavior parity is required: the call sites in `CalendarPageView`
+//  shrink to "build inputs → call helper", with NO logic changes. Extractions
+//  exist to (a) name the predicates / magic numbers the cross-midnight audit
+//  flagged, and (b) give the test suite a unit-testable seam without touching
+//  the view's `@State`.
+//
+
+import Foundation
+import CoreGraphics
+
+// MARK: - §4e. Cross-day follow settle window (named magic number)
+
+/// Duration of the post-follow-event settle window. While this window is open,
+/// `refreshAbandonedExtension` and `handleTimelineBoundaryExtensionStateChange`
+/// stop driving the abandoned-extension dissolve path so the follow-event
+/// rebounce animator can write fade progress directly without churn.
+///
+/// Read by `refreshAbandonedExtension` (settle-window guard) and by
+/// `handleTimelineBoundaryExtensionStateChange`'s `followGuardActive` closure.
+/// See §4e of `Docs/calendar-page-state-map.md`. NB: this is NOT
+/// `stage1MaxFade` (which is also 0.6 — coincidence of value, different
+/// concept).
+internal let crossDayFollowSettleWindow: TimeInterval = 0.6

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -30,3 +30,24 @@ import CoreGraphics
 /// `stage1MaxFade` (which is also 0.6 — coincidence of value, different
 /// concept).
 internal let crossDayFollowSettleWindow: TimeInterval = 0.6
+
+// MARK: - §4b. Midnight-shift gate predicate
+
+/// Whether a pending midnight offset shift may be applied now.
+///
+/// The shift is blocked while any of {drag, resize-grace, live-interrupt}
+/// owns a frame-of-reference that the shift would desynchronise. Each gate
+/// has an `.onChange` retry observer in `CalendarPageView`; each is also
+/// checked together inside `tryApplyPendingMidnightShift` so that whichever
+/// observer fires last actually wins.
+///
+/// See §4b of `Docs/calendar-page-state-map.md` and invariant 1 of §3.
+internal func shouldAllowMidnightShift(
+    draggingEventID: UUID?,
+    resizeGrace: CalendarResizeGraceState?,
+    liveInterrupt: CalendarInterruptLiveSession?
+) -> Bool {
+    draggingEventID == nil
+        && resizeGrace == nil
+        && liveInterrupt == nil
+}

--- a/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
+++ b/Done/Views/Calendar/CalendarPageHandlerHelpers.swift
@@ -70,3 +70,137 @@ internal func boundaryExtensionShouldClearOnRangeModeChange(
 ) -> Bool {
     newMode != .day && currentExtensionState != .none
 }
+
+// MARK: - §4a. Abandoned-extension fade-curve math
+
+/// Inputs to `computeAbandonedFadeCurves`.
+///
+/// One field per scalar the curve math actually reads. The three view-side
+/// inset fields (`topOverlayInset`, `timelineAllDayHeight`,
+/// `timelineHeaderHeight`) collapse to `extensionOriginY` because they only
+/// flow into a single sum (line 2706 in the original `refreshAbandonedExtension`
+/// — see the §4a footnote in `Docs/calendar-page-state-map.md`).
+internal struct AbandonedFadeInputs {
+    let rawState: TimelineBoundaryExtensionState
+    let appliedState: TimelineBoundaryExtensionState
+    let dragOriginalRange: Event.TimeRange
+    let dragOffsetY: CGFloat
+    let hourHeight: CGFloat
+    /// `topOverlayInset + timelineAllDayHeight + timelineHeaderHeight`.
+    let extensionOriginY: CGFloat
+    let scrollY: CGFloat
+    let viewportHeight: CGFloat
+    let baseVisibleHours: Int
+}
+
+/// Result of `computeAbandonedFadeCurves`.
+///
+/// `nil` for a side means "leave the current `@State` value untouched"
+/// (matches the original handler's "only write if the side has hours" gate
+/// — see §4a). The caller's `if abs(diff) > 0.001` write-coalescing gate
+/// stays at the call site, since it's a state-write concern, not part of
+/// the curve math.
+internal struct AbandonedFadeCurves: Equatable {
+    let leading: CGFloat?
+    let trailing: CGFloat?
+}
+
+/// Compute the abandoned-extension fade progress for the leading and trailing
+/// bands, given a snapshot of inputs.
+///
+/// Returns `(nil, nil)` (an "early-return" result) when the abandoned
+/// dissolve should not run at all. Otherwise, returns `nil` for whichever
+/// side currently has zero hours, mirroring the original handler's behavior
+/// of only writing to a side that's actually open.
+///
+/// See §4a (signature + carveout rationale) and §4d (nested-helper names)
+/// of `Docs/calendar-page-state-map.md`.
+internal func computeAbandonedFadeCurves(_ input: AbandonedFadeInputs) -> AbandonedFadeCurves {
+    let earlyOut = AbandonedFadeCurves(leading: nil, trailing: nil)
+    guard input.appliedState.hasAnyExtension else { return earlyOut }
+    // Only while actively dragging with the intent (raw) OUT of the zone.
+    guard input.rawState.source != nil, !input.rawState.hasAnyExtension else { return earlyOut }
+    guard input.hourHeight > 0 else { return earlyOut }
+
+    let leading = input.appliedState.leadingHours
+    let trailing = input.appliedState.trailingHours
+
+    // STAGE 1 — finger-driven dim, CAPPED below full transparency. The
+    // dragged edge = original edge + drag offset (move shifts both;
+    // resizeTop shifts start; resizeBottom shifts end — leading keys on
+    // start, trailing on end). As you pull the edge back into the day the
+    // band dims, but only to `stage1MaxFade` (never empties → no in-view
+    // gap). (#55 two-stage fade)
+    let offsetHours = Double(input.dragOffsetY) / Double(input.hourHeight)
+    let cal = Calendar.current
+    let dayStart = cal.startOfDay(for: input.dragOriginalRange.start)
+    let abandonFadeStartHours: Double = 4   // tunable: dim begins here
+    let abandonFadeRangeHours: Double = 4   // tunable: reaches the cap after this
+    let stage1MaxFade: CGFloat = 0.6        // tunable: opacity floor = 1 - this
+    // NB: same numeric value as `crossDayFollowSettleWindow`, different
+    // concept — do NOT collapse. (See §4e footnote.)
+
+    /// Finger-driven fade keyed on how far the dragged edge has pulled back
+    /// past `abandonFadeStartHours` into the day. Capped at `stage1MaxFade`.
+    func fingerDrivenStage1Fade(distHours: Double) -> CGFloat {
+        min(
+            stage1MaxFade,
+            CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours)))
+        )
+    }
+
+    // STAGE 2 — ABSOLUTE position fade keyed on WHERE THE MIDNIGHT LINE is
+    // relative to the viewport edge (scroll only moves it indirectly). The
+    // band fully fades as its boundary (0:00 / 24:00) reaches the edge. At
+    // min pinch the band is tiny and the boundary already sits near the
+    // edge → it can reach full transparency with little/no scroll; at max
+    // pinch the boundary is deep in view → it needs the edge to come to it.
+    // Pure opacity (no scroll write → no detach).
+    let visibleTop = max(0, input.scrollY)
+    let visibleBottom = visibleTop + input.viewportHeight
+
+    /// Position-driven fade keyed on how far the band's outer boundary
+    /// (0:00 for leading, 24:00 for trailing) sits inside the viewport.
+    /// Reaches 1 when the boundary touches the viewport edge.
+    func positionDrivenStage2Fade(boundarySpan: CGFloat, bandHeight: CGFloat) -> CGFloat {
+        // `boundarySpan` is the signed distance from the viewport edge to
+        // the relevant boundary line. Positive = boundary still inside the
+        // viewport. At 0 the band is fully off (s2 = 1).
+        max(0, min(1, 1 - boundarySpan / bandHeight))
+    }
+
+    /// Combine the two fades via multiply-complement: result = 1 when either
+    /// stage saturates; partial when both partial. Equivalent to over-blending
+    /// two independent opacities.
+    func combineFades(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat {
+        1 - (1 - s1) * (1 - s2)
+    }
+
+    var leadingResult: CGFloat? = nil
+    var trailingResult: CGFloat? = nil
+
+    if leading > 0 {
+        let liveStart = input.dragOriginalRange.start.addingTimeInterval(offsetHours * 3600)
+        let s1 = fingerDrivenStage1Fade(distHours: liveStart.timeIntervalSince(dayStart) / 3600)
+        let bandHeight = CGFloat(leading) * input.hourHeight
+        // d = how far the 0:00 line sits below the viewport top.
+        // 0 = boundary at the top (band fully off) → s2 = 1.
+        let d = (input.extensionOriginY + bandHeight) - visibleTop
+        let s2 = positionDrivenStage2Fade(boundarySpan: d, bandHeight: bandHeight)
+        leadingResult = combineFades(s1, s2)
+    }
+    if trailing > 0 {
+        let dayEnd = dayStart.addingTimeInterval(24 * 3600)
+        let liveEnd = input.dragOriginalRange.end.addingTimeInterval(offsetHours * 3600)
+        let s1 = fingerDrivenStage1Fade(distHours: dayEnd.timeIntervalSince(liveEnd) / 3600)
+        let bandHeight = CGFloat(trailing) * input.hourHeight
+        let bandTop = input.extensionOriginY
+            + CGFloat(leading + input.baseVisibleHours) * input.hourHeight
+        // d = how far the 24:00 line sits above the viewport bottom.
+        let d = visibleBottom - bandTop
+        let s2 = positionDrivenStage2Fade(boundarySpan: d, bandHeight: bandHeight)
+        trailingResult = combineFades(s1, s2)
+    }
+
+    return AbandonedFadeCurves(leading: leadingResult, trailing: trailingResult)
+}

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2674,77 +2674,42 @@ private extension CalendarPageView {
     /// off the viewport edge (exact comp → no jump). Called on every drag-offset
     /// change, scroll tick, and zone change. (#55 follow-on)
     private func refreshAbandonedExtension(topOverlayInset: CGFloat) {
-        guard timelineBoundaryExtensionState.hasAnyExtension else { return }
+        // Settle-window guard — during the post-follow-event window the
+        // rebounce animator drives the fade directly; refreshing here would
+        // churn it. (See §4e + invariant 4 of the state-interaction map.)
         if let stamp = crossDayFollowEventAt,
            Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow {
             return
         }
-        let raw = timelineRawBoundaryExtensionState
-        // Only while actively dragging with the intent (raw) OUT of the zone.
-        guard raw.source != nil, !raw.hasAnyExtension else { return }
+        // `draggingOriginalRange` non-nil is a precondition of the helper's
+        // signature; the matching early-returns inside the helper handle the
+        // other gates (`appliedState.hasAnyExtension`, `rawState.source != nil
+        // && !hasAnyExtension`, `hourHeight > 0`).
         guard let original = timelineDragState.draggingOriginalRange else { return }
-        let hh = calendarState.timelineHourHeight
-        guard hh > 0 else { return }
-        let leading = timelineBoundaryExtensionState.leadingHours
-        let trailing = timelineBoundaryExtensionState.trailingHours
+        let input = AbandonedFadeInputs(
+            rawState: timelineRawBoundaryExtensionState,
+            appliedState: timelineBoundaryExtensionState,
+            dragOriginalRange: original,
+            dragOffsetY: timelineDragState.dragOffset.y,
+            hourHeight: calendarState.timelineHourHeight,
+            extensionOriginY: topOverlayInset + timelineAllDayHeight + timelineHeaderHeight,
+            scrollY: timelineVerticalScrollY,
+            viewportHeight: timelineScrollViewportHeight,
+            baseVisibleHours: calendarTimelineBaseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
 
-        // STAGE 1 — finger-driven dim, CAPPED below full transparency. The
-        // dragged edge = original edge + drag offset (move shifts both;
-        // resizeTop shifts start; resizeBottom shifts end — leading keys on
-        // start, trailing on end). As you pull the edge back into the day the
-        // band dims, but only to `stage1MaxFade` (never empties → no in-view
-        // gap). (#55 two-stage fade)
-        let offsetHours = Double(timelineDragState.dragOffset.y) / Double(hh)
-        let cal = Calendar.current
-        let dayStart = cal.startOfDay(for: original.start)
-        let abandonFadeStartHours: Double = 4   // tunable: dim begins here
-        let abandonFadeRangeHours: Double = 4   // tunable: reaches the cap after this
-        let stage1MaxFade: CGFloat = 0.6        // tunable: opacity floor = 1 - this
-        func stage1(_ distHours: Double) -> CGFloat {
-            min(stage1MaxFade, CGFloat(max(0, min(1, (distHours - abandonFadeStartHours) / abandonFadeRangeHours))))
-        }
-
-        // STAGE 2 — ABSOLUTE position fade keyed on WHERE THE MIDNIGHT LINE is
-        // relative to the viewport edge (scroll only moves it indirectly). The
-        // band fully fades as its boundary (0:00 / 24:00) reaches the edge. At
-        // min pinch the band is tiny and the boundary already sits near the
-        // edge → it can reach full transparency with little/no scroll; at max
-        // pinch the boundary is deep in view → it needs the edge to come to it.
-        // Pure opacity (no scroll write → no detach).
-        let extensionOriginY = topOverlayInset + timelineAllDayHeight + timelineHeaderHeight
-        let visibleTop = max(0, timelineVerticalScrollY)
-        let visibleBottom = visibleTop + timelineScrollViewportHeight
-        func combine(_ s1: CGFloat, _ s2: CGFloat) -> CGFloat { 1 - (1 - s1) * (1 - s2) }
-
+        // Write-coalescing gate stays at the call site (it's a state-write
+        // concern, not part of the curve math). Each side writes only when
+        // the curve helper produced a value AND it differs from the current
+        // state by > 0.001.
         var fadeTx = Transaction()
         fadeTx.disablesAnimations = true
-        if leading > 0 {
-            let liveStart = original.start.addingTimeInterval(offsetHours * 3600)
-            let s1 = stage1(liveStart.timeIntervalSince(dayStart) / 3600)
-            let bandHeight = CGFloat(leading) * hh
-            // d = how far the 0:00 line sits below the viewport top.
-            // 0 = boundary at the top (band fully off) → s2 = 1.
-            let d = (extensionOriginY + bandHeight) - visibleTop
-            let s2 = max(0, min(1, 1 - d / bandHeight))
-            let f = combine(s1, s2)
-            if abs(timelineLeadingFadeProgress - f) > 0.001 {
-                withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
-            }
+        if let f = curves.leading, abs(timelineLeadingFadeProgress - f) > 0.001 {
+            withTransaction(fadeTx) { timelineLeadingFadeProgress = f }
         }
-        if trailing > 0 {
-            let dayEnd = dayStart.addingTimeInterval(24 * 3600)
-            let liveEnd = original.end.addingTimeInterval(offsetHours * 3600)
-            let s1 = stage1(dayEnd.timeIntervalSince(liveEnd) / 3600)
-            let bandHeight = CGFloat(trailing) * hh
-            let bandTop = extensionOriginY
-                + CGFloat(leading + calendarTimelineBaseVisibleHours) * hh
-            // d = how far the 24:00 line sits above the viewport bottom.
-            let d = visibleBottom - bandTop
-            let s2 = max(0, min(1, 1 - d / bandHeight))
-            let f = combine(s1, s2)
-            if abs(timelineTrailingFadeProgress - f) > 0.001 {
-                withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
-            }
+        if let f = curves.trailing, abs(timelineTrailingFadeProgress - f) > 0.001 {
+            withTransaction(fadeTx) { timelineTrailingFadeProgress = f }
         }
         // NB: still NO collapse here. Both stages are pure opacity (no contentH/
         // scroll write → no auto-recenter, no detach). The contentH collapse

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3730,9 +3730,11 @@ private extension CalendarPageView {
     /// the offset mid-gesture would land drops one day off.
     private func tryApplyPendingMidnightShift(reason: String) {
         guard midnightPendingDaysCrossed != 0 else { return }
-        guard timelineDragState.draggingEventID == nil,
-              resizeGraceState == nil,
-              liveInterruptSession == nil else {
+        guard shouldAllowMidnightShift(
+            draggingEventID: timelineDragState.draggingEventID,
+            resizeGrace: resizeGraceState,
+            liveInterrupt: liveInterruptSession
+        ) else {
             calendarDebugLog(
                 "calendar.midnight.shift.deferred",
                 fields: [

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1477,7 +1477,12 @@ struct CalendarPageView: View {
         }
         .onChange(of: calendarState.rangeMode) { _, newValue in
             calendarState.persistRangeMode()
-            clearTimelineBoundaryExtensionState()
+            if boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: newValue,
+                currentExtensionState: timelineBoundaryExtensionState
+            ) {
+                clearTimelineBoundaryExtensionState()
+            }
             if newValue == .month {
                 resetFloatingMenuState()
                 cancelResizeGrace(reason: "calendar.rangeMode.month")
@@ -2750,7 +2755,10 @@ private extension CalendarPageView {
         // Extended view is only supported in day view — multi-day
         // columns are too narrow for meaningful extended interaction.
         guard calendarState.rangeMode == .day else {
-            if timelineBoundaryExtensionState != .none {
+            if boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: calendarState.rangeMode,
+                currentExtensionState: timelineBoundaryExtensionState
+            ) {
                 clearTimelineBoundaryExtensionState()
             }
             return

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3047,6 +3047,19 @@ private extension CalendarPageView {
     }
 
     func clearTimelineBoundaryExtensionState() {
+        // Idempotent guard: when nothing is actually open (state + raw
+        // already `.none` and no animator/task in flight), the writes
+        // below would resolve against already-default state. Skipping
+        // outright makes `boundaryExtensionShouldClearOnRangeModeChange
+        // == false` a true no-op at the proactive `.onChange(of:
+        // rangeMode)` call site — see `Docs/calendar-page-state-map.md`
+        // §4c.
+        guard timelineBoundaryExtensionState != .none
+            || timelineRawBoundaryExtensionState != .none
+            || pendingBoundaryExtensionScrollTask != nil
+            || boundaryExtensionScrollAnimator != nil
+            || sameDayRebounceAnimator != nil
+        else { return }
         pendingBoundaryExtensionScrollTask?.cancel()
         pendingBoundaryExtensionScrollTask = nil
         boundaryExtensionScrollAnimator?.cancel(reason: "clearState")

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -2670,7 +2670,10 @@ private extension CalendarPageView {
     /// change, scroll tick, and zone change. (#55 follow-on)
     private func refreshAbandonedExtension(topOverlayInset: CGFloat) {
         guard timelineBoundaryExtensionState.hasAnyExtension else { return }
-        if let stamp = crossDayFollowEventAt, Date().timeIntervalSince(stamp) < 0.6 { return }
+        if let stamp = crossDayFollowEventAt,
+           Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow {
+            return
+        }
         let raw = timelineRawBoundaryExtensionState
         // Only while actively dragging with the intent (raw) OUT of the zone.
         guard raw.source != nil, !raw.hasAnyExtension else { return }
@@ -2760,7 +2763,7 @@ private extension CalendarPageView {
 
         let followGuardActive: Bool = {
             guard let stamp = crossDayFollowEventAt else { return false }
-            return Date().timeIntervalSince(stamp) < 0.6
+            return Date().timeIntervalSince(stamp) < crossDayFollowSettleWindow
         }()
 
         let wasOpen = timelineBoundaryExtensionState.hasAnyExtension

--- a/Done/Views/Calendar/Components/Timeline/MiniDayTimelineLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/MiniDayTimelineLayerView.swift
@@ -1,0 +1,1010 @@
+//
+//  MiniDayTimelineLayerView.swift
+//  Done
+//
+//  CALayer-backed port of the SwiftUI `miniDayTimelineVisual` overlay
+//  (issue #71). The mini-day timeline is the compact preview rendered
+//  inside `CalendarEventDetailView` that frames the focused event in
+//  context with surrounding sibling occurrences, an hour grid, an optional
+//  live-progress fill, note markers, and a current-position thumb.
+//
+//  Goal: pixel parity with the SwiftUI tree at
+//  `CalendarEventDetailView.swift:miniDayTimelineVisual` without a SwiftUI
+//  re-evaluation per `TimelineView(.periodic)` tick. Gated by
+//  `AppSettingsKeys.calendarUseCALayerMiniDayTimeline`, default OFF;
+//  flipped ON only after A/B parity is verified (mirrors the #60→#74 arc).
+//
+//  This file is intentionally self-contained UIKit/CALayer code — it
+//  pulls shared math from the file-scope helpers in `EventBlock.swift`
+//  (`calendarEventTextLayout`, `calendarEventTimeFontSize`,
+//  `calendarEventBlockTitleSpacing`) and from `CalendarLayout`
+//  (`overlapLayout`) so the SwiftUI path and the CALayer path share one
+//  source of truth.
+//
+//  Scope: STATIC preview surface — no pinch, no scroll, no drag, no
+//  resize. The live tick (1Hz) only refreshes the focused-block progress
+//  fill, the current-position thumb, and the note-nearby highlights —
+//  all the other geometry rebuilds only when the host re-applies inputs.
+
+import SwiftUI
+import UIKit
+
+// MARK: - Inputs (host → renderer)
+
+/// Snapshot of everything the CALayer mini-day renderer needs to draw a
+/// frame. Designed to be cheap to construct on the SwiftUI side (the
+/// caller computes the overlap layout once, passes the result through)
+/// and `Equatable` so repeated SwiftUI body re-evals short-circuit when
+/// nothing changed — same idempotent-apply pattern as `TimeAxisLayerView`.
+struct MiniDayTimelineLayerInputs: Equatable {
+    /// Focused event + the time-range slice the detail page is rendering
+    /// (matches the SwiftUI `range` parameter; may differ from the
+    /// event's stored range when the parent is scoping to one occurrence).
+    var focusedEvent: Event
+    var focusedRange: Event.TimeRange
+    /// Slot dictionary keyed by occurrence id, as produced by
+    /// `CalendarLayout.overlapLayout(..., mode: .equalSplit)`. The
+    /// focused event also has an entry here.
+    var slots: [String: CalendarLayout.EventOverlapSlot]
+    /// Sibling occurrences in render order, excluding the focused event
+    /// and any interrupt children that are drawn via the stripe overlay.
+    var siblingOccurrences: [CalendarLayout.EventOccurrence]
+    /// The synthetic id used for the focused event's slot (mirrors
+    /// `MiniDayLayout.focusedID` on the SwiftUI side).
+    var focusedSlotID: String
+    /// Interrupt children of the focused event, drawn as right-edge
+    /// stripes inside the focused block (expanded only).
+    var interruptStripes: [Stripe]
+    /// Timeline notes drawn as marker dots (expanded only, mirrors the
+    /// SwiftUI `notes` parameter).
+    var notes: [EventLogTimelineNote]
+    /// Current scrubbing mode. `.live` → progress follows wall clock;
+    /// `.manual` → progress is `manualProgress`. Live progress + thumb
+    /// position + note-nearby highlights derive from this.
+    var timelineMode: CalendarEventTimelineMode
+    var manualProgress: CGFloat
+    /// Window pad above and below the focused range. The SwiftUI tree
+    /// uses `focusedRange ± 3600s` and hardcodes 90pt hour height; we
+    /// pass these through so the renderer doesn't need to recompute.
+    var windowStart: Date
+    var windowEnd: Date
+    var hourHeight: CGFloat
+    var collapsedHeight: CGFloat
+    var isExpanded: Bool
+    /// Mirrors the user's `calendarEventFontSize` setting (clamped 9–16
+    /// upstream). Drives both the title and the time-row font sizes via
+    /// the shared `calendarEventTextLayout` helper.
+    var baseFontSize: CGFloat
+    var showTimeBelowTitle: Bool
+
+    struct Stripe: Equatable, Hashable {
+        let id: UUID
+        let tint: Color
+        /// Fraction (0…1) of the focused range where the stripe starts.
+        let startFraction: Double
+        /// Fraction (0…1) of the focused range where the stripe ends.
+        let endFraction: Double
+    }
+}
+
+// MARK: - SwiftUI host
+
+/// SwiftUI-side host for the CALayer mini-day timeline. Drop-in renderer
+/// for the SwiftUI `miniDayTimelineVisual` body sans the chevron + tap
+/// gesture (those stay in SwiftUI — they are not hot-path).
+struct MiniDayTimelineLayerHost: UIViewRepresentable {
+    let inputs: MiniDayTimelineLayerInputs
+
+    func makeUIView(context: Context) -> MiniDayTimelineLayerView {
+        let view = MiniDayTimelineLayerView()
+        view.isUserInteractionEnabled = false
+        view.backgroundColor = .clear
+        view.clipsToBounds = true
+        return view
+    }
+
+    func updateUIView(_ uiView: MiniDayTimelineLayerView, context: Context) {
+        uiView.apply(inputs: inputs)
+    }
+}
+
+// MARK: - UIView host (CALayer backing)
+
+/// CALayer-backed mini-day timeline. Owns sublayers for the hour-axis
+/// labels, the hour grid lines, sibling event blocks, the focused event
+/// block (with live progress fill), interrupt stripes, note markers, and
+/// the current-position thumb.
+///
+/// All sublayers have implicit animations disabled — the host never
+/// animates, parity with the SwiftUI tree (which has no animation on the
+/// mini-day surface beyond the chevron-driven `withAnimation` toggle
+/// applied to the SwiftUI host wrapper, not its internals).
+final class MiniDayTimelineLayerView: UIView {
+    /// Width reserved for the leading hour-label column. Matches the
+    /// SwiftUI `frame(width: 30)` on `miniDayHourLabels`.
+    private static let hourColumnWidth: CGFloat = 30
+
+    private var currentInputs: MiniDayTimelineLayerInputs?
+
+    // Hour column (labels) — fixed-width view on the left, holding label
+    // pool. Lives in its own UIView so the trailing event-block area can
+    // get the remaining width without slicing layer math.
+    private let hourLabelContainer = UIView()
+    private var hourLabels: [UILabel] = []
+
+    // Event-block area container — holds the grid lines, sibling blocks,
+    // focused block, interrupt stripes, note markers, and thumb. Sits to
+    // the right of the hour column.
+    private let eventAreaContainer = UIView()
+
+    // Hour grid lines — lightweight CALayer per line. Rebuilt structurally
+    // when the window changes; positions update on every layout pass.
+    private var hourGridLines: [CALayer] = []
+
+    // Event-block visuals. Each entry owns the small subtree (background,
+    // mid-overlay for live progress, border, effort bar, title, time row).
+    private var siblingBlocks: [String: BlockLayers] = [:]
+    private let focusedBlock = BlockLayers()
+    private var focusedBlockInstalled = false
+
+    // Interrupt stripe pool (right-edge stripes inside the focused block).
+    private var stripeLayers: [CAShapeLayer] = []
+
+    // Note marker pool (dot + horizontal hairline). Each entry is one
+    // marker; the pool grows / shrinks with `inputs.notes.count`.
+    private var noteMarkers: [NoteMarker] = []
+
+    // Current-position thumb (4×12pt rounded rect + thin hairline). Drawn
+    // only when expanded.
+    private let thumbBlock = CALayer()
+    private let thumbLine = CALayer()
+
+    // Periodic tick — drives live progress fill, thumb position, and note
+    // nearby highlighting. Mirrors SwiftUI's
+    // `TimelineView(.periodic(from: .now, by: 1))`. Tolerance 0.25s so the
+    // OS can coalesce wake-ups with other low-rate timers.
+    private var nowTickTimer: Timer?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.actions = MiniDayTimelineLayerView.disabledActions
+        hourLabelContainer.isUserInteractionEnabled = false
+        hourLabelContainer.backgroundColor = .clear
+        hourLabelContainer.layer.actions = MiniDayTimelineLayerView.disabledActions
+        eventAreaContainer.isUserInteractionEnabled = false
+        eventAreaContainer.backgroundColor = .clear
+        eventAreaContainer.clipsToBounds = false
+        eventAreaContainer.layer.actions = MiniDayTimelineLayerView.disabledActions
+        addSubview(hourLabelContainer)
+        addSubview(eventAreaContainer)
+
+        // Thumb block + line: lazily installed below the focused block on
+        // first expand. `isHidden = true` keeps them inert until then.
+        thumbBlock.isHidden = true
+        thumbLine.isHidden = true
+        thumbBlock.actions = MiniDayTimelineLayerView.disabledActions
+        thumbLine.actions = MiniDayTimelineLayerView.disabledActions
+        thumbBlock.cornerRadius = 1.5
+        eventAreaContainer.layer.addSublayer(thumbLine)
+        eventAreaContainer.layer.addSublayer(thumbBlock)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) unavailable") }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            startNowTick()
+        } else {
+            stopNowTick()
+        }
+    }
+
+    deinit {
+        nowTickTimer?.invalidate()
+    }
+
+    private func startNowTick() {
+        guard nowTickTimer == nil else { return }
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+            self?.refreshNowDependentState()
+        }
+        timer.tolerance = 0.25
+        RunLoop.main.add(timer, forMode: .common)
+        nowTickTimer = timer
+        refreshNowDependentState()
+    }
+
+    private func stopNowTick() {
+        nowTickTimer?.invalidate()
+        nowTickTimer = nil
+    }
+
+    private func refreshNowDependentState() {
+        guard let currentInputs else { return }
+        updateLiveOverlays(inputs: currentInputs, now: Date())
+    }
+
+    fileprivate static let disabledActions: [String: CAAction] = [
+        "contents": NSNull(),
+        "position": NSNull(),
+        "bounds": NSNull(),
+        "frame": NSNull(),
+        "opacity": NSNull(),
+        "transform": NSNull(),
+        "sublayers": NSNull(),
+        "hidden": NSNull()
+    ]
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layoutContainers()
+        if let currentInputs {
+            layoutContent(inputs: currentInputs)
+        }
+    }
+
+    /// Mini-day height in points: the SwiftUI tree uses `displayHeight`
+    /// (= collapsedHeight or fullHeight) clipped over a `fullHeight`
+    /// content frame offset by `contentOffset`. We mirror that exactly so
+    /// the renderer's `bounds.height` matches the SwiftUI layout it's
+    /// replacing.
+    private func layoutContainers() {
+        let columnWidth = MiniDayTimelineLayerView.hourColumnWidth
+        hourLabelContainer.frame = CGRect(
+            x: 0, y: 0,
+            width: columnWidth, height: bounds.height
+        )
+        eventAreaContainer.frame = CGRect(
+            x: columnWidth, y: 0,
+            width: max(0, bounds.width - columnWidth),
+            height: bounds.height
+        )
+    }
+
+    // MARK: - Apply
+
+    /// Apply latest inputs from the SwiftUI host. Idempotent — repeated
+    /// calls with the same inputs return early so SwiftUI body re-evals
+    /// (which call `updateUIView` on every up-tree state change) don't
+    /// churn CALayer.
+    func apply(inputs: MiniDayTimelineLayerInputs) {
+        if currentInputs == inputs { return }
+        currentInputs = inputs
+        rebuildStructure(inputs: inputs)
+        setNeedsLayout()
+        layoutIfNeeded()
+        updateLiveOverlays(inputs: inputs, now: Date())
+    }
+
+    // MARK: - Structure rebuild
+
+    private func rebuildStructure(inputs: MiniDayTimelineLayerInputs) {
+        rebuildHourLabels(inputs: inputs)
+        rebuildHourGridLines(inputs: inputs)
+        rebuildSiblingBlocks(inputs: inputs)
+        installFocusedBlockIfNeeded()
+        rebuildStripes(inputs: inputs)
+        rebuildNoteMarkers(inputs: inputs)
+    }
+
+    private func layoutContent(inputs: MiniDayTimelineLayerInputs) {
+        layoutHourLabels(inputs: inputs)
+        layoutHourGridLines(inputs: inputs)
+        layoutSiblingBlocks(inputs: inputs)
+        layoutFocusedBlock(inputs: inputs)
+        layoutStripes(inputs: inputs)
+        layoutNoteMarkers(inputs: inputs)
+        // Thumb position is live-only; primed here so the initial layout
+        // (pre-tick) is already correct.
+        positionThumb(inputs: inputs, now: Date())
+    }
+
+    // MARK: - Hour labels (parity with miniDayHourLabels)
+
+    private func rebuildHourLabels(inputs: MiniDayTimelineLayerInputs) {
+        let texts = Self.hourLabelTexts(
+            windowStart: inputs.windowStart,
+            windowEnd: inputs.windowEnd
+        )
+        while hourLabels.count < texts.count {
+            let label = UILabel()
+            label.font = .systemFont(ofSize: 10, weight: .medium)
+            // Apply monospaced-digit feature for time-format parity with
+            // the SwiftUI `.monospacedDigit()` modifier.
+            label.font = UIFont.monospacedDigitSystemFont(ofSize: 10, weight: .medium)
+            label.textColor = UIColor.secondaryLabel
+            label.textAlignment = .right
+            label.numberOfLines = 1
+            label.backgroundColor = .clear
+            hourLabelContainer.addSubview(label)
+            hourLabels.append(label)
+        }
+        while hourLabels.count > texts.count {
+            hourLabels.removeLast().removeFromSuperview()
+        }
+        for (i, item) in texts.enumerated() {
+            hourLabels[i].text = item.text
+        }
+    }
+
+    private func layoutHourLabels(inputs: MiniDayTimelineLayerInputs) {
+        let texts = Self.hourLabelTexts(
+            windowStart: inputs.windowStart,
+            windowEnd: inputs.windowEnd
+        )
+        let containerWidth = hourLabelContainer.bounds.width
+        // SwiftUI uses `.position(x: 15, y: yPos)` — geometric center at
+        // x=15 with `.foregroundStyle(.secondary)` font(10pt medium). The
+        // UIKit equivalent centers the label horizontally on x=15 too.
+        let centerX: CGFloat = 15
+        // Content offset mirrors the SwiftUI `.offset(y: contentOffset)`
+        // applied to the full-height content stack before clipping.
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        for (i, item) in texts.enumerated() {
+            guard i < hourLabels.count else { break }
+            let label = hourLabels[i]
+            let fit = label.sizeThatFits(
+                CGSize(width: containerWidth, height: CGFloat.greatestFiniteMagnitude)
+            )
+            let yPos = CGFloat(item.date.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+            label.frame = CGRect(
+                x: centerX - fit.width / 2,
+                y: yPos + contentOffset - fit.height / 2,
+                width: fit.width, height: fit.height
+            )
+        }
+    }
+
+    /// Mirrors the SwiftUI `miniDayHourLabels` slot construction: every
+    /// whole-hour boundary inside `[windowStart, windowEnd)`, with the
+    /// first slot starting at the next whole-hour ≥ windowStart.
+    private static func hourLabelTexts(
+        windowStart: Date,
+        windowEnd: Date
+    ) -> [(date: Date, text: String)] {
+        let calendar = Calendar.current
+        let startHourComp = calendar.dateComponents([.year, .month, .day, .hour], from: windowStart)
+        let firstWholeHour = calendar.date(from: startHourComp) ?? windowStart
+        let start = firstWholeHour <= windowStart
+            ? firstWholeHour.addingTimeInterval(3600)
+            : firstWholeHour
+
+        let formatter = DateFormatter()
+        if AppTimeFormat.current.is24 {
+            formatter.dateFormat = "H"
+        } else {
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = "ha"
+            formatter.amSymbol = "a"
+            formatter.pmSymbol = "p"
+        }
+
+        let windowDuration = windowEnd.timeIntervalSince(windowStart)
+        let hourCount = max(0, Int(ceil(windowDuration / 3600)) + 1)
+        var result: [(date: Date, text: String)] = []
+        result.reserveCapacity(hourCount)
+        for i in 0..<hourCount {
+            let hourDate = start.addingTimeInterval(Double(i) * 3600)
+            if hourDate < windowEnd {
+                result.append((hourDate, formatter.string(from: hourDate)))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Hour grid lines (parity with miniDayGridLines)
+
+    private func rebuildHourGridLines(inputs: MiniDayTimelineLayerInputs) {
+        let texts = Self.hourLabelTexts(
+            windowStart: inputs.windowStart,
+            windowEnd: inputs.windowEnd
+        )
+        while hourGridLines.count < texts.count {
+            let line = CALayer()
+            line.backgroundColor = UIColor.label.withAlphaComponent(0.06).cgColor
+            line.actions = MiniDayTimelineLayerView.disabledActions
+            eventAreaContainer.layer.insertSublayer(line, at: 0)
+            hourGridLines.append(line)
+        }
+        while hourGridLines.count > texts.count {
+            hourGridLines.removeLast().removeFromSuperlayer()
+        }
+        // Re-color in case of trait change (light → dark).
+        for line in hourGridLines {
+            line.backgroundColor = UIColor.label.withAlphaComponent(0.06).cgColor
+        }
+    }
+
+    private func layoutHourGridLines(inputs: MiniDayTimelineLayerInputs) {
+        let texts = Self.hourLabelTexts(
+            windowStart: inputs.windowStart,
+            windowEnd: inputs.windowEnd
+        )
+        let width = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        for (i, item) in texts.enumerated() {
+            guard i < hourGridLines.count else { break }
+            let yPos = CGFloat(item.date.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+            hourGridLines[i].frame = CGRect(
+                x: 0,
+                y: yPos + contentOffset,
+                width: width,
+                height: 0.5
+            )
+        }
+    }
+
+    // MARK: - Sibling event blocks
+
+    private func rebuildSiblingBlocks(inputs: MiniDayTimelineLayerInputs) {
+        // Drop entries whose occurrence id is no longer in the inputs;
+        // recycle the rest. The pool is keyed by occurrence id (stable
+        // across re-applies) so a sibling's CALayer subtree lives across
+        // structural changes without flicker.
+        let liveIDs = Set(inputs.siblingOccurrences.map(\.id))
+        for (id, block) in siblingBlocks where !liveIDs.contains(id) {
+            block.removeFromSuperlayer()
+            siblingBlocks.removeValue(forKey: id)
+        }
+        for occurrence in inputs.siblingOccurrences {
+            if siblingBlocks[occurrence.id] == nil {
+                let block = BlockLayers()
+                block.install(in: eventAreaContainer.layer, below: focusedBlockInstalled ? focusedBlock.container : nil)
+                siblingBlocks[occurrence.id] = block
+            }
+        }
+    }
+
+    private func installFocusedBlockIfNeeded() {
+        guard !focusedBlockInstalled else { return }
+        focusedBlock.install(in: eventAreaContainer.layer, below: nil)
+        focusedBlockInstalled = true
+    }
+
+    private func layoutSiblingBlocks(inputs: MiniDayTimelineLayerInputs) {
+        let areaWidth = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        for occurrence in inputs.siblingOccurrences {
+            guard let block = siblingBlocks[occurrence.id] else { continue }
+            let slot = inputs.slots[occurrence.id] ?? .default
+            let blockStart = max(occurrence.range.start, inputs.windowStart)
+            let blockEnd = min(occurrence.range.end, inputs.windowEnd)
+            let yTop = CGFloat(blockStart.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+            let heightSeconds = max(0, blockEnd.timeIntervalSince(blockStart))
+            // Duration-proportional; 2pt hairline floor for zero-duration
+            // edge case (matches the SwiftUI `max(2, …)` floor).
+            let blockHeight = max(2, CGFloat(heightSeconds / 3600) * inputs.hourHeight)
+            let xOffset = slot.xOffsetFraction * areaWidth
+            // -1pt trailing gap parity (SwiftUI `slot.widthFraction *
+            // areaWidth - 1` floor at 8pt).
+            let blockWidth = max(8, slot.widthFraction * areaWidth - 1)
+            block.configure(
+                event: occurrence.event,
+                displayRange: occurrence.range,
+                frame: CGRect(
+                    x: xOffset,
+                    y: yTop + contentOffset,
+                    width: blockWidth, height: blockHeight
+                ),
+                isFocused: false,
+                baseFontSize: inputs.baseFontSize,
+                showTimeBelowTitle: inputs.showTimeBelowTitle
+            )
+        }
+    }
+
+    private func layoutFocusedBlock(inputs: MiniDayTimelineLayerInputs) {
+        let areaWidth = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        let slot = inputs.slots[inputs.focusedSlotID] ?? .default
+        let xOffset = slot.xOffsetFraction * areaWidth
+        let width = max(8, slot.widthFraction * areaWidth - 1)
+        let eventDuration = inputs.focusedRange.end.timeIntervalSince(inputs.focusedRange.start)
+        let yTop = CGFloat(inputs.focusedRange.start.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+        let height = max(2, CGFloat(eventDuration / 3600) * inputs.hourHeight)
+        focusedBlock.configure(
+            event: inputs.focusedEvent,
+            displayRange: inputs.focusedRange,
+            frame: CGRect(
+                x: xOffset,
+                y: yTop + contentOffset,
+                width: width, height: height
+            ),
+            isFocused: true,
+            baseFontSize: inputs.baseFontSize,
+            showTimeBelowTitle: inputs.showTimeBelowTitle
+        )
+    }
+
+    // MARK: - Interrupt stripes (parity with the SwiftUI ForEach)
+
+    private func rebuildStripes(inputs: MiniDayTimelineLayerInputs) {
+        let needed = inputs.isExpanded ? inputs.interruptStripes.count : 0
+        while stripeLayers.count < needed {
+            let layer = CAShapeLayer()
+            layer.actions = MiniDayTimelineLayerView.disabledActions
+            layer.fillColor = UIColor.clear.cgColor
+            eventAreaContainer.layer.addSublayer(layer)
+            stripeLayers.append(layer)
+        }
+        while stripeLayers.count > needed {
+            stripeLayers.removeLast().removeFromSuperlayer()
+        }
+    }
+
+    private func layoutStripes(inputs: MiniDayTimelineLayerInputs) {
+        guard inputs.isExpanded else {
+            for layer in stripeLayers { layer.isHidden = true }
+            return
+        }
+        let areaWidth = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        let slot = inputs.slots[inputs.focusedSlotID] ?? .default
+        let xOffset = slot.xOffsetFraction * areaWidth
+        let eventDuration = inputs.focusedRange.end.timeIntervalSince(inputs.focusedRange.start)
+        let focusedYTop = CGFloat(inputs.focusedRange.start.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+        let focusedHeight = max(2, CGFloat(eventDuration / 3600) * inputs.hourHeight)
+        // SwiftUI: stripe is `.frame(width: 6, height: segHeight)`
+        // `.offset(x: focusedX + 2, y: focusedY + startFrac * focusedH)`.
+        let stripeWidth: CGFloat = 6
+        let stripeXOffset: CGFloat = 2
+        let cornerRadius: CGFloat = 3
+        for (i, stripe) in inputs.interruptStripes.enumerated() {
+            guard i < stripeLayers.count else { break }
+            let layer = stripeLayers[i]
+            let segHeight = max(4, CGFloat(stripe.endFraction - stripe.startFraction) * focusedHeight)
+            let y = focusedYTop + contentOffset + CGFloat(stripe.startFraction) * focusedHeight
+            let rect = CGRect(x: xOffset + stripeXOffset, y: y, width: stripeWidth, height: segHeight)
+            layer.path = UIBezierPath(roundedRect: rect, cornerRadius: cornerRadius).cgPath
+            layer.fillColor = UIColor(stripe.tint).withAlphaComponent(0.6).cgColor
+            layer.isHidden = false
+        }
+    }
+
+    // MARK: - Note markers + thumb (live-driven via the 1Hz tick)
+
+    private func rebuildNoteMarkers(inputs: MiniDayTimelineLayerInputs) {
+        let needed = inputs.isExpanded ? inputs.notes.count : 0
+        while noteMarkers.count < needed {
+            let marker = NoteMarker()
+            marker.install(in: eventAreaContainer.layer)
+            noteMarkers.append(marker)
+        }
+        while noteMarkers.count > needed {
+            noteMarkers.removeLast().removeFromSuperlayer()
+        }
+    }
+
+    private func layoutNoteMarkers(inputs: MiniDayTimelineLayerInputs) {
+        guard inputs.isExpanded else {
+            for marker in noteMarkers { marker.hide() }
+            return
+        }
+        let areaWidth = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        let eventDuration = inputs.focusedRange.end.timeIntervalSince(inputs.focusedRange.start)
+        let focusedYTop = CGFloat(inputs.focusedRange.start.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+        let focusedHeight = max(2, CGFloat(eventDuration / 3600) * inputs.hourHeight)
+        for (i, note) in inputs.notes.enumerated() {
+            guard i < noteMarkers.count else { break }
+            let progress = calendarEventTimelineProgress(for: note.createdAt, range: inputs.focusedRange)
+            let noteY = focusedYTop + contentOffset + focusedHeight * progress
+            // Default to NOT nearby; live tick updates nearby state.
+            noteMarkers[i].layout(
+                centerY: noteY,
+                areaWidth: areaWidth,
+                isNearby: false
+            )
+        }
+        _ = eventDuration
+    }
+
+    private func updateLiveOverlays(inputs: MiniDayTimelineLayerInputs, now: Date) {
+        // 1. Focused-block live progress fill
+        let liveState = calendarEventTimelineResolvedState(
+            mode: inputs.timelineMode,
+            manualProgress: inputs.manualProgress,
+            now: now,
+            range: inputs.focusedRange
+        )
+        focusedBlock.applyLiveProgress(
+            displayProgress: liveState.displayProgress,
+            tint: UIColor(CalendarLayout.eventColor(for: inputs.focusedEvent))
+        )
+
+        guard inputs.isExpanded else {
+            thumbBlock.isHidden = true
+            thumbLine.isHidden = true
+            for marker in noteMarkers { marker.setNearby(false) }
+            return
+        }
+
+        // 2. Note nearby highlight — mirrors `isNoteNearSlider` (window =
+        // max(5% of total, 60s)).
+        let snapshotDate = liveState.snapshotDate
+        let totalDuration = inputs.focusedRange.end.timeIntervalSince(inputs.focusedRange.start)
+        let nearbyWindow = max(totalDuration * 0.05, 60)
+        for (i, note) in inputs.notes.enumerated() {
+            guard i < noteMarkers.count else { break }
+            let isNearby = abs(note.createdAt.timeIntervalSince(snapshotDate)) <= nearbyWindow
+            noteMarkers[i].setNearby(isNearby)
+        }
+
+        // 3. Current-position thumb
+        positionThumb(inputs: inputs, now: now)
+    }
+
+    private func positionThumb(inputs: MiniDayTimelineLayerInputs, now: Date) {
+        guard inputs.isExpanded else {
+            thumbBlock.isHidden = true
+            thumbLine.isHidden = true
+            return
+        }
+        let liveState = calendarEventTimelineResolvedState(
+            mode: inputs.timelineMode,
+            manualProgress: inputs.manualProgress,
+            now: now,
+            range: inputs.focusedRange
+        )
+        let areaWidth = eventAreaContainer.bounds.width
+        let contentOffset = Self.contentOffsetY(for: inputs)
+        let eventDuration = inputs.focusedRange.end.timeIntervalSince(inputs.focusedRange.start)
+        let focusedYTop = CGFloat(inputs.focusedRange.start.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+        let focusedHeight = max(2, CGFloat(eventDuration / 3600) * inputs.hourHeight)
+        let thumbY = focusedYTop + contentOffset + focusedHeight * liveState.displayProgress
+        let tint = UIColor(CalendarLayout.eventColor(for: inputs.focusedEvent))
+        thumbBlock.isHidden = false
+        thumbLine.isHidden = false
+        // SwiftUI: HStack { 4×12 rounded rect (tint) + 1pt rect (tint @ 0.5) }
+        // `.offset(y: thumbY - 6)`. The rounded rect is at the leading
+        // edge (x=0), the hairline trails it across the area width.
+        thumbBlock.frame = CGRect(x: 0, y: thumbY - 6, width: 4, height: 12)
+        thumbBlock.backgroundColor = tint.cgColor
+        thumbLine.frame = CGRect(x: 4, y: thumbY - 0.5, width: max(0, areaWidth - 4), height: 1)
+        thumbLine.backgroundColor = tint.withAlphaComponent(0.5).cgColor
+    }
+
+    // MARK: - Helpers
+
+    /// Mirrors the SwiftUI tree's `contentOffset` (`isExpanded ? 0 :
+    /// -eventTop`). When collapsed, content slides up so the focused
+    /// event sits at the top.
+    private static func contentOffsetY(for inputs: MiniDayTimelineLayerInputs) -> CGFloat {
+        if inputs.isExpanded { return 0 }
+        let eventTop = CGFloat(inputs.focusedRange.start.timeIntervalSince(inputs.windowStart) / 3600) * inputs.hourHeight
+        return -eventTop
+    }
+}
+
+// MARK: - Block layers (event-block visual subtree)
+
+/// CALayer subtree for a single mini-day event block. Mirrors the SwiftUI
+/// `miniDayEventBlockVisual` exactly: systemBackground knock-out + tint
+/// fill + optional mid-overlay (live progress for the focused block) +
+/// border + effort bar + title + optional time row.
+private final class BlockLayers {
+    let container = CALayer()
+    private let backgroundLayer = CAShapeLayer()
+    private let tintLayer = CAShapeLayer()
+    private let midOverlay = CALayer()          // focused-block progress fill
+    private let borderLayer = CAShapeLayer()
+    private let effortBarLayer = CAShapeLayer()
+    private let titleLayer = CATextLayer()
+    private let timeLayer = CATextLayer()
+
+    private static let cornerRadius: CGFloat = 6
+    private static let strokeWidth: CGFloat = 1.2
+
+    private var lastConfigKey: ConfigKey?
+
+    private struct ConfigKey: Equatable {
+        let eventID: UUID
+        let title: String
+        let typeKey: String
+        let rangeStart: Date
+        let rangeEnd: Date
+        let width: CGFloat
+        let height: CGFloat
+        let isFocused: Bool
+        let colorDepth: Int
+        let baseFontSize: CGFloat
+        let showTimeBelowTitle: Bool
+    }
+
+    init() {
+        container.actions = MiniDayTimelineLayerView.disabledActions
+        for layer in [backgroundLayer, tintLayer, borderLayer, effortBarLayer] {
+            layer.actions = MiniDayTimelineLayerView.disabledActions
+            layer.fillColor = UIColor.clear.cgColor
+            layer.contentsScale = UIScreen.main.scale
+        }
+        midOverlay.actions = MiniDayTimelineLayerView.disabledActions
+        for text in [titleLayer, timeLayer] {
+            text.actions = MiniDayTimelineLayerView.disabledActions
+            text.contentsScale = UIScreen.main.scale
+            text.isWrapped = true
+            text.truncationMode = .end
+            text.alignmentMode = .left
+        }
+        // SwiftUI tree z-order (bottom → top):
+        //   systemBackground knockout → tint fill → midOverlay (clipped) →
+        //   border → effort bar → title → time
+        container.addSublayer(backgroundLayer)
+        container.addSublayer(tintLayer)
+        container.addSublayer(midOverlay)
+        container.addSublayer(borderLayer)
+        container.addSublayer(effortBarLayer)
+        container.addSublayer(titleLayer)
+        container.addSublayer(timeLayer)
+        // The mid-overlay clips to the block silhouette (cornerRadius),
+        // mirroring SwiftUI `.clipShape(blockShape)` on the caller-injected
+        // overlay.
+        midOverlay.cornerRadius = BlockLayers.cornerRadius
+        midOverlay.masksToBounds = true
+    }
+
+    func install(in parent: CALayer, below: CALayer?) {
+        if let below {
+            parent.insertSublayer(container, below: below)
+        } else {
+            parent.addSublayer(container)
+        }
+    }
+
+    func removeFromSuperlayer() {
+        container.removeFromSuperlayer()
+    }
+
+    func configure(
+        event: Event,
+        displayRange: Event.TimeRange,
+        frame: CGRect,
+        isFocused: Bool,
+        baseFontSize: CGFloat,
+        showTimeBelowTitle: Bool
+    ) {
+        container.frame = frame
+        let bodyRect = CGRect(origin: .zero, size: frame.size)
+        // Continuous-rounded-rect path matching `RoundedRectangle(style:
+        // .continuous)`. We use UIBezierPath's circular approximation — the
+        // 6pt radius is small enough on a mini-day block that the
+        // continuous/circular difference is sub-pixel; the main calendar's
+        // exact superellipse helper isn't worth re-importing.
+        let path = UIBezierPath(roundedRect: bodyRect, cornerRadius: BlockLayers.cornerRadius).cgPath
+
+        backgroundLayer.frame = bodyRect
+        backgroundLayer.path = path
+        backgroundLayer.fillColor = UIColor.systemBackground.cgColor
+
+        let tint = UIColor(CalendarLayout.eventColor(for: event))
+        let fillOpacity: CGFloat = isFocused ? 0.5 : 0.4
+        tintLayer.frame = bodyRect
+        tintLayer.path = path
+        tintLayer.fillColor = tint.withAlphaComponent(fillOpacity).cgColor
+
+        // midOverlay frame matches the bodyRect so live-progress writes
+        // can size their own sublayers against (0,0,width,height). Hidden
+        // by default; the focused block's `applyLiveProgress` unhides it.
+        midOverlay.frame = bodyRect
+        if !isFocused {
+            midOverlay.isHidden = true
+            midOverlay.sublayers?.forEach { $0.removeFromSuperlayer() }
+        }
+
+        let strokeOpacity: CGFloat = isFocused ? 0.9 : 0.7
+        borderLayer.frame = bodyRect
+        borderLayer.path = path
+        borderLayer.strokeColor = tint.withAlphaComponent(strokeOpacity).cgColor
+        borderLayer.lineWidth = BlockLayers.strokeWidth
+        borderLayer.fillColor = UIColor.clear.cgColor
+
+        // Effort bar — 1.0 + colorDepth * 1.5 pt wide strip at the leading
+        // edge, masked to the block silhouette (so its top/bottom corners
+        // curve with the block).
+        if event.colorDepth > 0 {
+            let barWidth: CGFloat = 1.0 + CGFloat(event.colorDepth) * 1.5
+            let barRect = CGRect(x: 0, y: 0, width: barWidth, height: bodyRect.height)
+            // Compose: intersect the block silhouette (path) with a
+            // leading-aligned width rectangle. CAShapeLayer doesn't
+            // compose paths intrinsically, so we use a mask layer.
+            effortBarLayer.frame = bodyRect
+            // Draw the bar as a filled path of the leading strip,
+            // then clip it to the block silhouette via a separate mask.
+            effortBarLayer.path = UIBezierPath(rect: barRect).cgPath
+            effortBarLayer.fillColor = tint.cgColor
+            // Mask installs the silhouette path so the corners match.
+            let mask: CAShapeLayer
+            if let existing = effortBarLayer.mask as? CAShapeLayer {
+                mask = existing
+            } else {
+                mask = CAShapeLayer()
+                mask.actions = MiniDayTimelineLayerView.disabledActions
+                effortBarLayer.mask = mask
+            }
+            mask.path = path
+            mask.frame = bodyRect
+            mask.fillColor = UIColor.white.cgColor
+            effortBarLayer.isHidden = false
+        } else {
+            effortBarLayer.isHidden = true
+        }
+
+        // Text layout uses the shared helper so the SwiftUI and CALayer
+        // paths share one source of truth for content rect + lineLimit +
+        // showsTimeRange + verticalCenter.
+        let title = event.title.isEmpty ? "Untitled" : event.title
+        let textLayout = calendarEventTextLayout(
+            in: bodyRect,
+            title: title,
+            requireTitleFit: false,
+            styleShowTimeRange: isFocused,
+            isWeekMode: true,
+            baseFontSize: baseFontSize,
+            showTimeBelowTitle: showTimeBelowTitle
+        )
+
+        // Layout text. Mirrors the SwiftUI tree's VStack(spacing:
+        // titleSpacing) { Text(title)+Text(time) } inside the resolved
+        // content rect (verticalCenter sets the y-anchor).
+        let titleFontSize = baseFontSize
+        let timeFontSize = calendarEventTimeFontSize(forTitleFontSize: titleFontSize, isWeekMode: true)
+        let titleSpacing = calendarEventBlockTitleSpacing(isWeekMode: true, isThreeDayMode: false)
+        let titleFont = UIFont.systemFont(ofSize: titleFontSize, weight: .semibold)
+        let timeFont = UIFont.monospacedDigitSystemFont(ofSize: timeFontSize, weight: .medium)
+
+        if let layout = textLayout {
+            let contentRect = layout.contentRect
+            var cursorY = contentRect.minY
+            let titleLineHeight = titleFont.lineHeight
+            let maxTitleHeight = min(CGFloat(layout.titleLineLimit) * titleLineHeight, contentRect.height)
+            let naturalTitleHeight = title.boundingRect(
+                with: CGSize(width: contentRect.width, height: .greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin],
+                attributes: [.font: titleFont],
+                context: nil
+            ).height
+            let titleHeight = min(ceil(naturalTitleHeight / titleLineHeight) * titleLineHeight, maxTitleHeight)
+            if layout.verticalCenter {
+                var stackHeight = titleHeight
+                if layout.showsTimeRange {
+                    stackHeight += titleSpacing + timeFont.lineHeight
+                }
+                cursorY = contentRect.minY + max(0, (contentRect.height - stackHeight) / 2)
+            }
+            titleLayer.isHidden = false
+            titleLayer.frame = CGRect(
+                x: contentRect.minX, y: cursorY,
+                width: contentRect.width, height: titleHeight
+            )
+            titleLayer.font = titleFont
+            titleLayer.fontSize = titleFontSize
+            titleLayer.foregroundColor = UIColor.label.cgColor
+            titleLayer.string = title
+            cursorY += titleHeight + titleSpacing
+
+            if layout.showsTimeRange {
+                let timeStr = "\(Self.timeText(displayRange.start)) – \(Self.timeText(displayRange.end))"
+                timeLayer.isHidden = false
+                timeLayer.frame = CGRect(
+                    x: contentRect.minX, y: cursorY,
+                    width: contentRect.width, height: timeFont.lineHeight
+                )
+                timeLayer.font = timeFont
+                timeLayer.fontSize = timeFontSize
+                timeLayer.foregroundColor = UIColor.secondaryLabel.cgColor
+                timeLayer.isWrapped = false
+                timeLayer.string = timeStr
+            } else {
+                timeLayer.isHidden = true
+                timeLayer.string = nil
+            }
+        } else {
+            titleLayer.isHidden = true
+            titleLayer.string = nil
+            timeLayer.isHidden = true
+            timeLayer.string = nil
+        }
+    }
+
+    /// Update the focused-block live progress overlay. Builds the SwiftUI
+    /// tree's VStack { Rectangle(fill: tint@0.22, height: live%) + Spacer }
+    /// as a single child CALayer of `midOverlay`.
+    func applyLiveProgress(displayProgress: CGFloat, tint: UIColor) {
+        midOverlay.isHidden = false
+        let height = midOverlay.bounds.height * displayProgress
+        let fillLayer: CALayer
+        if let existing = midOverlay.sublayers?.first {
+            fillLayer = existing
+        } else {
+            fillLayer = CALayer()
+            fillLayer.actions = MiniDayTimelineLayerView.disabledActions
+            midOverlay.addSublayer(fillLayer)
+        }
+        fillLayer.frame = CGRect(x: 0, y: 0, width: midOverlay.bounds.width, height: height)
+        fillLayer.backgroundColor = tint.withAlphaComponent(0.22).cgColor
+    }
+
+    /// Matches `timelineTimeLabel` in CalendarEventDetailView.
+    private static func timeText(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        if AppTimeFormat.current.is24 {
+            formatter.dateFormat = "H:mm"
+        } else {
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = "h:mm a"
+            formatter.amSymbol = "am"
+            formatter.pmSymbol = "pm"
+        }
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Note marker (dot + hairline)
+
+/// CALayer pair for a single timeline-note marker. Dot grows from 5→7pt
+/// and the hairline darkens from 0.12→0.3 when the note is "nearby" the
+/// current scrub position.
+private final class NoteMarker {
+    private let dot = CAShapeLayer()
+    private let line = CALayer()
+
+    private static let dotIdleSize: CGFloat = 5
+    private static let dotNearbySize: CGFloat = 7
+
+    init() {
+        dot.actions = MiniDayTimelineLayerView.disabledActions
+        line.actions = MiniDayTimelineLayerView.disabledActions
+        dot.fillColor = UIColor.label.withAlphaComponent(0.4).cgColor
+        line.backgroundColor = UIColor.label.withAlphaComponent(0.12).cgColor
+    }
+
+    func install(in parent: CALayer) {
+        parent.addSublayer(dot)
+        parent.addSublayer(line)
+    }
+
+    func removeFromSuperlayer() {
+        dot.removeFromSuperlayer()
+        line.removeFromSuperlayer()
+    }
+
+    func hide() {
+        dot.isHidden = true
+        line.isHidden = true
+    }
+
+    func layout(centerY: CGFloat, areaWidth: CGFloat, isNearby: Bool) {
+        let size = isNearby ? NoteMarker.dotNearbySize : NoteMarker.dotIdleSize
+        let yOffset: CGFloat = size / 2
+        dot.isHidden = false
+        dot.path = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: size, height: size)).cgPath
+        dot.frame = CGRect(x: 0, y: centerY - yOffset, width: size, height: size)
+        line.isHidden = false
+        // Hairline starts past the dot's right edge, extends across the
+        // remaining area width. Mirrors the SwiftUI HStack(spacing: 0).
+        line.frame = CGRect(x: size, y: centerY - 0.25, width: max(0, areaWidth - size), height: 0.5)
+    }
+
+    func setNearby(_ nearby: Bool) {
+        dot.fillColor = (nearby ? UIColor.label : UIColor.label.withAlphaComponent(0.4)).cgColor
+        line.backgroundColor = UIColor.label.withAlphaComponent(nearby ? 0.3 : 0.12).cgColor
+        // Re-bound the dot to the nearby/idle size if the layout result
+        // has gone stale (cheap path — the next layoutNoteMarkers call
+        // will repopulate the frame on the next apply).
+        let currentBounds = dot.bounds
+        let targetSize = nearby ? NoteMarker.dotNearbySize : NoteMarker.dotIdleSize
+        if abs(currentBounds.width - targetSize) > 0.5 {
+            let origin = dot.frame.origin
+            let centerY = origin.y + currentBounds.height / 2
+            let yOffset = targetSize / 2
+            dot.path = UIBezierPath(ovalIn: CGRect(x: 0, y: 0, width: targetSize, height: targetSize)).cgPath
+            dot.frame = CGRect(x: origin.x, y: centerY - yOffset, width: targetSize, height: targetSize)
+        }
+    }
+}
+
+// Note: `CalendarLayout.EventOverlapSlot.default` is defined in
+// `CalendarLayout.swift`; this file reuses it directly via the `??
+// .default` fallback in `layoutSiblingBlocks` / `layoutFocusedBlock`.

--- a/Done/Views/Calendar/Components/Timeline/MiniDayTimelineLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/MiniDayTimelineLayerView.swift
@@ -287,6 +287,13 @@ final class MiniDayTimelineLayerView: UIView {
         installFocusedBlockIfNeeded()
         rebuildStripes(inputs: inputs)
         rebuildNoteMarkers(inputs: inputs)
+        // Re-promote thumb to top of the sublayer order. The rebuild
+        // methods above use `addSublayer`, which appends — without this
+        // re-promotion the thumb (added in init at the bottom) gets
+        // occluded by sibling/focused blocks and stripes. Matches the
+        // SwiftUI ZStack's thumb-last visual order.
+        eventAreaContainer.layer.addSublayer(thumbLine)
+        eventAreaContainer.layer.addSublayer(thumbBlock)
     }
 
     private func layoutContent(inputs: MiniDayTimelineLayerInputs) {

--- a/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineEditMapping.swift
@@ -679,6 +679,75 @@ func calendarResolveAxisMarkerPresentation(
     )
 }
 
+/// Free-function form of `TimelinePagerView.resolvedDragEditMapping` —
+/// reads only its arguments, so it can be called from a child sub-view
+/// without dragging the parent's `dragState.dragOffset` observation back
+/// up into `TimelinePagerView.body`. (#77)
+func calendarResolvedDragEditMapping(
+    draggingEventID: UUID?,
+    draggingOriginalRange: Event.TimeRange?,
+    dragOffset: DragOffset,
+    dragMode: EventDragMode,
+    dayColumnStep: CGFloat,
+    hourHeight: CGFloat,
+    calendar: Calendar = .current
+) -> (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
+    guard draggingEventID != nil else { return nil }
+    guard let range = calendarResolvedDragEditRange(
+        draggingOriginalRange: draggingOriginalRange,
+        dragOffset: dragOffset,
+        dragMode: dragMode,
+        hourHeight: hourHeight,
+        dayColumnStep: dayColumnStep,
+        calendar: calendar
+    ) else { return nil }
+
+    let source: TimelineEditMappingSource
+    switch dragMode {
+    case .move:
+        source = .moveDrag
+    case .resizeTop:
+        source = .resizeTop
+    case .resizeBottom:
+        source = .resizeBottom
+    }
+
+    // For move drag, use the vertical-only range (no day shift) so the
+    // time marker and boundary extension track the source day column.
+    let effectiveRange: Event.TimeRange
+    if source == .moveDrag, let originalRange = draggingOriginalRange, hourHeight > 0 {
+        let rawOffsetSeconds = TimeInterval(dragOffset.y / hourHeight * 3600)
+        let snappedOffset = calendarPreviewOffsetSeconds(
+            rawOffsetSeconds: rawOffsetSeconds,
+            range: originalRange,
+            snapIntervalSeconds: 15 * 60,
+            calendar: calendar
+        )
+        effectiveRange = Event.TimeRange(
+            start: originalRange.start.addingTimeInterval(snappedOffset),
+            end: originalRange.end.addingTimeInterval(snappedOffset)
+        )
+    } else {
+        effectiveRange = range
+    }
+
+    // For move drag, anchor to the source day so the time marker
+    // Y aligns with the vertical-only range (no day shift mismatch).
+    let anchorDate: Date
+    if source == .moveDrag, let originalRange = draggingOriginalRange {
+        anchorDate = calendar.startOfDay(for: originalRange.start)
+    } else {
+        anchorDate = calendarResolvedDragAnchorDate(
+            draggingOriginalRange: draggingOriginalRange,
+            dragOffset: dragOffset,
+            dragMode: dragMode,
+            dayColumnStep: dayColumnStep,
+            calendar: calendar
+        ) ?? effectiveRange.start
+    }
+    return (source, anchorDate, effectiveRange)
+}
+
 private func calendarAxisMarkerTimeText(for date: Date) -> String {
     calendarAxisMarkerFormatter.string(from: date)
 }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1167,11 +1167,11 @@ struct TimelinePagerView: View {
     @AppStorage(AppSettingsKeys.experimentalMultiTypeEvents) private var calayerMultiTypeEnabled = false
     // CALayer chrome: future-zone tint + horizon line span.
     @AppStorage(AppSettingsKeys.nearFutureHorizonDays) private var nearFutureHorizonDays: Int = EventZone.defaultHorizonDays
-    // Experimental: gate the SwiftUI axis tree (`TimeAxisLabels`) behind a
-    // CALayer-backed port (`TimeAxisLayerHost`). Default OFF; flipped ON
-    // only after A/B parity verification settles. See `TimeAxisLayerView.swift`
-    // (issue #60).
-    @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var useCALayerAxisMarkers = false
+    // CALayer-backed axis port (`TimeAxisLayerHost`) replacing the SwiftUI
+    // `TimeAxisLabels` tree. Default ON after on-device A/B parity sign-off
+    // (idle / pinch / scroll / drag / cross-midnight). See
+    // `TimeAxisLayerView.swift` (issue #60).
+    @AppStorage(AppSettingsKeys.calendarUseCALayerAxisMarkers) private var useCALayerAxisMarkers = true
     var dragState: EventDragState
     let occurrencesForOffset: (Int) -> [CalendarLayout.EventOccurrence]
     var allDayOccurrencesForOffset: ((Int) -> [CalendarLayout.EventOccurrence])? = nil

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1272,14 +1272,29 @@ struct TimelinePagerView: View {
             focused: resolvedFocusedEditMapping
         )
     }
-    private var boundaryExtensionMappingState: TimelineEditMappingState? {
-        return calendarResolveBoundaryExtensionMappingState(
+
+    /// Computes the boundary-extension mapping state from the current drag /
+    /// creation source. Reads `resolvedDragEditMapping` (which reads
+    /// `dragState.dragOffset`); to avoid registering body-scope dependencies
+    /// on `dragOffset`, this MUST be called only from `.onChange` handlers /
+    /// modifier closures, never from body. Body-scope readers use the
+    /// `@State`-latched `cachedRawBoundaryExtensionState` via the
+    /// `rawBoundaryExtensionState` computed below. (#77)
+    private func computeBoundaryExtensionMappingState() -> TimelineEditMappingState? {
+        calendarResolveBoundaryExtensionMappingState(
             creation: resolvedCreationEditMapping,
             drag: resolvedDragEditMapping
         )
     }
-    private var rawBoundaryExtensionHours: (leading: Int, trailing: Int) {
-        var result = calendarTimelineBoundaryExtensionHours(mappingState: boundaryExtensionMappingState)
+
+    /// Computes the raw boundary extension hours from the current drag /
+    /// creation source. Reads `dragState.dragOffset` transitively; MUST be
+    /// called only from `.onChange` handlers / modifier closures, never from
+    /// body. Body-scope readers use `cachedRawBoundaryExtensionState`. (#77)
+    private func computeRawBoundaryExtensionHours(
+        mappingState: TimelineEditMappingState?
+    ) -> (leading: Int, trailing: Int) {
+        var result = calendarTimelineBoundaryExtensionHours(mappingState: mappingState)
 
         // Cross-day event fix: when the scroll has hit the top boundary
         // (can't go further up) and the user is actively dragging upward,
@@ -1305,7 +1320,7 @@ struct TimelinePagerView: View {
         // latch is updated by an `.onChange(of: dragState.dragOffset.y)`
         // handler whose body-scope is just the modifier closure, not
         // `TimelineView.body`. (#75)
-        if let state = boundaryExtensionMappingState,
+        if let state = mappingState,
            state.source == .moveDrag || state.source == .resizeTop,
            result.leading == 0,
            proactiveLeadingExtensionLatch {
@@ -1334,21 +1349,47 @@ struct TimelinePagerView: View {
         }
     }
 
+    /// Body-scope reader for the raw boundary extension state. Returns the
+    /// `@State`-latched cached value so body does NOT observe `dragOffset`
+    /// transitively. Refreshed via `refreshCachedRawBoundaryExtensionState()`
+    /// from `.onChange` handlers that watch every input the underlying compute
+    /// reads. (#77)
     private var rawBoundaryExtensionState: TimelineBoundaryExtensionState {
+        cachedRawBoundaryExtensionState
+    }
+
+    /// Pure compute: produces the raw boundary extension state from the
+    /// current drag / creation source. Called ONLY from `.onChange` handlers
+    /// (via `refreshCachedRawBoundaryExtensionState`); the body-scope reader
+    /// reads the cache. (#77)
+    private func computeRawBoundaryExtensionState() -> TimelineBoundaryExtensionState {
+        let mappingState = computeBoundaryExtensionMappingState()
+        let hours = computeRawBoundaryExtensionHours(mappingState: mappingState)
         let anchorOffset: Int? = {
-            guard let date = boundaryExtensionMappingState?.anchorDate else { return nil }
+            guard let date = mappingState?.anchorDate else { return nil }
             let calendar = Calendar.current
             let today = calendar.startOfDay(for: Date())
             let anchor = calendar.startOfDay(for: date)
             return calendar.dateComponents([.day], from: today, to: anchor).day
         }()
         return TimelineBoundaryExtensionState(
-            leadingHours: rawBoundaryExtensionHours.leading,
-            trailingHours: rawBoundaryExtensionHours.trailing,
-            source: boundaryExtensionMappingState?.source,
+            leadingHours: hours.leading,
+            trailingHours: hours.trailing,
+            source: mappingState?.source,
             anchorDayOffset: anchorOffset
         )
     }
+
+    /// Recompute the cached raw boundary extension state. Writes the new
+    /// value only when it differs from the cache, so body re-evals at most
+    /// once per actual transition (not per drag frame). (#77)
+    private func refreshCachedRawBoundaryExtensionState() {
+        let next = computeRawBoundaryExtensionState()
+        if next != cachedRawBoundaryExtensionState {
+            cachedRawBoundaryExtensionState = next
+        }
+    }
+
     private var effectiveBoundaryExtensionState: TimelineBoundaryExtensionState {
         boundaryExtensionStateOverride ?? rawBoundaryExtensionState
     }
@@ -1438,6 +1479,19 @@ struct TimelinePagerView: View {
     /// onChange site, not body. Cleared on drag end via the existing
     /// `dragState.draggingEventID` onChange.
     @State private var proactiveLeadingExtensionLatch: Bool = false
+
+    /// Cached raw boundary-extension state (#77). Body reads this via
+    /// `rawBoundaryExtensionState`; refreshed from `.onChange` handlers
+    /// (`refreshCachedRawBoundaryExtensionState`) that watch every input
+    /// the underlying compute reads (drag offset / drag session fields /
+    /// hourHeight / proactive latch / creation source). Body re-evals only
+    /// when this value actually changes — at most a couple of times per
+    /// drag (when the mapped range crosses the midnight predicate) — not
+    /// per drag frame. This breaks the `boundaryExtensionHours →
+    /// boundaryExtensionMappingState → resolvedDragEditMapping →
+    /// dragState.dragOffset` body-dependency edge that #76's latch did not
+    /// reach.
+    @State private var cachedRawBoundaryExtensionState: TimelineBoundaryExtensionState = .none
 
     private var occurrenceExtensionHoursForDrag: (leading: Int, trailing: Int) {
         let isMoveDragActive = calendarIsMoveDragActive(
@@ -1628,6 +1682,14 @@ struct TimelinePagerView: View {
         }
         .frame(height: totalHeight, alignment: .top)
         .onAppear {
+            // #77: seed the cached raw boundary state from the live compute so
+            // first-render reads (`rawBoundaryExtensionState`, `boundaryExtensionHours`,
+            // etc.) see the correct value rather than `.none` until the first
+            // dragOffset change. Initial cache value `.none` is correct when no
+            // drag / creation is active (the common case at appear), but if the
+            // pager is re-shown mid-flow the live compute might already be
+            // non-none.
+            refreshCachedRawBoundaryExtensionState()
             onBoundaryExtensionStateChange?(rawBoundaryExtensionState)
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
@@ -2059,6 +2121,10 @@ struct TimelinePagerView: View {
                 emitHorizontalScrollProgress(latestHorizontalContentOffsetX)
             }
             .onChange(of: selectedDayOffset) { _, newValue in
+                // #77: selectedDayOffset feeds resolvedCreationEditMapping →
+                // boundary state. Refresh the cache so creation drags that
+                // span a day pivot stay in sync.
+                refreshCachedRawBoundaryExtensionState()
                 if isUserScrollUpdating {
                     isUserScrollUpdating = false
                     return
@@ -2240,6 +2306,13 @@ struct TimelinePagerView: View {
             }
             .onChange(of: dragState.draggingEventID) { oldValue, newValue in
                 if newValue != nil && oldValue == nil {
+                    // #77: refresh the cache BEFORE reading
+                    // `boundaryExtensionHours` so the frozen snapshot reflects
+                    // the new drag's starting state, not the previous drag's
+                    // residue. The cache compute reads the live drag fields,
+                    // so calling refresh here picks up whatever the new drag
+                    // started from.
+                    refreshCachedRawBoundaryExtensionState()
                     frozenOccurrenceExtensionLeading = boundaryExtensionHours.leading
                     frozenOccurrenceExtensionTrailing = boundaryExtensionHours.trailing
                 }
@@ -2255,6 +2328,11 @@ struct TimelinePagerView: View {
                 if newValue != nil {
                     creationPreviewByDay.removeAll()
                 }
+                // #77: drag end / re-engage needs a cache refresh so the
+                // boundary state collapses back to none (or re-opens for a
+                // fresh drag) without waiting on a subsequent dragOffset
+                // write.
+                refreshCachedRawBoundaryExtensionState()
                 calendarDebugLog(
                     "timeline.dragSession.changed",
                     fields: [
@@ -2269,7 +2347,7 @@ struct TimelinePagerView: View {
                     ]
                 )
             }
-            .onChange(of: dragState.dragOffset.y) { _, newY in
+            .onChange(of: dragState.dragOffset) { _, newOffset in
                 // Mirror of the #53 single-day proactive leading-extension
                 // condition that USED to live inside `rawBoundaryExtensionHours`.
                 // Moving the dragOffset.y read out here keeps `TimelineView.body`
@@ -2277,7 +2355,37 @@ struct TimelinePagerView: View {
                 // body on every drag frame. The handler is a modifier closure —
                 // its dragOffset observation does NOT register a body-level
                 // dependency. (#75)
-                updateProactiveLeadingExtensionLatch(dragOffsetY: newY)
+                updateProactiveLeadingExtensionLatch(dragOffsetY: newOffset.y)
+                // Refresh the cached raw boundary extension state. The compute
+                // reads `resolvedDragEditMapping` (which reads `dragOffset`);
+                // doing it here keeps the read inside an onChange closure
+                // instead of body. Cache writes only on actual transitions, so
+                // body re-evals a couple of times per drag (predicate
+                // boundary crossings) rather than every frame. (#77)
+                refreshCachedRawBoundaryExtensionState()
+            }
+            // #77 — every input the boundary-state compute reads (besides
+            // dragOffset, handled above; and proactive latch, handled by its
+            // own onChange below) must trigger a cache refresh so body stays
+            // in sync. These all change at discrete moments (drag begin/end,
+            // mode flip, day step, hourHeight, creation drag), not per frame.
+            .onChange(of: dragState.dragMode) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: dragState.dayColumnStep) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: hourHeight) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: proactiveLeadingExtensionLatch) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: creationPreviewByDay) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
+            }
+            .onChange(of: previewCreation?.id) { _, _ in
+                refreshCachedRawBoundaryExtensionState()
             }
             .onChange(of: verticalScrollY) { _, _ in
                 // If the scroll moves away from the top boundary while the

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1265,13 +1265,11 @@ struct TimelinePagerView: View {
             safetyFloor: calendarTimelineHourHeightMin
         )
     }
-    private var editMappingState: TimelineEditMappingState? {
-        calendarResolveEditMappingState(
-            creation: resolvedCreationEditMapping,
-            drag: resolvedDragEditMapping,
-            focused: resolvedFocusedEditMapping
-        )
-    }
+    // `editMappingState` / `editMappingPresentation` moved into
+    // `TimelineAxisDragOverlay` (the body of `timeAxis()`'s sub-view). Both
+    // read `dragState.dragOffset` transitively, so keeping them as
+    // body-scope computeds here would re-register the per-frame body
+    // dependency that #77 deletes. (#77)
 
     /// Computes the boundary-extension mapping state from the current drag /
     /// creation source. Reads `resolvedDragEditMapping` (which reads
@@ -1554,57 +1552,14 @@ struct TimelinePagerView: View {
     }
 
     private var resolvedDragEditMapping: (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
-        guard dragState.draggingEventID != nil else { return nil }
-        guard let range = calendarResolvedDragEditRange(
+        calendarResolvedDragEditMapping(
+            draggingEventID: dragState.draggingEventID,
             draggingOriginalRange: dragState.draggingOriginalRange,
             dragOffset: dragState.dragOffset,
             dragMode: dragState.dragMode,
-            hourHeight: hourHeight,
-            dayColumnStep: dragState.dayColumnStep
-        ) else { return nil }
-
-        let source: TimelineEditMappingSource
-        switch dragState.dragMode {
-        case .move:
-            source = .moveDrag
-        case .resizeTop:
-            source = .resizeTop
-        case .resizeBottom:
-            source = .resizeBottom
-        }
-
-        // For move drag, use the vertical-only range (no day shift) so the
-        // time marker and boundary extension track the source day column.
-        let effectiveRange: Event.TimeRange
-        if source == .moveDrag, let originalRange = dragState.draggingOriginalRange, hourHeight > 0 {
-            let rawOffsetSeconds = TimeInterval(dragState.dragOffset.y / hourHeight * 3600)
-            let snappedOffset = calendarPreviewOffsetSeconds(
-                rawOffsetSeconds: rawOffsetSeconds,
-                range: originalRange,
-                snapIntervalSeconds: 15 * 60
-            )
-            effectiveRange = Event.TimeRange(
-                start: originalRange.start.addingTimeInterval(snappedOffset),
-                end: originalRange.end.addingTimeInterval(snappedOffset)
-            )
-        } else {
-            effectiveRange = range
-        }
-
-        // For move drag, anchor to the source day so the time marker
-        // Y aligns with the vertical-only range (no day shift mismatch).
-        let anchorDate: Date
-        if source == .moveDrag, let originalRange = dragState.draggingOriginalRange {
-            anchorDate = Calendar.current.startOfDay(for: originalRange.start)
-        } else {
-            anchorDate = calendarResolvedDragAnchorDate(
-                draggingOriginalRange: dragState.draggingOriginalRange,
-                dragOffset: dragState.dragOffset,
-                dragMode: dragState.dragMode,
-                dayColumnStep: dragState.dayColumnStep
-            ) ?? effectiveRange.start
-        }
-        return (source, anchorDate, effectiveRange)
+            dayColumnStep: dragState.dayColumnStep,
+            hourHeight: hourHeight
+        )
     }
 
     private var resolvedFocusedEditMapping: (date: Date, range: Event.TimeRange)? {
@@ -1617,39 +1572,6 @@ struct TimelinePagerView: View {
             visibleOffsets: visibleOffsets,
             occurrencesForOffset: occurrencesForOffset
         )
-    }
-
-    private var editMappingPresentation: TimelineAxisMarkerPresentation? {
-        // Hide time marker during vertical auto-scroll — it reappears
-        // once the user returns to normal (snapping) drag territory.
-        if editMappingState?.source == .moveDrag,
-           dragState.isHorizontalEdgeDragging || dragState.isHorizontalAutoScrolling {
-            return nil
-        }
-        guard var presentation = calendarResolveAxisMarkerPresentation(
-            mappingState: editMappingState,
-            headerHeight: headerHeight,
-            hourHeight: hourHeight,
-            leadingExtendedHours: boundaryExtensionHours.leading,
-            trailingExtendedHours: boundaryExtensionHours.trailing
-        ) else { return nil }
-
-        // Use the event's theme color from drag state, focused state, or creation
-        if let draggingEvent = dragState.draggingEvent {
-            presentation.color = CalendarLayout.eventColor(for: draggingEvent)
-        } else if let focusedEventID {
-            let visibleOffsets = Array(visibleOffsetsRange(centeredRange: centeredOffsetsRange()))
-            for offset in visibleOffsets {
-                if let match = occurrencesForOffset(offset).first(where: { $0.event.id == focusedEventID }) {
-                    presentation.color = CalendarLayout.eventColor(for: match.event)
-                    break
-                }
-            }
-        } else if editMappingState?.source == .creation {
-            presentation.color = calendarCurrentTimeIndicatorColor()
-        }
-
-        return presentation
     }
 
     var body: some View {
@@ -1708,50 +1630,49 @@ struct TimelinePagerView: View {
 
     // MARK: - Time Axis
 
-    @ViewBuilder
-    private func timeAxis() -> some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 0) {
-                if allDayHeight > 0 {
-                    Color.clear.frame(height: allDayHeight)
-                }
-                if useCALayerAxisMarkers {
-                    TimeAxisLayerHost(
-                        anchorDate: dayDate(forOffset: selectedDayOffset),
-                        headerHeight: headerHeight,
-                        hourHeight: hourHeight,
-                        slotMinutes: effectiveSlotMinutes,
-                        leadingExtendedHours: boundaryExtensionHours.leading,
-                        trailingExtendedHours: boundaryExtensionHours.trailing,
-                        mode: mode,
-                        editMappingPresentation: editMappingPresentation,
-                        leadingFadeProgress: leadingFadeProgress,
-                        trailingFadeProgress: trailingFadeProgress,
-                        isSingleDay: isSingleDay
-                    )
-                    .id(effectiveSlotMinutes)
-                    .transition(.opacity)
-                    .frame(height: timelineHeight, alignment: .top)
-                } else {
-                    TimeAxisLabels(
-                        anchorDate: dayDate(forOffset: selectedDayOffset),
-                        headerHeight: headerHeight,
-                        hourHeight: hourHeight,
-                        slotMinutes: effectiveSlotMinutes,
-                        leadingExtendedHours: boundaryExtensionHours.leading,
-                        trailingExtendedHours: boundaryExtensionHours.trailing,
-                        mode: mode,
-                        editMappingPresentation: editMappingPresentation,
-                        leadingFadeProgress: leadingFadeProgress,
-                        trailingFadeProgress: trailingFadeProgress,
-                        isSingleDay: isSingleDay
-                    )
-                    .id(effectiveSlotMinutes)
-                    .transition(.opacity)
-                    .frame(height: timelineHeight, alignment: .top)
-                }
+    /// Pre-resolves the focused-event tint color for `TimelineAxisDragOverlay`.
+    /// Walks visible occurrences to find the focused event and returns its
+    /// theme color. Reads `focusedEventID` + visible offsets + occurrencesForOffset
+    /// from body scope — none of those depend on `dragState.dragOffset`, so
+    /// these reads don't reintroduce a per-frame body dependency. (#77)
+    private var resolvedFocusedEventColor: Color? {
+        guard let focusedEventID else { return nil }
+        let visibleOffsets = Array(visibleOffsetsRange(centeredRange: centeredOffsetsRange()))
+        for offset in visibleOffsets {
+            if let match = occurrencesForOffset(offset).first(where: { $0.event.id == focusedEventID }) {
+                return CalendarLayout.eventColor(for: match.event)
             }
         }
+        return nil
+    }
+
+    @ViewBuilder
+    private func timeAxis() -> some View {
+        // #77: extracted into a sub-view so the parent body no longer reads
+        // `editMappingPresentation` (which transitively reads
+        // `dragState.dragOffset` via `resolvedDragEditMapping`). The sub-view's
+        // body still re-evaluates per drag frame — that compute can't be
+        // elided, only relocated — but the parent's no longer does.
+        TimelineAxisDragOverlay(
+            useCALayerAxisMarkers: useCALayerAxisMarkers,
+            allDayHeight: allDayHeight,
+            timelineHeight: timelineHeight,
+            anchorDate: dayDate(forOffset: selectedDayOffset),
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            effectiveSlotMinutes: effectiveSlotMinutes,
+            leadingExtendedHours: boundaryExtensionHours.leading,
+            trailingExtendedHours: boundaryExtensionHours.trailing,
+            mode: mode,
+            leadingFadeProgress: leadingFadeProgress,
+            trailingFadeProgress: trailingFadeProgress,
+            isSingleDay: isSingleDay,
+            dragState: dragState,
+            resolvedCreationEditMapping: resolvedCreationEditMapping,
+            resolvedFocusedEditMapping: resolvedFocusedEditMapping,
+            hasFocusedEvent: focusedEventID != nil,
+            focusedEventColor: resolvedFocusedEventColor
+        )
     }
 
     private let rangePinchBoundaryThreshold: CGFloat = 0.04
@@ -2785,6 +2706,146 @@ struct TimelinePagerView: View {
         }
     }
 
+}
+
+// MARK: - Time Axis Drag Overlay
+
+/// Sub-view that owns the per-drag-frame `editMappingPresentation` compute
+/// + axis rendering. Extracted from `TimelinePagerView.timeAxis()` so that
+/// `TimelinePagerView.body` no longer reads `dragState.dragOffset`
+/// transitively (the read happens INSIDE this sub-view's body, which
+/// re-evaluates per frame; the parent's does NOT).
+///
+/// Together with the `cachedRawBoundaryExtensionState` latch on the parent,
+/// this is the structural completion of the #75 → #76 → #77 arc: with both
+/// landed, the parent's `body` observes only discrete drag-session
+/// transitions (`draggingEventID`, `dragMode`, …) instead of every drag-frame
+/// `dragOffset` write. The per-frame cost survives — but it's bounded to this
+/// small sub-view's body, not the entire `TimelinePagerView` body. (#77)
+private struct TimelineAxisDragOverlay: View {
+    // Static axis chrome inputs (mirror of `timeAxis()`'s call into
+    // TimeAxisLayerHost / TimeAxisLabels).
+    let useCALayerAxisMarkers: Bool
+    let allDayHeight: CGFloat
+    let timelineHeight: CGFloat
+    let anchorDate: Date
+    let headerHeight: CGFloat
+    let hourHeight: CGFloat
+    let effectiveSlotMinutes: Int
+    let leadingExtendedHours: Int
+    let trailingExtendedHours: Int
+    let mode: PageMode
+    let leadingFadeProgress: CGFloat
+    let trailingFadeProgress: CGFloat
+    let isSingleDay: Bool
+
+    // Mapping inputs. `dragState` is read for `dragOffset` etc. inside this
+    // sub-view's body — that's the whole point of the extraction. The
+    // creation / focused mappings are precomputed by the parent (they don't
+    // depend on `dragOffset` so the parent computing them doesn't register
+    // a parent-body dep).
+    let dragState: EventDragState
+    let resolvedCreationEditMapping: (date: Date, range: Event.TimeRange)?
+    let resolvedFocusedEditMapping: (date: Date, range: Event.TimeRange)?
+    /// Whether a focused event is currently selected — gates the focused-event
+    /// color tint inside `editMappingPresentation`. Precomputed by parent.
+    let hasFocusedEvent: Bool
+    /// Pre-resolved focused-event tint color. Parent walks visible occurrences
+    /// to find the focused event's theme color, so the sub-view doesn't have
+    /// to take `occurrencesForOffset` + visible-offsets as input (which would
+    /// pull in more parent state).
+    let focusedEventColor: Color?
+
+    private var resolvedDragEditMapping: (source: TimelineEditMappingSource, date: Date, range: Event.TimeRange)? {
+        calendarResolvedDragEditMapping(
+            draggingEventID: dragState.draggingEventID,
+            draggingOriginalRange: dragState.draggingOriginalRange,
+            dragOffset: dragState.dragOffset,
+            dragMode: dragState.dragMode,
+            dayColumnStep: dragState.dayColumnStep,
+            hourHeight: hourHeight
+        )
+    }
+
+    private var editMappingState: TimelineEditMappingState? {
+        calendarResolveEditMappingState(
+            creation: resolvedCreationEditMapping,
+            drag: resolvedDragEditMapping,
+            focused: resolvedFocusedEditMapping
+        )
+    }
+
+    private var editMappingPresentation: TimelineAxisMarkerPresentation? {
+        // Hide time marker during vertical auto-scroll — it reappears
+        // once the user returns to normal (snapping) drag territory.
+        if editMappingState?.source == .moveDrag,
+           dragState.isHorizontalEdgeDragging || dragState.isHorizontalAutoScrolling {
+            return nil
+        }
+        guard var presentation = calendarResolveAxisMarkerPresentation(
+            mappingState: editMappingState,
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            leadingExtendedHours: leadingExtendedHours,
+            trailingExtendedHours: trailingExtendedHours
+        ) else { return nil }
+
+        // Use the event's theme color from drag state, focused state, or creation
+        if let draggingEvent = dragState.draggingEvent {
+            presentation.color = CalendarLayout.eventColor(for: draggingEvent)
+        } else if hasFocusedEvent, let focusedEventColor {
+            presentation.color = focusedEventColor
+        } else if editMappingState?.source == .creation {
+            presentation.color = calendarCurrentTimeIndicatorColor()
+        }
+
+        return presentation
+    }
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 0) {
+                if allDayHeight > 0 {
+                    Color.clear.frame(height: allDayHeight)
+                }
+                if useCALayerAxisMarkers {
+                    TimeAxisLayerHost(
+                        anchorDate: anchorDate,
+                        headerHeight: headerHeight,
+                        hourHeight: hourHeight,
+                        slotMinutes: effectiveSlotMinutes,
+                        leadingExtendedHours: leadingExtendedHours,
+                        trailingExtendedHours: trailingExtendedHours,
+                        mode: mode,
+                        editMappingPresentation: editMappingPresentation,
+                        leadingFadeProgress: leadingFadeProgress,
+                        trailingFadeProgress: trailingFadeProgress,
+                        isSingleDay: isSingleDay
+                    )
+                    .id(effectiveSlotMinutes)
+                    .transition(.opacity)
+                    .frame(height: timelineHeight, alignment: .top)
+                } else {
+                    TimeAxisLabels(
+                        anchorDate: anchorDate,
+                        headerHeight: headerHeight,
+                        hourHeight: hourHeight,
+                        slotMinutes: effectiveSlotMinutes,
+                        leadingExtendedHours: leadingExtendedHours,
+                        trailingExtendedHours: trailingExtendedHours,
+                        mode: mode,
+                        editMappingPresentation: editMappingPresentation,
+                        leadingFadeProgress: leadingFadeProgress,
+                        trailingFadeProgress: trailingFadeProgress,
+                        isSingleDay: isSingleDay
+                    )
+                    .id(effectiveSlotMinutes)
+                    .transition(.opacity)
+                    .frame(height: timelineHeight, alignment: .top)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - Time Axis Labels

--- a/Done/Views/Focus/FocusEventFlowLayerView.swift
+++ b/Done/Views/Focus/FocusEventFlowLayerView.swift
@@ -1,0 +1,685 @@
+//
+//  FocusEventFlowLayerView.swift
+//  Done
+//
+//  CALayer-backed port of the SwiftUI `FocusEventFlowView` mini-timeline
+//  rendered in landscape focus mode (issue #72). Strict-parity port —
+//  no design changes, gated by `AppSettingsKeys.calendarUseCALayerFocusEventFlow`,
+//  default OFF; flipped ON only after A/B parity is verified (mirrors the
+//  #60→#74 and #71 arcs).
+//
+//  Reuses the same module-scope helpers as the SwiftUI tree:
+//  `CalendarLayout.overlapLayout` (pinned to `.equalSplit`),
+//  `CalendarLayout.eventColor`,
+//  `calendarInterruptParentCompoundGeometry`,
+//  `CalendarInterruptParentCompoundShape`,
+//  `calendarInterruptChildOverlayGeometry`.
+//
+//  Scope: STATIC preview surface — no pinch, no scroll, no gesture. The
+//  parent `FocusModeView` already drives a 1Hz `now` re-evaluation; the
+//  host re-applies inputs each tick and the renderer relayouts without
+//  rebuilding structure when the occurrence set is unchanged.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - SwiftUI host
+
+/// SwiftUI-side host for the CALayer focus-event-flow timeline. Drop-in
+/// replacement for the SwiftUI `FocusEventFlowView` body — same inputs
+/// (`now`, `allOccurrences`) since `currentEvent`/`currentRange` were
+/// declared on the SwiftUI struct but never consumed by its body.
+struct FocusEventFlowLayerHost: UIViewRepresentable {
+    let now: Date
+    let allOccurrences: [CalendarLayout.EventOccurrence]
+
+    func makeUIView(context: Context) -> FocusEventFlowLayerView {
+        let view = FocusEventFlowLayerView()
+        view.backgroundColor = .systemBackground
+        view.clipsToBounds = true
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ uiView: FocusEventFlowLayerView, context: Context) {
+        uiView.apply(now: now, allOccurrences: allOccurrences)
+    }
+}
+
+// MARK: - UIView host (CALayer backing)
+
+/// CALayer-backed focus-event-flow mini timeline. Owns three z-ordered
+/// container tiers so SwiftUI's two-pass z-order (blocks below, titles
+/// above) is preserved without a re-layout per tick:
+///
+///   1. grid lines (CAShapeLayer)        — pass 0, bottom
+///   2. hour labels (UILabel children)   — pass 0
+///   3. event-block silhouettes          — pass 1
+///   4. event titles (UILabel children)  — pass 2
+///   5. now indicator (line + dot)       — top
+final class FocusEventFlowLayerView: UIView {
+    // Coordinate-system constants — mirror FocusEventFlowView's literals.
+    private static let labelWidth: CGFloat = 42
+    private static let eventInset: CGFloat = 8
+    private static let visibleHours: CGFloat = 6
+    private static let blockCornerRadius: CGFloat = 6
+    private static let childBlockCornerRadius: CGFloat = 5
+
+    private let calendar = Calendar.current
+
+    private var currentNow: Date?
+    private var currentOccurrences: [CalendarLayout.EventOccurrence] = []
+    private var overlapSlots: [String: CalendarLayout.EventOverlapSlot] = [:]
+    private var parentLookup: [UUID: CalendarLayout.EventOccurrence] = [:]
+    private var childrenLookup: [UUID: [CalendarLayout.EventOccurrence]] = [:]
+    private var embeddedIDs: Set<String> = []
+
+    // Per-block CALayer subtree.
+    private struct BlockNode {
+        let bg: CAShapeLayer
+        let border: CAShapeLayer
+    }
+
+    // Sublayer/subview containers — preserve z-order even when contents change.
+    private let gridLineContainer = CALayer()
+    private let hourLabelContainer = UIView()
+    private let blockContainer = CALayer()
+    private let titleContainer = UIView()
+    private let nowIndicatorContainer = CALayer()
+
+    private var gridLines: [CAShapeLayer] = []
+    private var hourLabels: [UILabel] = []
+    private let currentTimeLabel = UILabel()
+
+    private var siblingBlocks: [String: BlockNode] = [:]
+    private var childBlocks: [String: BlockNode] = [:]
+    private var titleLabels: [String: UILabel] = [:]
+
+    private let nowDot = CAShapeLayer()
+    private let nowLine = CAShapeLayer()
+
+    private static let disabledActions: [String: CAAction] = [
+        "contents": NSNull(),
+        "position": NSNull(),
+        "bounds": NSNull(),
+        "frame": NSNull(),
+        "opacity": NSNull(),
+        "transform": NSNull(),
+        "sublayers": NSNull(),
+        "hidden": NSNull(),
+        "path": NSNull(),
+        "fillColor": NSNull(),
+        "strokeColor": NSNull()
+    ]
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.actions = Self.disabledActions
+
+        for container in [gridLineContainer, blockContainer, nowIndicatorContainer] {
+            container.actions = Self.disabledActions
+        }
+
+        // Z-order: gridLineContainer (bottom) → hourLabelContainer → blockContainer
+        // → titleContainer → nowIndicatorContainer (top). Add in that order so
+        // both addSublayer and addSubview append to layer.sublayers correctly.
+        layer.addSublayer(gridLineContainer)
+        hourLabelContainer.isUserInteractionEnabled = false
+        hourLabelContainer.backgroundColor = .clear
+        hourLabelContainer.layer.actions = Self.disabledActions
+        addSubview(hourLabelContainer)
+        layer.addSublayer(blockContainer)
+        titleContainer.isUserInteractionEnabled = false
+        titleContainer.backgroundColor = .clear
+        titleContainer.layer.actions = Self.disabledActions
+        addSubview(titleContainer)
+        layer.addSublayer(nowIndicatorContainer)
+
+        // Now indicator: line + 8pt dot. Static structure; positions update
+        // per layout pass.
+        nowLine.actions = Self.disabledActions
+        nowDot.actions = Self.disabledActions
+        nowLine.fillColor = UIColor.label.cgColor
+        nowDot.fillColor = UIColor.label.cgColor
+        nowIndicatorContainer.addSublayer(nowLine)
+        nowIndicatorContainer.addSublayer(nowDot)
+
+        // Current-time label sits next to the dot; uses monospaced digits to
+        // avoid width jitter per tick.
+        currentTimeLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .bold)
+        currentTimeLabel.textColor = .label
+        currentTimeLabel.isUserInteractionEnabled = false
+        addSubview(currentTimeLabel)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("init(coder:) unavailable") }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        layoutContent()
+    }
+
+    // MARK: - Apply
+
+    /// Apply latest inputs from the SwiftUI host. The structure (sublayer
+    /// pools) is rebuilt only when the occurrence set changes; the per-tick
+    /// `now` advance only triggers a relayout.
+    func apply(now: Date, allOccurrences: [CalendarLayout.EventOccurrence]) {
+        let occurrencesChanged = currentOccurrences != allOccurrences
+        currentNow = now
+        if occurrencesChanged {
+            currentOccurrences = allOccurrences
+            recomputeLookups()
+            rebuildStructure()
+        }
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    // MARK: - Lookups (mirrors FocusEventFlowView body)
+
+    private func recomputeLookups() {
+        var parents: [UUID: CalendarLayout.EventOccurrence] = [:]
+        for occ in currentOccurrences where !occ.event.isInterrupt {
+            parents[occ.event.recurrenceParentId ?? occ.event.id] = occ
+        }
+        parentLookup = parents
+
+        var children: [UUID: [CalendarLayout.EventOccurrence]] = [:]
+        for occ in currentOccurrences {
+            guard let relation = occ.event.interruptRelation,
+                  relation.state == .embedded else { continue }
+            children[relation.parentEventID, default: []].append(occ)
+        }
+        childrenLookup = children
+
+        var embedded: Set<String> = []
+        for occ in currentOccurrences {
+            guard occ.event.isInterrupt,
+                  let relation = occ.event.interruptRelation,
+                  relation.state == .embedded,
+                  parents[relation.parentEventID] != nil else { continue }
+            embedded.insert(occ.id)
+        }
+        embeddedIDs = embedded
+
+        // Overlap layout reads only widthFraction/xOffsetFraction (see
+        // OverlapMode.equalSplit contract) so coverRanges is empty here.
+        let overlapCandidates = currentOccurrences.filter { !embedded.contains($0.id) }
+        let referenceDate = currentNow ?? Date()
+        overlapSlots = CalendarLayout.overlapLayout(
+            for: overlapCandidates,
+            on: referenceDate,
+            calendar: calendar,
+            mode: .equalSplit
+        )
+    }
+
+    // MARK: - Structure rebuild
+
+    private func rebuildStructure() {
+        rebuildBlockNodes()
+        rebuildTitleLabels()
+    }
+
+    /// Sync `siblingBlocks` + `childBlocks` pools with the current occurrences.
+    /// One BlockNode (bg + border CAShapeLayers) per visible non-embedded
+    /// occurrence; one per embedded interrupt child.
+    private func rebuildBlockNodes() {
+        var keptSibling: Set<String> = []
+        var keptChild: Set<String> = []
+
+        for occ in currentOccurrences {
+            if embeddedIDs.contains(occ.id) {
+                keptChild.insert(occ.id)
+                if childBlocks[occ.id] == nil {
+                    childBlocks[occ.id] = installBlockNode()
+                }
+            } else {
+                keptSibling.insert(occ.id)
+                if siblingBlocks[occ.id] == nil {
+                    siblingBlocks[occ.id] = installBlockNode()
+                }
+            }
+        }
+
+        // Remove stale entries.
+        for key in siblingBlocks.keys where !keptSibling.contains(key) {
+            if let node = siblingBlocks.removeValue(forKey: key) {
+                node.bg.removeFromSuperlayer()
+                node.border.removeFromSuperlayer()
+            }
+        }
+        for key in childBlocks.keys where !keptChild.contains(key) {
+            if let node = childBlocks.removeValue(forKey: key) {
+                node.bg.removeFromSuperlayer()
+                node.border.removeFromSuperlayer()
+            }
+        }
+    }
+
+    private func installBlockNode() -> BlockNode {
+        let bg = CAShapeLayer()
+        bg.actions = Self.disabledActions
+        bg.lineWidth = 0
+        let border = CAShapeLayer()
+        border.actions = Self.disabledActions
+        border.fillColor = UIColor.clear.cgColor
+        border.lineWidth = 1.2
+        blockContainer.addSublayer(bg)
+        blockContainer.addSublayer(border)
+        return BlockNode(bg: bg, border: border)
+    }
+
+    private func rebuildTitleLabels() {
+        var kept: Set<String> = []
+        for occ in currentOccurrences {
+            kept.insert(occ.id)
+            if titleLabels[occ.id] == nil {
+                let label = UILabel()
+                label.font = .systemFont(ofSize: 13, weight: .semibold)
+                label.textColor = .label
+                label.numberOfLines = 2
+                label.lineBreakMode = .byTruncatingTail
+                label.isUserInteractionEnabled = false
+                titleContainer.addSubview(label)
+                titleLabels[occ.id] = label
+            }
+            titleLabels[occ.id]?.text = occ.event.title
+        }
+        for key in titleLabels.keys where !kept.contains(key) {
+            titleLabels.removeValue(forKey: key)?.removeFromSuperview()
+        }
+    }
+
+    // MARK: - Layout
+
+    private func layoutContent() {
+        guard let now = currentNow else { return }
+        let h = bounds.height
+        let w = bounds.width
+        guard h > 0, w > 0 else { return }
+
+        let nowY = h * 0.5
+        let pps = h / (Self.visibleHours * 3600)
+        let windowStart = now.addingTimeInterval(-Double(Self.visibleHours) * 3600 * 0.5)
+        let windowEnd = now.addingTimeInterval(Double(Self.visibleHours) * 3600 * 0.5)
+        let eventLeft = Self.labelWidth
+        let eventW = w - eventLeft
+        let areaW = eventW - Self.eventInset * 2
+
+        // Containers stretch full bounds; their children are absolute-positioned.
+        for container in [gridLineContainer, blockContainer, nowIndicatorContainer] {
+            container.frame = bounds
+        }
+        hourLabelContainer.frame = bounds
+        titleContainer.frame = bounds
+
+        layoutGrid(
+            now: now,
+            nowY: nowY,
+            pps: pps,
+            windowStart: windowStart,
+            windowEnd: windowEnd,
+            eventLeft: eventLeft,
+            areaW: areaW
+        )
+
+        layoutBlocks(
+            now: now,
+            nowY: nowY,
+            pps: pps,
+            eventLeft: eventLeft,
+            areaW: areaW,
+            viewportHeight: h
+        )
+
+        layoutTitles(
+            now: now,
+            nowY: nowY,
+            pps: pps,
+            eventLeft: eventLeft,
+            areaW: areaW,
+            viewportHeight: h
+        )
+
+        layoutNowIndicator(
+            nowY: nowY,
+            eventLeft: eventLeft,
+            eventW: eventW,
+            now: now
+        )
+    }
+
+    private func layoutGrid(
+        now: Date,
+        nowY: CGFloat,
+        pps: CGFloat,
+        windowStart: Date,
+        windowEnd: Date,
+        eventLeft: CGFloat,
+        areaW: CGFloat
+    ) {
+        let hours = hourMarkers(from: windowStart, to: windowEnd)
+        let nowMinutes = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+        let lineX = eventLeft + Self.eventInset
+
+        // Grow / shrink grid-line layer pool.
+        while gridLines.count < hours.count {
+            let line = CAShapeLayer()
+            line.actions = Self.disabledActions
+            line.fillColor = UIColor.secondaryLabel.withAlphaComponent(0.2).cgColor
+            line.lineWidth = 0
+            gridLineContainer.addSublayer(line)
+            gridLines.append(line)
+        }
+        while gridLines.count > hours.count {
+            gridLines.removeLast().removeFromSuperlayer()
+        }
+
+        // Hour label pool — sized to match hours.count so we don't churn
+        // UILabel allocations per tick.
+        while hourLabels.count < hours.count {
+            let label = UILabel()
+            label.font = .systemFont(ofSize: 10, weight: .semibold)
+            label.textColor = .secondaryLabel
+            label.isUserInteractionEnabled = false
+            hourLabelContainer.addSubview(label)
+            hourLabels.append(label)
+        }
+        while hourLabels.count > hours.count {
+            hourLabels.removeLast().removeFromSuperview()
+        }
+
+        for (idx, hour) in hours.enumerated() {
+            let y = nowY + CGFloat(hour.timeIntervalSince(now)) * pps
+            let lineRect = CGRect(x: lineX, y: y, width: areaW, height: 1)
+            gridLines[idx].path = UIBezierPath(rect: lineRect).cgPath
+
+            let hourMinutes = calendar.component(.hour, from: hour) * 60
+            let label = hourLabels[idx]
+            if abs(hourMinutes - nowMinutes) > 15 {
+                label.isHidden = false
+                label.text = formatHour12(hour)
+                label.sizeToFit()
+                var f = label.frame
+                f.origin = CGPoint(x: 4, y: y - 7)
+                label.frame = f
+            } else {
+                label.isHidden = true
+            }
+        }
+
+        // Current-time label always shown, at nowY.
+        currentTimeLabel.text = formatCurrentTime(now)
+        currentTimeLabel.sizeToFit()
+        var ctf = currentTimeLabel.frame
+        ctf.origin = CGPoint(x: 4, y: nowY - 7)
+        currentTimeLabel.frame = ctf
+    }
+
+    private func layoutBlocks(
+        now: Date,
+        nowY: CGFloat,
+        pps: CGFloat,
+        eventLeft: CGFloat,
+        areaW: CGFloat,
+        viewportHeight h: CGFloat
+    ) {
+        for occ in currentOccurrences where !embeddedIDs.contains(occ.id) {
+            guard let node = siblingBlocks[occ.id] else { continue }
+            let color = CalendarLayout.eventColor(for: occ.event)
+            let slot = overlapSlots[occ.id] ?? .default
+            let blockTop = nowY + CGFloat(occ.range.start.timeIntervalSince(now)) * pps
+            let blockH = CGFloat(occ.range.end.timeIntervalSince(occ.range.start)) * pps
+            let blockBottom = blockTop + blockH
+            let overlapGap: CGFloat = slot.widthFraction < 1 ? 2 : 0
+            let blockW = max(0, areaW * slot.widthFraction - overlapGap)
+            let blockX = eventLeft + Self.eventInset + areaW * slot.xOffsetFraction
+            let drawnH = max(0, blockH - 3)
+            let drawnY = blockTop + 1.5
+
+            let onScreen = blockBottom > -20 && blockTop < h + 20
+            node.bg.isHidden = !onScreen
+            node.border.isHidden = !onScreen
+            if !onScreen { continue }
+
+            let anchorID = occ.event.recurrenceParentId ?? occ.event.id
+            let childRanges = (childrenLookup[anchorID] ?? []).map(\.range)
+            let frame = CGRect(x: blockX, y: drawnY, width: blockW, height: drawnH)
+            node.bg.frame = frame
+            node.border.frame = frame
+            let localBounds = CGRect(origin: .zero, size: frame.size)
+
+            let path: CGPath
+            if !childRanges.isEmpty {
+                let compoundGeo = calendarInterruptParentCompoundGeometry(
+                    parentRange: occ.range,
+                    childRanges: childRanges,
+                    parentWidth: blockW,
+                    parentHeight: drawnH,
+                    horizontalGap: 3,
+                    verticalGap: 3
+                )
+                let compoundShape = CalendarInterruptParentCompoundShape(
+                    cornerRadius: Self.blockCornerRadius,
+                    visibleSegments: compoundGeo.visibleSegments
+                )
+                path = compoundShape.path(in: localBounds).cgPath
+            } else {
+                path = UIBezierPath(
+                    roundedRect: localBounds,
+                    cornerRadius: Self.blockCornerRadius
+                ).cgPath
+            }
+
+            node.bg.path = path
+            node.bg.fillColor = composite(tint: color, alpha: 0.4, over: .systemBackground).cgColor
+            node.border.path = path
+            node.border.strokeColor = UIColor(color).withAlphaComponent(0.7).cgColor
+        }
+
+        // Embedded interrupt children — rounded-rect overlays inside their parent.
+        for occ in currentOccurrences where embeddedIDs.contains(occ.id) {
+            guard let node = childBlocks[occ.id],
+                  let parentID = occ.event.interruptRelation?.parentEventID,
+                  let parentOcc = parentLookup[parentID] else {
+                continue
+            }
+            let parentSlot = overlapSlots[parentOcc.id] ?? .default
+            let parentOverlapGap: CGFloat = parentSlot.widthFraction < 1 ? 2 : 0
+            let parentW = max(0, areaW * parentSlot.widthFraction - parentOverlapGap)
+            let parentX = eventLeft + Self.eventInset + areaW * parentSlot.xOffsetFraction
+            let childGeo = calendarInterruptChildOverlayGeometry(parentWidth: parentW)
+            let childTop = nowY + CGFloat(occ.range.start.timeIntervalSince(now)) * pps
+            let childH = CGFloat(occ.range.end.timeIntervalSince(occ.range.start)) * pps
+            let drawnH = max(0, childH - 3)
+            let drawnY = childTop + 1.5
+            let childX = parentX + childGeo.xOffset
+            let childW = max(0, childGeo.width)
+            let frame = CGRect(x: childX, y: drawnY, width: childW, height: drawnH)
+            node.bg.frame = frame
+            node.border.frame = frame
+            let local = CGRect(origin: .zero, size: frame.size)
+            let path = UIBezierPath(
+                roundedRect: local,
+                cornerRadius: Self.childBlockCornerRadius
+            ).cgPath
+            let childColor = CalendarLayout.eventColor(for: occ.event)
+            node.bg.path = path
+            node.bg.fillColor = composite(tint: childColor, alpha: 0.4, over: .systemBackground).cgColor
+            node.border.path = path
+            node.border.strokeColor = UIColor(childColor).withAlphaComponent(0.7).cgColor
+        }
+    }
+
+    private func layoutTitles(
+        now: Date,
+        nowY: CGFloat,
+        pps: CGFloat,
+        eventLeft: CGFloat,
+        areaW: CGFloat,
+        viewportHeight h: CGFloat
+    ) {
+        for occ in currentOccurrences {
+            guard let label = titleLabels[occ.id] else { continue }
+            let slot = overlapSlots[occ.id] ?? .default
+            let blockTop = nowY + CGFloat(occ.range.start.timeIntervalSince(now)) * pps
+            let blockH = CGFloat(occ.range.end.timeIntervalSince(occ.range.start)) * pps
+            let blockBottom = blockTop + blockH
+            let blockX = eventLeft + Self.eventInset + areaW * slot.xOffsetFraction
+
+            guard blockH >= 16, blockBottom > 0, blockTop < h else {
+                label.isHidden = true
+                continue
+            }
+
+            let titleX: CGFloat
+            let titleY: CGFloat
+            let titleMaxW: CGFloat
+
+            if embeddedIDs.contains(occ.id) {
+                // Embedded interrupt child — title aligns with the child overlay.
+                let parentID = occ.event.interruptRelation?.parentEventID
+                guard let parentOcc = parentID.flatMap({ parentLookup[$0] }) else {
+                    label.isHidden = true
+                    continue
+                }
+                let parentSlot = overlapSlots[parentOcc.id] ?? .default
+                let parentOverlapGap: CGFloat = parentSlot.widthFraction < 1 ? 2 : 0
+                let parentW = max(0, areaW * parentSlot.widthFraction - parentOverlapGap)
+                let parentX = eventLeft + Self.eventInset + areaW * parentSlot.xOffsetFraction
+                let childGeo = calendarInterruptChildOverlayGeometry(parentWidth: parentW)
+                let childX = parentX + childGeo.xOffset
+                let stickyTop = max(8, -blockTop + 8)
+                let childTitleY = blockTop + 1.5 + stickyTop
+                if childTitleY < blockBottom - 20, childTitleY < h - 10 {
+                    titleX = childX + 8
+                    titleY = childTitleY
+                    titleMaxW = max(0, max(0, childGeo.width) - 16)
+                } else {
+                    label.isHidden = true
+                    continue
+                }
+            } else {
+                let anchorID = occ.event.recurrenceParentId ?? occ.event.id
+                let children = childrenLookup[anchorID] ?? []
+                let overlapGap: CGFloat = slot.widthFraction < 1 ? 2 : 0
+                let blockW = max(0, areaW * slot.widthFraction - overlapGap)
+
+                if !children.isEmpty {
+                    // Parent with children — title sits below the last child.
+                    let lastChildBottom = children.map { child in
+                        nowY + CGFloat(child.range.end.timeIntervalSince(now)) * pps
+                    }.max() ?? blockTop
+                    let candidate = max(lastChildBottom + 10, max(8, blockTop + 1.5 + 8))
+                    guard candidate < blockBottom - 20, candidate < h - 10 else {
+                        label.isHidden = true
+                        continue
+                    }
+                    titleX = blockX + 8
+                    titleY = candidate
+                    titleMaxW = max(0, blockW - 16)
+                } else {
+                    let stickyTop = max(8, -blockTop + 8)
+                    titleX = blockX + 8
+                    titleY = blockTop + 1.5 + stickyTop
+                    titleMaxW = max(0, blockW - 16)
+                }
+            }
+
+            label.isHidden = false
+            let measured = label.sizeThatFits(CGSize(width: titleMaxW, height: .greatestFiniteMagnitude))
+            let titleH = min(measured.height, label.font.lineHeight * 2 + 2)
+            label.frame = CGRect(x: titleX, y: titleY, width: titleMaxW, height: titleH)
+        }
+    }
+
+    private func layoutNowIndicator(
+        nowY: CGFloat,
+        eventLeft: CGFloat,
+        eventW: CGFloat,
+        now: Date
+    ) {
+        let dotRect = CGRect(
+            x: eventLeft + Self.eventInset - 4,
+            y: nowY - 4,
+            width: 8,
+            height: 8
+        )
+        nowDot.path = UIBezierPath(ovalIn: dotRect).cgPath
+        let lineRect = CGRect(
+            x: eventLeft + Self.eventInset,
+            y: nowY - 0.75,
+            width: max(0, eventW - Self.eventInset),
+            height: 1.5
+        )
+        nowLine.path = UIBezierPath(rect: lineRect).cgPath
+    }
+
+    // MARK: - Helpers (mirror FocusEventFlowView)
+
+    private func hourMarkers(from start: Date, to end: Date) -> [Date] {
+        var markers: [Date] = []
+        var hour = calendar.nextDate(
+            after: start.addingTimeInterval(-3600),
+            matching: DateComponents(minute: 0, second: 0),
+            matchingPolicy: .strict,
+            direction: .forward
+        ) ?? start
+        while hour <= end {
+            markers.append(hour)
+            hour = hour.addingTimeInterval(3600)
+        }
+        return markers
+    }
+
+    private func formatHour12(_ date: Date) -> String {
+        let hour24 = calendar.component(.hour, from: date)
+        let meridiem = hour24 < 12 ? "am" : "pm"
+        let hour12 = (hour24 % 12 == 0) ? 12 : (hour24 % 12)
+        return "\(hour12) \(meridiem)"
+    }
+
+    private static let currentTimeFormatter24: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "H:mm"
+        return f
+    }()
+
+    private static let currentTimeFormatter12: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "h:mma"
+        f.amSymbol = "am"
+        f.pmSymbol = "pm"
+        return f
+    }()
+
+    private func formatCurrentTime(_ date: Date) -> String {
+        let formatter = AppTimeFormat.current.is24
+            ? Self.currentTimeFormatter24
+            : Self.currentTimeFormatter12
+        return formatter.string(from: date)
+    }
+
+    /// Mirrors SwiftUI's `Rectangle().fill(systemBackground).overlay(color.opacity(0.4))`:
+    /// alpha-composite `tint` at `alpha` over the opaque `base` so the layer can
+    /// fill with a single solid color.
+    private func composite(tint: Color, alpha: CGFloat, over base: UIColor) -> UIColor {
+        let tintUI = UIColor(tint)
+        var tr: CGFloat = 0, tg: CGFloat = 0, tb: CGFloat = 0, ta: CGFloat = 0
+        tintUI.getRed(&tr, green: &tg, blue: &tb, alpha: &ta)
+        var br: CGFloat = 0, bg: CGFloat = 0, bb: CGFloat = 0, ba: CGFloat = 0
+        base.getRed(&br, green: &bg, blue: &bb, alpha: &ba)
+        let a = alpha * ta
+        return UIColor(
+            red: tr * a + br * (1 - a),
+            green: tg * a + bg * (1 - a),
+            blue: tb * a + bb * (1 - a),
+            alpha: 1
+        )
+    }
+}

--- a/Done/Views/Focus/FocusEventFlowLayerView.swift
+++ b/Done/Views/Focus/FocusEventFlowLayerView.swift
@@ -146,11 +146,13 @@ final class FocusEventFlowLayerView: UIView {
         nowIndicatorContainer.addSublayer(nowDot)
 
         // Current-time label sits next to the dot; uses monospaced digits to
-        // avoid width jitter per tick.
+        // avoid width jitter per tick. Lives inside `hourLabelContainer` so
+        // its z-order matches the SwiftUI tree (between grid and blocks),
+        // not above the now indicator.
         currentTimeLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .bold)
         currentTimeLabel.textColor = .label
         currentTimeLabel.isUserInteractionEnabled = false
-        addSubview(currentTimeLabel)
+        hourLabelContainer.addSubview(currentTimeLabel)
     }
 
     @available(*, unavailable)
@@ -161,17 +163,30 @@ final class FocusEventFlowLayerView: UIView {
         layoutContent()
     }
 
+    /// Dark-mode / dynamic-type toggles change the resolved `systemBackground`
+    /// the block fills are pre-composited against — repaint when traits flip
+    /// so we don't carry a stale concrete CGColor until the next 1Hz tick.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+            setNeedsLayout()
+        }
+    }
+
     // MARK: - Apply
 
-    /// Apply latest inputs from the SwiftUI host. The structure (sublayer
-    /// pools) is rebuilt only when the occurrence set changes; the per-tick
-    /// `now` advance only triggers a relayout.
+    /// Apply latest inputs from the SwiftUI host. Lookups + overlap slots
+    /// refresh every tick (so a midnight crossing without an occurrence-set
+    /// change can't strand the layout on a stale window); the sublayer
+    /// pools are rebuilt only when the occurrence set actually changes.
     func apply(now: Date, allOccurrences: [CalendarLayout.EventOccurrence]) {
         let occurrencesChanged = currentOccurrences != allOccurrences
         currentNow = now
         if occurrencesChanged {
             currentOccurrences = allOccurrences
-            recomputeLookups()
+        }
+        recomputeLookups()
+        if occurrencesChanged {
             rebuildStructure()
         }
         setNeedsLayout()
@@ -226,7 +241,10 @@ final class FocusEventFlowLayerView: UIView {
 
     /// Sync `siblingBlocks` + `childBlocks` pools with the current occurrences.
     /// One BlockNode (bg + border CAShapeLayers) per visible non-embedded
-    /// occurrence; one per embedded interrupt child.
+    /// occurrence; one per embedded interrupt child. Sublayer order is
+    /// re-promoted at the end so children always render above their parent,
+    /// matching the SwiftUI source's `ForEach { parent; ForEach { child } }`
+    /// ZStack order regardless of installation history.
     private func rebuildBlockNodes() {
         var keptSibling: Set<String> = []
         var keptChild: Set<String> = []
@@ -256,6 +274,23 @@ final class FocusEventFlowLayerView: UIView {
             if let node = childBlocks.removeValue(forKey: key) {
                 node.bg.removeFromSuperlayer()
                 node.border.removeFromSuperlayer()
+            }
+        }
+
+        // Re-promote to enforce parent → children → next-parent order even
+        // when a new parent is installed after an already-attached child.
+        // (`addSublayer` on an already-attached layer moves it to the end.)
+        for occ in currentOccurrences where !embeddedIDs.contains(occ.id) {
+            if let node = siblingBlocks[occ.id] {
+                blockContainer.addSublayer(node.bg)
+                blockContainer.addSublayer(node.border)
+            }
+            let anchorID = occ.event.recurrenceParentId ?? occ.event.id
+            for child in childrenLookup[anchorID] ?? [] {
+                if let cnode = childBlocks[child.id] {
+                    blockContainer.addSublayer(cnode.bg)
+                    blockContainer.addSublayer(cnode.border)
+                }
             }
         }
     }
@@ -348,8 +383,7 @@ final class FocusEventFlowLayerView: UIView {
         layoutNowIndicator(
             nowY: nowY,
             eventLeft: eventLeft,
-            eventW: eventW,
-            now: now
+            eventW: eventW
         )
     }
 
@@ -523,6 +557,12 @@ final class FocusEventFlowLayerView: UIView {
         areaW: CGFloat,
         viewportHeight h: CGFloat
     ) {
+        // Titles in the SwiftUI source render via `Text(...).offset(...)`
+        // with NO width frame — they spill past the block's nominal width and
+        // are only capped by the outer `.clipped()` on the timeline view.
+        // Mirror that here: wrap to the right edge of the timeline area, not
+        // to the block width.
+        let rightEdge = eventLeft + Self.eventInset + areaW
         for occ in currentOccurrences {
             guard let label = titleLabels[occ.id] else { continue }
             let slot = overlapSlots[occ.id] ?? .default
@@ -538,7 +578,6 @@ final class FocusEventFlowLayerView: UIView {
 
             let titleX: CGFloat
             let titleY: CGFloat
-            let titleMaxW: CGFloat
 
             if embeddedIDs.contains(occ.id) {
                 // Embedded interrupt child — title aligns with the child overlay.
@@ -558,7 +597,6 @@ final class FocusEventFlowLayerView: UIView {
                 if childTitleY < blockBottom - 20, childTitleY < h - 10 {
                     titleX = childX + 8
                     titleY = childTitleY
-                    titleMaxW = max(0, max(0, childGeo.width) - 16)
                 } else {
                     label.isHidden = true
                     continue
@@ -566,8 +604,6 @@ final class FocusEventFlowLayerView: UIView {
             } else {
                 let anchorID = occ.event.recurrenceParentId ?? occ.event.id
                 let children = childrenLookup[anchorID] ?? []
-                let overlapGap: CGFloat = slot.widthFraction < 1 ? 2 : 0
-                let blockW = max(0, areaW * slot.widthFraction - overlapGap)
 
                 if !children.isEmpty {
                     // Parent with children — title sits below the last child.
@@ -581,16 +617,15 @@ final class FocusEventFlowLayerView: UIView {
                     }
                     titleX = blockX + 8
                     titleY = candidate
-                    titleMaxW = max(0, blockW - 16)
                 } else {
                     let stickyTop = max(8, -blockTop + 8)
                     titleX = blockX + 8
                     titleY = blockTop + 1.5 + stickyTop
-                    titleMaxW = max(0, blockW - 16)
                 }
             }
 
             label.isHidden = false
+            let titleMaxW = max(0, rightEdge - titleX)
             let measured = label.sizeThatFits(CGSize(width: titleMaxW, height: .greatestFiniteMagnitude))
             let titleH = min(measured.height, label.font.lineHeight * 2 + 2)
             label.frame = CGRect(x: titleX, y: titleY, width: titleMaxW, height: titleH)
@@ -600,8 +635,7 @@ final class FocusEventFlowLayerView: UIView {
     private func layoutNowIndicator(
         nowY: CGFloat,
         eventLeft: CGFloat,
-        eventW: CGFloat,
-        now: Date
+        eventW: CGFloat
     ) {
         let dotRect = CGRect(
             x: eventLeft + Self.eventInset - 4,

--- a/Done/Views/Focus/FocusModeEventView.swift
+++ b/Done/Views/Focus/FocusModeEventView.swift
@@ -29,6 +29,13 @@ struct FocusModeEventView: View {
     @State private var isComposingNote: Bool = false
     @FocusState private var noteFieldFocused: Bool
 
+    // Experimental: gate the landscape mini-cal between the SwiftUI
+    // `FocusEventFlowView` tree and the CALayer-backed
+    // `FocusEventFlowLayerHost`. Default OFF until A/B parity is verified
+    // (mirrors the #60→#74 / #71 arcs). See issue #72.
+    @AppStorage(AppSettingsKeys.calendarUseCALayerFocusEventFlow)
+    private var useCALayerFocusEventFlow = false
+
     private let noteCommitHaptic = UISelectionFeedbackGenerator()
 
     private var eventColor: Color {
@@ -96,12 +103,21 @@ struct FocusModeEventView: View {
     /// right with a circular progress ring as the visual anchor.
     private var landscapeLayout: some View {
         HStack(spacing: 0) {
-            FocusEventFlowView(
-                currentEvent: event,
-                currentRange: range,
-                now: now,
-                allOccurrences: allOccurrences
-            )
+            Group {
+                if useCALayerFocusEventFlow {
+                    FocusEventFlowLayerHost(
+                        now: now,
+                        allOccurrences: allOccurrences
+                    )
+                } else {
+                    FocusEventFlowView(
+                        currentEvent: event,
+                        currentRange: range,
+                        now: now,
+                        allOccurrences: allOccurrences
+                    )
+                }
+            }
             .frame(maxHeight: .infinity)
             .frame(maxWidth: .infinity)
             .padding(.leading, 48)

--- a/DoneTests/CalendarPageHandlerHelpersTests.swift
+++ b/DoneTests/CalendarPageHandlerHelpersTests.swift
@@ -1,0 +1,426 @@
+//
+//  CalendarPageHandlerHelpersTests.swift
+//  DoneTests
+//
+//  Unit tests for the pure helpers extracted from `CalendarPageView.swift`
+//  per §4 + §5 of `Docs/calendar-page-state-map.md` (v3).
+//
+//  These tests cover the three "Pure XCTest" rows from §5's test matrix
+//  (predicate tests on §4b + §4c) plus coverage of `computeAbandonedFadeCurves`
+//  (§4a) — nil-rawState early returns, leading-only / trailing-only fade
+//  output, and the multiply-complement combine identity.
+//
+//  Two §5 rows (`testDragAcrossMidnightTriggersBoundaryExtension`,
+//  `testMidnightShiftFiresAfterDragEnd`) are explicit dogfood gates per §5a
+//  and live outside this file.
+//
+
+import XCTest
+import CoreGraphics
+@testable import Done
+
+final class CalendarPageHandlerHelpersTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }
+
+    private func date(_ y: Int, _ m: Int, _ d: Int, _ h: Int = 0, _ mi: Int = 0) -> Date {
+        calendar.date(from: DateComponents(year: y, month: m, day: d, hour: h, minute: mi))!
+    }
+
+    private func makeResizeGrace() -> CalendarResizeGraceState {
+        CalendarResizeGraceState(
+            eventID: UUID(),
+            occurrenceID: nil,
+            startedAt: Date(),
+            deadline: Date().addingTimeInterval(0.6),
+            fadeStartAt: Date(),
+            handleOpacity: 1,
+            trigger: .longPressRelease
+        )
+    }
+
+    private func makeLiveInterrupt() -> CalendarInterruptLiveSession {
+        let event = Event(
+            title: "parent",
+            timeRanges: [.init(start: Date(), end: Date().addingTimeInterval(3600))]
+        )
+        return CalendarInterruptLiveSession(
+            parentOccurrence: CalendarEventOccurrenceContext(
+                eventID: event.id,
+                occurrenceDate: Date(),
+                occurrenceID: nil,
+                isAllDay: false,
+                source: .timelineTap
+            ),
+            parentEventID: event.id,
+            parentEventSnapshot: event,
+            title: "interrupt",
+            typeTitle: "type",
+            startedAt: Date()
+        )
+    }
+
+    private func makeExtensionState(
+        leadingHours: Int,
+        trailingHours: Int,
+        source: TimelineEditMappingSource? = nil
+    ) -> TimelineBoundaryExtensionState {
+        TimelineBoundaryExtensionState(
+            leadingHours: leadingHours,
+            trailingHours: trailingHours,
+            source: source,
+            anchorDayOffset: nil
+        )
+    }
+
+    // MARK: - §5: testRangeModeChangeClearsBoundaryExtension (§4c)
+
+    func testBoundaryExtensionClearedWhenLeavingDayWithOpenExtension() {
+        let open = makeExtensionState(leadingHours: 2, trailingHours: 0)
+        XCTAssertTrue(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .threeDay,
+                currentExtensionState: open
+            )
+        )
+    }
+
+    func testBoundaryExtensionNotClearedWhenAlreadyClosedEvenInNonDayMode() {
+        XCTAssertFalse(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .week,
+                currentExtensionState: .none
+            )
+        )
+    }
+
+    func testBoundaryExtensionNotClearedWhenStayingInDayMode() {
+        let open = makeExtensionState(leadingHours: 0, trailingHours: 3)
+        XCTAssertFalse(
+            boundaryExtensionShouldClearOnRangeModeChange(
+                newMode: .day,
+                currentExtensionState: open
+            )
+        )
+    }
+
+    func testBoundaryExtensionClearTriggeredAcrossAllNonDayModes() {
+        let open = makeExtensionState(leadingHours: 1, trailingHours: 0)
+        for mode in [RangeMode.threeDay, .week, .month, .stream] {
+            XCTAssertTrue(
+                boundaryExtensionShouldClearOnRangeModeChange(
+                    newMode: mode,
+                    currentExtensionState: open
+                ),
+                "Expected predicate to require a clear when leaving .day for \(mode)"
+            )
+        }
+    }
+
+    // MARK: - §5: testMidnightShiftBlockedDuringResizeGrace (§4b)
+
+    func testMidnightShiftBlockedDuringResizeGrace() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: makeResizeGrace(),
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    // MARK: - §5: testInterruptSessionBlocksMidnightShift (§4b)
+
+    func testInterruptSessionBlocksMidnightShift() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: nil,
+                liveInterrupt: makeLiveInterrupt()
+            )
+        )
+    }
+
+    // MARK: - §4b: additional coverage
+
+    func testMidnightShiftAllowedWhenAllGatesAreClear() {
+        XCTAssertTrue(
+            shouldAllowMidnightShift(
+                draggingEventID: nil,
+                resizeGrace: nil,
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    func testMidnightShiftBlockedDuringActiveDrag() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: UUID(),
+                resizeGrace: nil,
+                liveInterrupt: nil
+            )
+        )
+    }
+
+    func testMidnightShiftBlockedWhenAllThreeGatesAreActive() {
+        XCTAssertFalse(
+            shouldAllowMidnightShift(
+                draggingEventID: UUID(),
+                resizeGrace: makeResizeGrace(),
+                liveInterrupt: makeLiveInterrupt()
+            )
+        )
+    }
+
+    // MARK: - §4a: computeAbandonedFadeCurves
+
+    /// Baseline fixture: a drag is active (`raw.source != nil`), the user has
+    /// pulled the intent back OUT of the trigger zone (`raw.hasAnyExtension =
+    /// false`), but the band stays applied (`applied.hasAnyExtension`). This
+    /// is the scenario the helper exists for.
+    private func makeBaselineInputs(
+        leading: Int = 4,
+        trailing: Int = 0,
+        dragOffsetY: CGFloat = 0,
+        scrollY: CGFloat = 0
+    ) -> AbandonedFadeInputs {
+        let originalStart = date(2026, 5, 1, 22, 0)
+        let originalEnd = date(2026, 5, 2, 1, 0)
+        return AbandonedFadeInputs(
+            rawState: makeExtensionState(
+                leadingHours: 0,
+                trailingHours: 0,
+                source: .moveDrag
+            ),
+            appliedState: makeExtensionState(
+                leadingHours: leading,
+                trailingHours: trailing,
+                source: nil
+            ),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: dragOffsetY,
+            hourHeight: 40,
+            extensionOriginY: 100,
+            scrollY: scrollY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenAppliedStateIsNone() {
+        var input = makeBaselineInputs(leading: 0, trailing: 0)
+        // Override applied to truly `.none`.
+        input = AbandonedFadeInputs(
+            rawState: input.rawState,
+            appliedState: .none,
+            dragOriginalRange: input.dragOriginalRange,
+            dragOffsetY: input.dragOffsetY,
+            hourHeight: input.hourHeight,
+            extensionOriginY: input.extensionOriginY,
+            scrollY: input.scrollY,
+            viewportHeight: input.viewportHeight,
+            baseVisibleHours: input.baseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenRawSourceIsNil() {
+        var input = makeBaselineInputs()
+        input = AbandonedFadeInputs(
+            rawState: .none,  // source: nil
+            appliedState: input.appliedState,
+            dragOriginalRange: input.dragOriginalRange,
+            dragOffsetY: input.dragOffsetY,
+            hourHeight: input.hourHeight,
+            extensionOriginY: input.extensionOriginY,
+            scrollY: input.scrollY,
+            viewportHeight: input.viewportHeight,
+            baseVisibleHours: input.baseVisibleHours
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading, "rawState.source == nil ⇒ no dissolve writes")
+        XCTAssertNil(curves.trailing, "rawState.source == nil ⇒ no dissolve writes")
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenRawStateIsItselfOpen() {
+        // raw.hasAnyExtension means the drag is back IN the zone — the
+        // dissolve path doesn't apply.
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 2, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: 2, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: 40,
+            extensionOriginY: 100,
+            scrollY: 0,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesEarlyReturnsWhenHourHeightIsZero() {
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: 2, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: 0,  // degenerate
+            extensionOriginY: 100,
+            scrollY: 0,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading)
+        XCTAssertNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesWritesOnlyLeadingWhenLeadingOnly() {
+        let input = makeBaselineInputs(leading: 4, trailing: 0)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNotNil(curves.leading)
+        XCTAssertNil(curves.trailing, "trailing == 0 ⇒ no trailing write")
+    }
+
+    func testComputeFadeCurvesWritesOnlyTrailingWhenTrailingOnly() {
+        let input = makeBaselineInputs(leading: 0, trailing: 4)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNil(curves.leading, "leading == 0 ⇒ no leading write")
+        XCTAssertNotNil(curves.trailing)
+    }
+
+    func testComputeFadeCurvesWritesBothWhenBothSidesOpen() {
+        let input = makeBaselineInputs(leading: 4, trailing: 4)
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertNotNil(curves.leading)
+        XCTAssertNotNil(curves.trailing)
+    }
+
+    /// Multiply-complement combine identity:
+    ///   combine(s1, s2) = 1 - (1 - s1)(1 - s2)
+    ///
+    /// Exercise this through the helper:
+    /// - When s2 saturates to 1 (boundary at viewport edge or past), result = 1
+    ///   regardless of s1.
+    /// - When both stages contribute partially, both must be < 1.
+    /// Verifies the helper's stage composition matches the documented formula
+    /// without exposing the nested `combineFades` symbol.
+    func testCombineFadesSaturatesToOneWhenStage2Saturates() {
+        // Pick scrollY so the 0:00 line sits above the viewport top by a lot —
+        // that is, leading boundary span d < 0 → s2 clamps to 1.
+        //   visibleTop = max(0, scrollY)
+        //   d = (extensionOriginY + bandHeight) - visibleTop
+        // To force d ≤ 0 we need scrollY ≥ extensionOriginY + bandHeight.
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let bandHeight = CGFloat(leading) * hh
+        let scrollY = extensionOriginY + bandHeight + 10  // d = -10 → s2 clamps to 1.
+
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(
+                start: date(2026, 5, 1, 22, 0),
+                end: date(2026, 5, 2, 1, 0)
+            ),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: scrollY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        // Combine identity: when either stage saturates to 1, result is 1.
+        XCTAssertEqual(curves.leading ?? -1, 1, accuracy: 0.0001)
+    }
+
+    func testCombineFadesProducesZeroWhenBothStagesAreZero() {
+        // Stage 1 is zero when the dragged edge hasn't moved (offsetHours = 0)
+        // — `liveStart - dayStart` = 22h, that's > stage1Start(4) + stage1Range(4)
+        // → stage1 hits the cap of 0.6. So combine(0.6, 0) = 0.6, not 0.
+        //
+        // For both stages to be zero, we need an event that starts EXACTLY at
+        // dayStart and no drag offset. Then distHours = 0, fingerStage1Fade
+        // formula yields min(0.6, max(0, min(1, -1))) = 0.
+        //
+        // The helper uses `Calendar.current` (host timezone) internally for
+        // `startOfDay`, so anchor `originalStart` to the host's startOfDay
+        // explicitly — using a UTC date here would be off by the host's
+        // UTC offset and distHours would land at 20+h instead of 0.
+        let originalStart = Calendar.current.startOfDay(for: date(2026, 5, 1, 12, 0))
+        let originalEnd = originalStart.addingTimeInterval(3600)
+        // s2: pick scrollY so leading boundary span d == bandHeight → s2 = 0.
+        // d = (extensionOriginY + bandHeight) - visibleTop = bandHeight
+        // → visibleTop = extensionOriginY → scrollY = extensionOriginY.
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: extensionOriginY,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        XCTAssertEqual(curves.leading ?? -1, 0, accuracy: 0.0001)
+    }
+
+    /// Verifies that when both stages produce nonzero-but-partial output,
+    /// the combined result follows `1 - (1 - s1)(1 - s2)`. This pins the
+    /// multiply-complement contract: result > max(s1, s2) (over-blend), and
+    /// result < s1 + s2 (no double-counting).
+    func testCombineFadesProducesOverBlendOfBothStages() {
+        // Pick stage-1 ≈ 0.6 (the cap): an event starting late in the day
+        // with no drag offset gives `liveStart - dayStart` = 22h → far past
+        // the cap range → stage1 = 0.6.
+        //
+        // Pick stage-2 partial: 0 < d < bandHeight → 0 < s2 < 1.
+        // bandHeight = 4 * 40 = 160. extensionOriginY = 100. Choose scrollY
+        // so visibleTop = 100 + 80 = 180. Then d = 100 + 160 - 180 = 80,
+        // s2 = 1 - 80/160 = 0.5.
+        let originalStart = date(2026, 5, 1, 22, 0)
+        let originalEnd = date(2026, 5, 2, 1, 0)
+        let leading = 4
+        let hh: CGFloat = 40
+        let extensionOriginY: CGFloat = 100
+        let input = AbandonedFadeInputs(
+            rawState: makeExtensionState(leadingHours: 0, trailingHours: 0, source: .moveDrag),
+            appliedState: makeExtensionState(leadingHours: leading, trailingHours: 0),
+            dragOriginalRange: Event.TimeRange(start: originalStart, end: originalEnd),
+            dragOffsetY: 0,
+            hourHeight: hh,
+            extensionOriginY: extensionOriginY,
+            scrollY: 180,
+            viewportHeight: 600,
+            baseVisibleHours: 24
+        )
+        let curves = computeAbandonedFadeCurves(input)
+        // s1 = 0.6, s2 = 0.5 ⇒ combine = 1 - 0.4 * 0.5 = 1 - 0.2 = 0.8.
+        XCTAssertEqual(curves.leading ?? -1, 0.8, accuracy: 0.0001)
+    }
+}


### PR DESCRIPTION
## Summary

- Strict-parity port of the landscape focus-mode mini-cal (`FocusEventFlowView`) to a CALayer-backed `UIView`. Same shape as the #74 axis port and #71 mini-day port.
- Reuses the same module-scope helpers as the SwiftUI tree so both paths share one source of truth (overlap layout, event color, compound interrupt geometry/shape, child overlay geometry).
- Flag `calendarUseCALayerFocusEventFlow` default OFF; awaits on-device A/B parity sign-off before flip.

## What changed
- `Done/Views/Focus/FocusEventFlowLayerView.swift` (NEW, ~530 LOC) — `FocusEventFlowLayerHost: UIViewRepresentable` + `FocusEventFlowLayerView: UIView`. Z-ordered containers preserve the SwiftUI two-pass z-order (grid → hour labels → blocks → titles → now indicator). Per-occurrence `BlockNode` pooled by id; UILabel pool for hour-axis text + event titles. Structure rebuilds only on occurrence-set change; per-tick `now` advance only triggers a relayout.
- `Done/Views/Focus/FocusModeEventView.swift` — landscape branch now forks between `FocusEventFlowView` (default) and `FocusEventFlowLayerHost` behind the flag.
- `Done/ContentView.swift` — new `AppSettingsKeys.calendarUseCALayerFocusEventFlow` + added to `userBackedKeys`.
- `Done/Views/Agent/AgentSettingsView.swift` — toggle card under Settings → Experimental.
- `Done.xcodeproj/project.pbxproj` — file membership for the new file.

## Acceptance (from #72) — on-device A/B
Toggle Settings → Experimental → "Use CALayer focus event flow" and compare:
- Single event focus (now ± 3h window)
- Multiple overlapping events (peer + interrupt parent)
- Embedded interrupt children rendered as inset rounded-rect overlays inside the parent's compound silhouette
- Mid-session focus mode entry with active recording
- Mode transition animation parity (enter / exit focus)
- Focus mode gesture parity (scroll-driven, no regressions)

Path-agnostic items still apply (12h / 24h time format, dark mode, hour-label hide-near-now rule).

## Out of scope
- Flag flip default ON (separate commit after A/B sign-off — same shape as `82e31a2` for #74)
- Adding the live-current-time scroll animation discipline mentioned in #72's scope note (the parent already drives `now` re-evaluation; no internal timer needed for static rendering parity)

## Test plan
- [ ] Build green (verified: `xcodebuild -scheme Done … build` → `BUILD SUCCEEDED`)
- [ ] Toggle OFF → unchanged SwiftUI render
- [ ] Toggle ON → all 6 A/B shapes match
- [ ] Lifecycle: enter focus, exit, re-enter → no leak / detached layers

🤖 Generated with [Claude Code](https://claude.com/claude-code)