### PR TITLE
feat(timeline): #57 spec-07 S1 — constant 12/12 occurrence supply on imperative single-day

### DIFF
--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1580,6 +1580,22 @@ struct TimelinePagerView: View {
     @State private var cachedRawBoundaryExtensionState: TimelineBoundaryExtensionState = .none
 
     private var occurrenceExtensionHoursForDrag: (leading: Int, trailing: Int) {
+        // Spec 07 §5 S1: imperative single-day path keeps the occurrence
+        // supply CONSTANT at 12/12, mirroring the constant 48h coordinate
+        // substrate. Adjacent-day occurrences (last 12h of dayOffset −1 +
+        // first 12h of dayOffset +1) are always loaded; the day-layer's
+        // drawable-window clip + viewport cull decide what actually paints.
+        // Without this, the band region drawable can open before the supply
+        // catches up (e.g., a cross-midnight rebounce or fast scroll into
+        // the band), leaving the band visually empty for a frame even
+        // though events should be there. Multi-day + non-imperative path
+        // unchanged.
+        if shouldUseExtendedBandWindow {
+            return (
+                leading: calendarTimelineMaximumBoundaryExtensionHours,
+                trailing: calendarTimelineMaximumBoundaryExtensionHours
+            )
+        }
         let isMoveDragActive = calendarIsMoveDragActive(
             draggingEventID: dragState.draggingEventID,
             dragMode: dragState.dragMode


### PR DESCRIPTION
## Summary

Next slice in spec-07 (`docs/calayer-rewrite/07-day-layer-imperative.md` §5 row S1). Builds on #94 (S0+Phase1) and #96 (S2), both merged into king.

S0 made the coordinate substrate constant 48h (`renderBoundaryExtensionHours = 12/12` on imperative single-day). But the **occurrence supply** still tracked the real band state — `occurrenceExtensionHoursForDrag` returns the current `boundaryExtensionHours` (0/0 when band closed), then bumps to 12/12 only during an active move drag via the `max(frozen, current band)` clamp.

That worked for the immediate move-drag → band-open path because the supply caught up at drag start. But the drawable window can OPEN from other entry points too (cross-midnight rebounce, finger-driven day-switch, fast scroll into a band region), where the supply was still 0/0 → band region drawable opens but the layer has no adjacent-day occurrences cached → visually empty for a frame until the next supply update.

## Change

`TimelineView.occurrenceExtensionHoursForDrag` now returns `(12, 12)` UNCONDITIONALLY when `shouldUseExtendedBandWindow` (imperative single-day). Multi-day + non-imperative path unchanged.

```swift
if shouldUseExtendedBandWindow {
    return (
        leading: calendarTimelineMaximumBoundaryExtensionHours,
        trailing: calendarTimelineMaximumBoundaryExtensionHours
    )
}
// existing move-drag / rest logic preserved for non-imperative
```

## Cost analysis

- Adjacent-day occurrence merge runs every render frame on imperative single-day, instead of only during drag.
- `CalendarLayout.timelineVisibleOccurrences` is already memoized via the `occurrencesByOffset` cache + `mergedByID` dedup.
- Net additional work per frame: include two extra candidate `dayOffset`s in the merge loop (the cache hit is O(1); the merge is O(N_occurrences_adjacent_day) which is small).
- Spec §risks calls this out as expected (\"the host already paints cross-midnight events; the only change is keeping the band hours constant\").

## What's NOT in

- S3 (DayLayerCoordinator scaffolding) — separate PR
- S4–S7 — sequential
- Phase 2 (#93), multi-day ±12h wall (#95) — parked

## Test plan

- [ ] Flag OFF: byte-identical to king (the imperative branch is gated by `shouldUseExtendedBandWindow`).
- [ ] 3-day / week: byte-identical (multi-day → `shouldUseExtendedBandWindow == false`).
- [ ] Flag ON, single-day: cross-midnight rebounce → band region populated with adjacent-day events immediately (no empty frame).
- [ ] Flag ON, single-day: fast scroll up to expose leading band region while not dragging → adjacent-day events visible immediately.
- [ ] Flag ON, single-day: cold-start with adjacent-day events near midnight → events in band region paint on first frame (no flash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)