### PR TITLE
feat(calendar): restore boundary day hints in CALayer day host (#61)

### DIFF
--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -79,6 +79,12 @@ struct CalendarDayLayerView: UIViewRepresentable {
     /// grid's `slotHeight` / `slotCount` use this frozen value while line
     /// density (`isSubHourLine`) still uses the LIVE `slotMinutes` (spec 03 §9).
     let frozenSlotMinutes: Int?
+    /// Extension-band fade progress (#61). 0 = band fully visible, 1 = fully
+    /// faded out (matches `extensionFadeMask`'s opacity ramp). Drives the
+    /// in-band day-hint label opacity so the "SAT 26"-style hints fade in
+    /// lockstep with the band.
+    let leadingFadeProgress: CGFloat
+    let trailingFadeProgress: CGFloat
 
     // MARK: Gesture inputs (S4)
 
@@ -169,6 +175,8 @@ struct CalendarDayLayerView: UIViewRepresentable {
             nearFutureHorizonDays: nearFutureHorizonDays,
             isPinchActive: isPinchActive,
             frozenSlotMinutes: frozenSlotMinutes,
+            leadingFadeProgress: leadingFadeProgress,
+            trailingFadeProgress: trailingFadeProgress,
             dayColumnStep: dayColumnStep,
             dragPreviewDayStep: dragPreviewDayStep,
             creationPreviewRange: creationPreviewRange,

--- a/Done/Views/Calendar/Components/Timeline/DayLayerHostView.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerHostView.swift
@@ -49,6 +49,12 @@ final class DayLayerHostView: UIView {
         let nearFutureHorizonDays: Int
         let isPinchActive: Bool
         let frozenSlotMinutes: Int?
+        /// Extension-band fade progress (#61) — drives the in-band day-hint
+        /// opacity. Not in `StructureKey` (no overlap-topology effect); a
+        /// change here triggers a chrome-only repaint via the visual-state
+        /// path.
+        var leadingFadeProgress: CGFloat = 0
+        var trailingFadeProgress: CGFloat = 0
         // S4 gesture / live-state fields. These do NOT participate in the
         // StructureKey (they don't change overlap topology), but changing
         // them must still re-render (focus dim, drag preview, grace handles).
@@ -84,6 +90,8 @@ final class DayLayerHostView: UIView {
                 && a.dayColumnStep == b.dayColumnStep
                 && a.dragPreviewDayStep == b.dragPreviewDayStep
                 && a.recentlyAbsorbedEventIDs == b.recentlyAbsorbedEventIDs
+                && a.leadingFadeProgress == b.leadingFadeProgress
+                && a.trailingFadeProgress == b.trailingFadeProgress
         }
 
         /// Structural identity of everything that affects overlap topology +
@@ -1083,6 +1091,27 @@ final class DayLayerHostView: UIView {
         layer.addSublayer(c.nowLine)
         return c
     }()
+
+    /// In-band day-hint labels (#61). One UILabel per side; visible only when
+    /// the corresponding extension band is open. Positioned per
+    /// `calendarTimelineBoundaryDayHintPlacements`; opacity = 1 − fadeProgress
+    /// so they fade in lockstep with the band. Lazy so a day with no bands
+    /// never allocates the labels.
+    private lazy var leadingDayHintLabel: UILabel = makeBoundaryDayHintLabel()
+    private lazy var trailingDayHintLabel: UILabel = makeBoundaryDayHintLabel()
+
+    private func makeBoundaryDayHintLabel() -> UILabel {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 11, weight: .semibold)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .right
+        label.isUserInteractionEnabled = false
+        label.isHidden = true
+        // Sits above the grid + events, below the now-line (zPosition 100).
+        label.layer.zPosition = 99
+        addSubview(label)
+        return label
+    }
 
     // MARK: Apply
 
@@ -3102,6 +3131,75 @@ final class DayLayerHostView: UIView {
         } else {
             chrome.nowLine.isHidden = true
         }
+
+        updateBoundaryDayHints(model: model)
+    }
+
+    /// In-band day hints (#61). Placement comes from the existing
+    /// `calendarTimelineBoundaryDayHintPlacements` helper (a pure function
+    /// over the same hour math the host already uses) so the hint sits
+    /// inside the extension band, right-aligned to the event area's right
+    /// edge. Text combines weekday + day-of-month ("SAT 26") via the two
+    /// static formatters that survived the legacy-SwiftUI timeline removal.
+    /// Opacity tracks the band's own fade so the hint doesn't linger when
+    /// the band is collapsing.
+    private func updateBoundaryDayHints(model: Model) {
+        let placements = calendarTimelineBoundaryDayHintPlacements(
+            anchorDate: model.date,
+            headerHeight: model.headerHeight,
+            hourHeight: model.hourHeight,
+            leadingExtendedHours: model.leadingExtendedHours,
+            trailingExtendedHours: model.trailingExtendedHours
+        )
+        let rightInset = model.eventHorizontalInset
+        let hintHeight: CGFloat = 14
+        let hintWidth: CGFloat = 60
+
+        applyDayHint(
+            label: leadingDayHintLabel,
+            placement: placements.leading,
+            fadeProgress: model.leadingFadeProgress,
+            rightInset: rightInset,
+            hintWidth: hintWidth,
+            hintHeight: hintHeight
+        )
+        applyDayHint(
+            label: trailingDayHintLabel,
+            placement: placements.trailing,
+            fadeProgress: model.trailingFadeProgress,
+            rightInset: rightInset,
+            hintWidth: hintWidth,
+            hintHeight: hintHeight
+        )
+    }
+
+    private func applyDayHint(
+        label: UILabel,
+        placement: TimelineBoundaryDayHintPlacement?,
+        fadeProgress: CGFloat,
+        rightInset: CGFloat,
+        hintWidth: CGFloat,
+        hintHeight: CGFloat
+    ) {
+        guard let placement else {
+            label.isHidden = true
+            return
+        }
+        let opacity = max(0, min(1, 1 - fadeProgress))
+        guard opacity > 0.001 else {
+            label.isHidden = true
+            return
+        }
+        let weekday = calendarBoundaryDayHintWeekdayFormatter
+            .string(from: placement.date)
+            .uppercased()
+        let day = calendarBoundaryDayHintDayFormatter
+            .string(from: placement.date)
+        label.text = "\(weekday) \(day)"
+        let x = max(0, bounds.width - hintWidth - rightInset)
+        label.frame = CGRect(x: x, y: placement.originY, width: hintWidth, height: hintHeight)
+        label.alpha = opacity
+        label.isHidden = false
     }
 
     /// Now-line / horizon indicator color (mirrors the file-private

--- a/Done/Views/Calendar/Components/Timeline/DayLayerHostView.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerHostView.swift
@@ -1107,8 +1107,11 @@ final class DayLayerHostView: UIView {
         label.textAlignment = .right
         label.isUserInteractionEnabled = false
         label.isHidden = true
-        // Sits above the grid + events, below the now-line (zPosition 100).
-        label.layer.zPosition = 99
+        // Sits above the grid + events, just below the deadline lines (99)
+        // and the now-line (100). 98 breaks the z tie with `deadlineLines`
+        // so a deadline marker that lands inside the band's interior corner
+        // strip (rare but possible) renders above the hint.
+        label.layer.zPosition = 98
         addSubview(label)
         return label
     }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2535,6 +2535,8 @@ struct TimelinePagerView: View {
             nearFutureHorizonDays: nearFutureHorizonDays,
             isPinchActive: isRangePinchActive,
             frozenSlotMinutes: rangePinchFrozenSlotMinutes,
+            leadingFadeProgress: leadingFadeProgress,
+            trailingFadeProgress: trailingFadeProgress,
             dayColumnStep: dayColumnStep,
             dragPreviewDayStep: dragPreviewDayStep,
             creationPreviewRange: previewRange,
@@ -3132,20 +3134,6 @@ private struct TimeAxisLabels: View {
         return formatter
     }
 
-    static let boundaryDayHintWeekdayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.setLocalizedDateFormatFromTemplate("EEE")
-        return formatter
-    }()
-
-    static let boundaryDayHintDayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale.current
-        formatter.setLocalizedDateFormatFromTemplate("d")
-        return formatter
-    }()
-
     private func currentTimeText(for now: Date) -> String {
         Self.currentTimeFormatter.string(from: now).lowercased()
     }
@@ -3185,6 +3173,25 @@ struct TimelineBoundaryDayHintPlacement: Equatable {
     let originY: CGFloat
     let isTrailingEdge: Bool
 }
+
+/// Weekday + day-of-month formatters for the boundary day hint
+/// ("SAT 26"-style label inside an extension band). Top-level so they can
+/// be reached from both `TimelineView` (the historical SwiftUI render
+/// site; now retired) and `DayLayerHostView` (the active CALayer renderer,
+/// #61). Locale-aware via `setLocalizedDateFormatFromTemplate`.
+let calendarBoundaryDayHintWeekdayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.setLocalizedDateFormatFromTemplate("EEE")
+    return formatter
+}()
+
+let calendarBoundaryDayHintDayFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale.current
+    formatter.setLocalizedDateFormatFromTemplate("d")
+    return formatter
+}()
 
 func calendarTimelineBoundaryDayHintPlacements(
     anchorDate: Date,


### PR DESCRIPTION
## Summary
- Boundary day hint ("SAT 26"-style label in an open extension band) was lost when `89f11db` removed the SwiftUI fallback timeline. This PR ports the visual into the CALayer renderer (`DayLayerHostView`).
- **Base**: `refactor-split-calendar-day-layer-view` (PR #86). Once #86 merges to king-of-rubbish-bin this rebases trivially onto king.
- Strict in scope: ZERO behavior change to event blocks / grid / chrome. Only the previously-missing day-hint surface is added.

## Why

Today opening a cross-midnight follow band (#55) or a boundary drag shows no day-label inside the band. The original SwiftUI overlay was deleted with the broader fallback removal, but the placement helper (`calendarTimelineBoundaryDayHintPlacements`) and tests survived — exactly the "missing CALayer port" #61 calls out.

## What changed

| File | Change |
|---|---|
| `CalendarDayLayerView.swift` | Add `leadingFadeProgress` + `trailingFadeProgress` inputs; forward into `Model` |
| `DayLayerHostView.swift` | Add 2 `UILabel` properties + `updateBoundaryDayHints` / `applyDayHint` helpers; call from `renderChrome`'s tail. `Model.visualStateEqual` now considers the two fade fields so a fade-only update repaints. |
| `TimelineView.swift` | Two formatters moved from the private `TimeAxisLabels` struct to top-level (`calendarBoundaryDayHintWeekdayFormatter`, `calendarBoundaryDayHintDayFormatter`) so they reach across files. The CalendarDayLayerView call site forwards `leadingFadeProgress` / `trailingFadeProgress`. |

Diff: +127 / −14 across three files.

## How opacity works
- Band closed (`leadingExtendedHours == 0` etc.) → `calendarTimelineBoundaryDayHintPlacements` returns `nil` for that side → label hidden.
- Band open + not animating → `fadeProgress = 0` → opacity 1.
- Band collapsing animation → `fadeProgress → 1` → opacity 0; label hidden at `< 0.001` to avoid hit-test / debug visibility on a transparent label.

## Verification
- `xcodebuild -project Done.xcodeproj -scheme Done -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 17 Pro" -configuration Debug build` → **BUILD SUCCEEDED**.
- No on-device verification yet — this is a visual restoration the user sign-off should cover (in particular: position inside the band, correct weekday for cross-midnight target, fade lockstep with band collapse).

## Test plan
- [x] Build green
- [ ] Open trailing extension band via cross-midnight follow → "SAT 26"-style label appears inside the band, right-aligned to event-area's right edge
- [ ] Same on leading band (cross-midnight backwards)
- [ ] Band collapse animation: label fades with the band, doesn't strand
- [ ] Pinch through the band-open state: label position recomputes per hourHeight (no flicker)
- [ ] Dark mode: label uses `.secondaryLabel`, legible on band background

## Refs
- Issue #61
- Memory `project_calayer_timeline_render_paths` — `renderChrome` is the chrome-pass entry point; this hooks at its tail so the cheap-pinch fast path remains untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)