### PR TITLE
feat(timeline): #57 spec-07 S2 — lift imperative close-path gate upstream

### DIFF
--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1185,6 +1185,15 @@ struct CalendarPageView: View {
     /// Caller passes only the SwiftUI fade reset they want — close paths
     /// that fully close zero both; partial-close paths leave the surviving
     /// side's fade progress alone.
+    /// Legacy (UIScrollView, non-imperative) close-path: the contentSize +
+    /// contentOffset atomic co-commit used to hide the 1-frame mismatch when
+    /// the band collapses. Imperative single-day NEVER reaches this — its
+    /// callers fork upstream to `handleImperativeBandStateChange` (band
+    /// visibility is `contentInset`, not contentSize; see spec 07 §5 S2).
+    ///
+    /// S7 deletion gate: this function + `TimelineScrollProxy.coCommit` +
+    /// `applyCloseLeadingTransientCompensation` all become dead code once the
+    /// flag default flips ON and the legacy fallback is removed.
     private func applyCloseBandStateAtomicCoCommit(
         targetState newState: TimelineBoundaryExtensionState,
         resetLeadingFade: Bool,
@@ -1193,10 +1202,12 @@ struct CalendarPageView: View {
     ) {
         let previousState = timelineBoundaryExtensionState
         guard previousState != newState else { return }
-        // Spec 07: contentSize co-commit must never run on the constant-48h
-        // imperative substrate. All current callers are gated upstream; this
-        // entry guard makes any future caller safe-by-default — redirect the
-        // close to the inset-driven imperative band path.
+        // Spec 07 §5 S2: imperative callers fork upstream, so this is now
+        // unreachable on the imperative path. Assert in debug; on release we
+        // still defend by redirecting to the inset path so any future caller
+        // added without the upstream fork doesn't write contentSize into a
+        // 48h-constant substrate.
+        assert(!usesImperativeDayLayerModel, "applyCloseBandStateAtomicCoCommit reached on imperative path — caller missing spec-07 S2 fork")
         if usesImperativeDayLayerModel {
             handleImperativeBandStateChange(newState)
             return
@@ -3181,11 +3192,18 @@ private extension CalendarPageView {
                                 // (Outer guard at line :2937 already verified
                                 // `source == nil` for this completion frame;
                                 // no need to re-check.)
-                                applyCloseBandStateAtomicCoCommit(
-                                    targetState: .none,
-                                    resetLeadingFade: true,
-                                    resetTrailingFade: true
-                                )
+                                // Spec 07 §5 S2: imperative skips the
+                                // contentSize co-commit machinery — band
+                                // visibility is `contentInset`, not size.
+                                if usesImperativeDayLayerModel {
+                                    handleImperativeBandStateChange(.none)
+                                } else {
+                                    applyCloseBandStateAtomicCoCommit(
+                                        targetState: .none,
+                                        resetLeadingFade: true,
+                                        resetTrailingFade: true
+                                    )
+                                }
                             } else {
                                 if useUIScrollViewTimeline {
                                     print("🚨[#57.dim.UNREACHABLE] dim fade fired on flag-ON path — fork broken at single-side rebounce close")
@@ -3235,11 +3253,18 @@ private extension CalendarPageView {
                         // transaction (1-frame mismatch hidden by the
                         // already-invisible band).
                         if useUIScrollViewTimeline {
-                            applyCloseBandStateAtomicCoCommit(
-                                targetState: .none,
-                                resetLeadingFade: true,
-                                resetTrailingFade: true
-                            )
+                            // Spec 07 §5 S2: imperative skips the contentSize
+                            // co-commit machinery — band visibility is
+                            // `contentInset`, not size.
+                            if usesImperativeDayLayerModel {
+                                handleImperativeBandStateChange(.none)
+                            } else {
+                                applyCloseBandStateAtomicCoCommit(
+                                    targetState: .none,
+                                    resetLeadingFade: true,
+                                    resetTrailingFade: true
+                                )
+                            }
                         } else {
                             var transaction = Transaction()
                             transaction.disablesAnimations = true
@@ -3402,13 +3427,25 @@ private extension CalendarPageView {
         // didn't catch (memory `feedback_calayer_parity_multi_state_gates`).
         // Reset fade ONLY on sides that actually collapsed in this tick.
         if useUIScrollViewTimeline {
-            applyCloseBandStateAtomicCoCommit(
-                targetState: collapsedState,
-                resetLeadingFade: timelineBoundaryExtensionState.leadingHours > 0
-                    && collapsedState.leadingHours == 0,
-                resetTrailingFade: timelineBoundaryExtensionState.trailingHours > 0
-                    && collapsedState.trailingHours == 0
-            )
+            // Spec 07 §5 S2: imperative skips the contentSize co-commit
+            // machinery — band visibility is `contentInset`, not size.
+            // Note: `handleImperativeBandStateChange(collapsedState)` with
+            // `source == nil` currently routes through the unconditional
+            // full-close release branch (sets state to `.none`) — byte-
+            // identical to today's defensive-redirect behavior. A future
+            // slice can teach the imperative path partial-side close if
+            // visual A/B surfaces a regression.
+            if usesImperativeDayLayerModel {
+                handleImperativeBandStateChange(collapsedState)
+            } else {
+                applyCloseBandStateAtomicCoCommit(
+                    targetState: collapsedState,
+                    resetLeadingFade: timelineBoundaryExtensionState.leadingHours > 0
+                        && collapsedState.leadingHours == 0,
+                    resetTrailingFade: timelineBoundaryExtensionState.trailingHours > 0
+                        && collapsedState.trailingHours == 0
+                )
+            }
             return
         }
         // Mirror the drag-end dismiss path's `disablesAnimations` guard

--- a/Done/Views/Calendar/Components/Timeline/TimelineScrollHost.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineScrollHost.swift
@@ -116,6 +116,13 @@ final class TimelineScrollProxy: ObservableObject {
     /// `leadingExtendedHours`. See
     /// `applyCloseLeadingTransientCompensation(deltaY:)` for the full
     /// rationale.
+    ///
+    /// Spec 07 §5 S2 deletion gate: imperative single-day band collapse
+    /// goes through `contentInset` (constant `contentSize`), so this
+    /// function is only reached on the legacy (non-imperative) fork. When
+    /// the imperative flag default flips ON in S7, this + `applyClose
+    /// LeadingTransientCompensation` + the height-constraint write path
+    /// become dead code and can be removed.
     func coCommit(
         contentHeight: CGFloat,
         offsetY: CGFloat,
@@ -225,6 +232,32 @@ final class TimelineScrollProxy: ObservableObject {
         guard let scrollView else { return }
         let target = UIEdgeInsets(top: top, left: 0, bottom: bottom, right: 0)
         guard scrollView.contentInset != target else { return }
+        applyContentInsetTarget(target, animated: animated)
+    }
+
+    /// Spec 07 §5 S2: drive ONE band side independently. Leading band uses
+    /// `setContentInsetTop`, trailing uses `setContentInsetBottom`. Each preserves
+    /// the other side's current inset so a single-side rebounce doesn't perturb
+    /// the open side. The combined `setBandInset` remains the atomic-both-sides
+    /// API used when a state transition flips both at once.
+    func setContentInsetTop(_ top: CGFloat, animated: Bool) {
+        guard let scrollView else { return }
+        let current = scrollView.contentInset
+        let target = UIEdgeInsets(top: top, left: current.left, bottom: current.bottom, right: current.right)
+        guard current != target else { return }
+        applyContentInsetTarget(target, animated: animated)
+    }
+
+    func setContentInsetBottom(_ bottom: CGFloat, animated: Bool) {
+        guard let scrollView else { return }
+        let current = scrollView.contentInset
+        let target = UIEdgeInsets(top: current.top, left: current.left, bottom: bottom, right: current.right)
+        guard current != target else { return }
+        applyContentInsetTarget(target, animated: animated)
+    }
+
+    private func applyContentInsetTarget(_ target: UIEdgeInsets, animated: Bool) {
+        guard let scrollView else { return }
         if animated {
             isAnimatingBandInset = true
             UIView.animate(


### PR DESCRIPTION
## Summary

Next slice in the spec-07 arc (`docs/calayer-rewrite/07-day-layer-imperative.md` §5 row S2). Builds on #94 (S0 + Phase 1) which just merged into king.

S0 + Phase 1 had imperative-path callers route to `handleImperativeBandStateChange` via a **defensive redirect INSIDE** `applyCloseBandStateAtomicCoCommit`. Functionally correct, but:
- `coCommit` machinery still got invoked and immediately no-op'd
- The contentSize co-commit + transient host-translate compensation stayed reachable code on the imperative path
- S7's deletion of the legacy close-path machinery couldn't be mechanical

S2 lifts the gate **upstream to the three call sites**, so `coCommit` is genuinely unreachable on imperative single-day → S7 can delete the legacy machinery without ceremony.

## What's in

### `Done/Views/Calendar/CalendarPageView.swift`

Three close-path entries now fork on `usesImperativeDayLayerModel` BEFORE calling `applyCloseBandStateAtomicCoCommit`:

1. **Single-side rebounce completion** — passes `.none`
2. **Both-sides fade-then-collapse** — passes `.none`
3. **Scroll-tick auto-collapse** — passes the (potentially partial) `collapsedState`

Imperative branch in each goes directly to `handleImperativeBandStateChange(targetState)`. Legacy `else` branches call `applyCloseBandStateAtomicCoCommit` exactly as before (byte-identical).

The downstream defensive redirect inside `applyCloseBandStateAtomicCoCommit` becomes `assert(!usesImperativeDayLayerModel)` to catch future imperative callers added without the upstream fork. Release builds still belt+suspenders by redirecting.

### `Done/Views/Calendar/Components/Timeline/TimelineScrollHost.swift`

Spec §5 S2 mandates `setContentInsetTop(_:)` / `setContentInsetBottom(_:)` primitives on `TimelineScrollProxy`. Added them — they preserve the other side's current inset so single-side close doesn't perturb the open side. `setBandInset(top:bottom:animated:)` retains its atomic-both-sides semantics, routes through a shared private `applyContentInsetTarget` helper.

### Doc updates

`coCommit` doc-comment now explicitly marks itself + `applyCloseLeadingTransientCompensation` as **S7-deletable** when the imperative flag default flips ON.

## Known scope-deferrals (documented inline)

**Scroll-tick partial-side close.** Site 3 passes a state that can be partial (e.g., `(leading: 0, trailing: 12)`). `handleImperativeBandStateChange(partial, source: nil)` currently routes through its unconditional full-close release branch — same as today's defensive redirect, byte-identical. A future slice can teach the imperative path partial-side close if visual A/B surfaces a regression.

## What's NOT in

- S1 (occurrence supply ±12h) — separate PR
- Cross-midnight resize symmetry (Phase 2 / #93, awaiting designer)
- Multi-day ±12h drag wall (just-surfaced bug, filed as **#95**, separate slice)
- S3-S7

## Independent pre-push review verdict

`PUSH ✓` — zero critical, zero important findings. All three call sites correctly gated; imperative targetState shapes correct; assert + defensive redirect control flow unambiguous; new inset primitives truly independent; legacy path byte-identical. Full review record available in the conversation.

## Test plan

- [ ] Flag OFF (`calendarUseImperativeDayLayer`): full single-day regression — band open/close, drag-release, scroll-tick auto-collapse. Byte-identical to king.
- [ ] Flag ON, single-day: same scenarios — visually identical to king (since defensive redirect already routed). No assertion fires.
- [ ] 3-day / week: byte-identical to king (imperative gate guards exclude multi-day; `useUIScrollViewTimeline && !usesImperativeDayLayerModel` reaches the legacy `applyCloseBandStateAtomicCoCommit` unchanged).
- [ ] Debug build, flag ON, exercise band collapse paths: confirm no `assert(!usesImperativeDayLayerModel)` fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)