### PR TITLE
feat(timeline): #57 spec-07 S4 — 11-channel migration to DayLayerCoordinator (coordinator stays nil throughout)

### DIFF
--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3994,7 +3994,8 @@ private extension CalendarPageView {
                     rangePinchFrozenSlotMinutes = frozen
                 }
             },
-            boundaryExtensionStateOverride: timelineBoundaryExtensionState
+            boundaryExtensionStateOverride: timelineBoundaryExtensionState,
+            dayLayerCoordinator: dayLayerCoordinator
         )
         // Rebuild when range changes to avoid stale TabView pages across layouts.
         .id(rebuildKey)

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1680,6 +1680,10 @@ struct CalendarPageView: View {
             focusedOccurrenceID: focusedOccurrenceID,
             coordinator: dayLayerCoordinator
         ))
+        .modifier(CalendarPageS4GraceChannelModifier(
+            resizeGraceState: resizeGraceState,
+            coordinator: dayLayerCoordinator
+        ))
         .onChange(of: calendarState.selectedDayOffset) { oldValue, newValue in
             if !legendIsInteracting && timelineDragState.draggingEventID == nil {
                 let isJump = abs(newValue - oldValue) > 1
@@ -5561,6 +5565,22 @@ private struct CalendarPageS4FocusChannelModifier: ViewModifier {
             }
             .onChange(of: focusedOccurrenceID) { _, newValue in
                 coordinator?.setFocus(eventID: focusedEventID, occurrenceID: newValue)
+            }
+    }
+}
+
+private struct CalendarPageS4GraceChannelModifier: ViewModifier {
+    let resizeGraceState: CalendarResizeGraceState?
+    let coordinator: DayLayerCoordinator?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: resizeGraceState) { _, newValue in
+                coordinator?.setGraceResize(
+                    eventID: newValue?.eventID,
+                    occurrenceID: newValue?.occurrenceID,
+                    opacity: newValue?.handleOpacity ?? 1
+                )
             }
     }
 }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1689,6 +1689,10 @@ struct CalendarPageView: View {
             frozenSlotMinutes: rangePinchFrozenSlotMinutes,
             coordinator: dayLayerCoordinator
         ))
+        .modifier(CalendarPageS4ModeChannelModifier(
+            rangeMode: calendarState.rangeMode,
+            coordinator: dayLayerCoordinator
+        ))
         .onChange(of: calendarState.selectedDayOffset) { oldValue, newValue in
             if !legendIsInteracting && timelineDragState.draggingEventID == nil {
                 let isJump = abs(newValue - oldValue) > 1
@@ -5609,6 +5613,18 @@ private struct CalendarPageS4PinchChannelModifier: ViewModifier {
             }
             .onChange(of: frozenSlotMinutes) { _, newValue in
                 coordinator?.setFrozenSlotMinutes(newValue)
+            }
+    }
+}
+
+private struct CalendarPageS4ModeChannelModifier: ViewModifier {
+    let rangeMode: RangeMode
+    let coordinator: DayLayerCoordinator?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: rangeMode) { _, newValue in
+                coordinator?.setMode(newValue)
             }
     }
 }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1084,6 +1084,14 @@ struct CalendarPageView: View {
     @State private var timerRefreshCancellable: AnyCancellable?
     @State private var focusedEventID: UUID? = nil
     @State private var focusedOccurrenceID: String? = nil
+    /// Spec 07 §4a / §5 row S4 — `docs/calayer-rewrite/07-day-layer-imperative.md`.
+    /// Optional handle to the imperative day-layer coordinator. S4 declares this
+    /// slot so the channel migration `.onChange` handlers can route writes
+    /// through it; the actual instantiation lands in S5. While nil (S4), every
+    /// `dayLayerCoordinator?.setX(...)` call below is a no-op, leaving the
+    /// SwiftUI struct field path into `CalendarDayLayerView(...)` as the sole
+    /// channel — flag-OFF and flag-ON are byte-identical to king.
+    @State private var dayLayerCoordinator: DayLayerCoordinator? = nil
     @State private var resizeGraceState: CalendarResizeGraceState? = nil
     @State private var resizeGraceOccurrenceContext: CalendarEventOccurrenceContext? = nil
     @State private var resizeGraceFadeTask: Task<Void, Never>? = nil
@@ -1667,6 +1675,11 @@ struct CalendarPageView: View {
                 ]
             )
         }
+        .modifier(CalendarPageS4FocusChannelModifier(
+            focusedEventID: focusedEventID,
+            focusedOccurrenceID: focusedOccurrenceID,
+            coordinator: dayLayerCoordinator
+        ))
         .onChange(of: calendarState.selectedDayOffset) { oldValue, newValue in
             if !legendIsInteracting && timelineDragState.draggingEventID == nil {
                 let isJump = abs(newValue - oldValue) > 1
@@ -5525,6 +5538,31 @@ private extension CalendarPageView {
         formatter.dateFormat = "d"
         return formatter
     }()
+}
+
+// MARK: - Spec 07 §5 row S4 — Day-Layer Coordinator Channel Modifiers
+//
+// Each channel migration in S4 adds one `.onChange`-bearing modifier to the
+// `CalendarPageView` body so the (currently nil) `DayLayerCoordinator` will
+// see SwiftUI state changes once S5 instantiates it. Extracted into
+// `ViewModifier`s rather than inline `.onChange`s to keep the page body
+// type-checker complexity under control — adding 11 `.onChange`s inline
+// blows past Swift's type-checking budget for that builder.
+
+private struct CalendarPageS4FocusChannelModifier: ViewModifier {
+    let focusedEventID: UUID?
+    let focusedOccurrenceID: String?
+    let coordinator: DayLayerCoordinator?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: focusedEventID) { _, newValue in
+                coordinator?.setFocus(eventID: newValue, occurrenceID: focusedOccurrenceID)
+            }
+            .onChange(of: focusedOccurrenceID) { _, newValue in
+                coordinator?.setFocus(eventID: focusedEventID, occurrenceID: newValue)
+            }
+    }
 }
 
 // MARK: - Date Picker Sheet

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1684,6 +1684,11 @@ struct CalendarPageView: View {
             resizeGraceState: resizeGraceState,
             coordinator: dayLayerCoordinator
         ))
+        .modifier(CalendarPageS4PinchChannelModifier(
+            hourHeight: calendarState.timelineHourHeight,
+            frozenSlotMinutes: rangePinchFrozenSlotMinutes,
+            coordinator: dayLayerCoordinator
+        ))
         .onChange(of: calendarState.selectedDayOffset) { oldValue, newValue in
             if !legendIsInteracting && timelineDragState.draggingEventID == nil {
                 let isJump = abs(newValue - oldValue) > 1
@@ -5582,6 +5587,28 @@ private struct CalendarPageS4GraceChannelModifier: ViewModifier {
                     occurrenceID: newValue?.occurrenceID,
                     opacity: newValue?.handleOpacity ?? 1
                 )
+            }
+    }
+}
+
+/// Spec 07 §5 row S4 — pinch channel (3 setters: hourHeight, frozenSlotMinutes,
+/// isPinchActive). This modifier covers the two pieces of pinch state owned by
+/// `CalendarPageView` (`calendarState.timelineHourHeight` — a @Published on
+/// the calendar state — and `rangePinchFrozenSlotMinutes`). The third
+/// (isRangePinchActive) lives in `TimelinePagerView` and is wired via an
+/// .onChange there.
+private struct CalendarPageS4PinchChannelModifier: ViewModifier {
+    let hourHeight: CGFloat
+    let frozenSlotMinutes: Int?
+    let coordinator: DayLayerCoordinator?
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: hourHeight) { _, newValue in
+                coordinator?.setHourHeight(newValue)
+            }
+            .onChange(of: frozenSlotMinutes) { _, newValue in
+                coordinator?.setFrozenSlotMinutes(newValue)
             }
     }
 }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1784,6 +1784,11 @@ struct TimelinePagerView: View {
         .onChange(of: calayerMultiTypeEnabled) { _, newValue in
             dayLayerCoordinator?.setMultiTypeEnabled(newValue)
         }
+        // Spec 07 §5 row S4 — horizon channel migration. AppStorage owned
+        // here. Inert while coordinator is nil (S4).
+        .onChange(of: nearFutureHorizonDays) { _, newValue in
+            dayLayerCoordinator?.setHorizonDays(newValue)
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1779,6 +1779,11 @@ struct TimelinePagerView: View {
         .onChange(of: calayerShowTimeBelowTitle) { _, newValue in
             dayLayerCoordinator?.setShowTimeBelowTitle(newValue)
         }
+        // Spec 07 §5 row S4 — settings: multi-type channel migration.
+        // AppStorage owned here. Inert while coordinator is nil (S4).
+        .onChange(of: calayerMultiTypeEnabled) { _, newValue in
+            dayLayerCoordinator?.setMultiTypeEnabled(newValue)
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1247,6 +1247,14 @@ struct TimelinePagerView: View {
     /// pinch frame.
     var onFrozenSlotMinutesChange: ((Int?) -> Void)? = nil
     var boundaryExtensionStateOverride: TimelineBoundaryExtensionState? = nil
+    /// Spec 07 §4a / §5 row S4 — `docs/calayer-rewrite/07-day-layer-imperative.md`.
+    /// Optional handle forwarded from `CalendarPageView` so the channels owned
+    /// here (font, time-below, multi-type, horizon, isRangePinchActive,
+    /// recentlyAbsorbed, creationPreviewRange, dragPreviewDayStep) can route
+    /// SwiftUI state writes through the coordinator. Coordinator is nil
+    /// throughout S4 — setters never fire, SwiftUI struct field path into
+    /// `CalendarDayLayerView(...)` is unchanged.
+    var dayLayerCoordinator: DayLayerCoordinator? = nil
 
     // Layout Constants
     private let labelWidth: CGFloat = 26
@@ -1720,6 +1728,11 @@ struct TimelinePagerView: View {
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
             onBoundaryExtensionStateChange?(newValue)
+        }
+        // Spec 07 §5 row S4 — recentlyAbsorbed channel migration to coordinator.
+        // While `dayLayerCoordinator` is nil (S4), this is inert; S5 wires it.
+        .onChange(of: calayerRecentlyAbsorbedParents) { _, newValue in
+            dayLayerCoordinator?.setRecentlyAbsorbedEventIDs(newValue)
         }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1774,6 +1774,11 @@ struct TimelinePagerView: View {
         .onChange(of: calayerTitleFontSizeSetting) { _, newValue in
             dayLayerCoordinator?.setTitleFontSize(newValue)
         }
+        // Spec 07 §5 row S4 — settings: time-below channel migration.
+        // AppStorage owned here. Inert while coordinator is nil (S4).
+        .onChange(of: calayerShowTimeBelowTitle) { _, newValue in
+            dayLayerCoordinator?.setShowTimeBelowTitle(newValue)
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1734,6 +1734,22 @@ struct TimelinePagerView: View {
         .onChange(of: calayerRecentlyAbsorbedParents) { _, newValue in
             dayLayerCoordinator?.setRecentlyAbsorbedEventIDs(newValue)
         }
+        // Spec 07 §5 row S4 — creationPreviewRange channel migration to
+        // coordinator. While `dayLayerCoordinator` is nil (S4), this is inert;
+        // S5 wires it. The imperative day-layer is single-day-only, so the
+        // selected-day entry (dayOffset 0 relative to the coordinator's host)
+        // is the only one S5 will consult; nevertheless replay every per-day
+        // entry into the coordinator's per-day cache to keep the channel
+        // contract complete — `setCreationPreviewRange(nil, for:)` evicts.
+        .onChange(of: creationPreviewByDay) { oldValue, newValue in
+            guard let coord = dayLayerCoordinator else { return }
+            for key in oldValue.keys where newValue[key] == nil {
+                coord.setCreationPreviewRange(nil, for: key)
+            }
+            for (key, range) in newValue {
+                coord.setCreationPreviewRange(range, for: key)
+            }
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1769,6 +1769,11 @@ struct TimelinePagerView: View {
         .onChange(of: isRangePinchActive) { _, newValue in
             dayLayerCoordinator?.setPinchActive(newValue)
         }
+        // Spec 07 §5 row S4 — settings: font channel migration. AppStorage
+        // owned here; observe + push. Inert while coordinator is nil (S4).
+        .onChange(of: calayerTitleFontSizeSetting) { _, newValue in
+            dayLayerCoordinator?.setTitleFontSize(newValue)
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1713,6 +1713,18 @@ struct TimelinePagerView: View {
             .offset(y: boundaryExtensionVisualYOffset)
             .animation(boundaryExtensionAnimation, value: boundaryExtensionHours.leading)
             .animation(boundaryExtensionAnimation, value: boundaryExtensionHours.trailing)
+            // Spec 07 §5 row S4 — dragState mirror channel (dragPreviewDayStep).
+            // The value passed to `CalendarDayLayerView` for the imperative
+            // single-day path is `dayFrameWidth + daySpacing` (`daySpacing` is 0
+            // in single-day mode). Push on first appearance + every geometry
+            // change so the coordinator's mirror reflects the live layout.
+            // While `dayLayerCoordinator` is nil (S4), inert; S5 wires.
+            .onAppear {
+                dayLayerCoordinator?.setDragPreviewDayStep(dayFrameWidth + daySpacing)
+            }
+            .onChange(of: dayFrameWidth) { _, newValue in
+                dayLayerCoordinator?.setDragPreviewDayStep(newValue + daySpacing)
+            }
         }
         .frame(height: totalHeight, alignment: .top)
         .onAppear {

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1750,6 +1750,13 @@ struct TimelinePagerView: View {
                 coord.setCreationPreviewRange(range, for: key)
             }
         }
+        // Spec 07 §5 row S4 — pinch channel (isPinchActive piece). The other
+        // two pinch setters (hourHeight, frozenSlotMinutes) live in
+        // `CalendarPageView`'s pinch modifier; isPinchActive is owned here as
+        // @State so the .onChange must live with it.
+        .onChange(of: isRangePinchActive) { _, newValue in
+            dayLayerCoordinator?.setPinchActive(newValue)
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into


### PR DESCRIPTION
## Summary

Spec 07 §5 row **S4**: migrate 11 state channels from SwiftUI struct field passing on `CalendarDayLayerView(...)` to setter calls on `DayLayerCoordinator`. **Pure addition** — the existing struct field passing is untouched (S5 will cut the SwiftUI representable cord). The `DayLayerCoordinator` instance stays **nil** throughout S4 (no UIScrollView ref is reachable from the SwiftUI struct's scope yet — S5 instantiates), so all `.onChange` handlers call `dayLayerCoordinator?.setX(newValue)` against an optional that never fires. **Zero behavior change.**

This is implementation work done end-to-end by a subagent (`feat/timeline-imperative-day-layer-s4` is its branch). 11 commits, one per channel, build-verified after each.

## Channel order (per spec §5 S4)

| # | Channel | Setter(s) | Owner |
|---|---|---|---|
| 1 | focus | `setFocus(eventID:, occurrenceID:)` | CalendarPageView |
| 2 | grace | `setGraceResize(eventID:, occurrenceID:, opacity:)` | CalendarPageView |
| 3 | recentlyAbsorbed | `setRecentlyAbsorbedEventIDs(_:)` | TimelinePagerView |
| 4 | creationPreviewRange | `setCreationPreviewRange(_:for:)` | TimelinePagerView |
| 5 | pinchHourHeight | `setHourHeight(_:)` + `setPinchActive(_:)` + `setFrozenSlotMinutes(_:)` | split (CPV + TPV) |
| 6 | dragState mirror | `setDragPreviewDayStep(_:)` | TimelinePagerView (GeometryReader scope) |
| 7 | settings: font | `setTitleFontSize(_:)` | TimelinePagerView |
| 8 | settings: time-below | `setShowTimeBelowTitle(_:)` | TimelinePagerView |
| 9 | settings: multi-type | `setMultiTypeEnabled(_:)` | TimelinePagerView |
| 10 | mode | `setMode(_:)` | CalendarPageView |
| 11 | horizon | `setHorizonDays(_:)` | TimelinePagerView |

Total diff: **2 files, +171 / -1**. The `-1` is a trailing-comma reformat from adding the coordinator forward to TimelinePagerView in commit S4.3 — not a real deletion. `CalendarDayLayerView.swift` is untouched.

## Subagent-noted deviations from spec sketch

1. **ViewModifier wrappers for 4 CalendarPageView-side `.onChange`s.** Channel 1 first attempt hit a Swift type-checker timeout on CalendarPageView's already-huge body. Resolved by extracting `.onChange`s into private `ViewModifier`s. Pure mechanical, behavior-identical, established escape hatch.

2. **`dayLayerCoordinator` forwarded into `TimelinePagerView`.** 7 of 11 channels are owned in `TimelinePagerView`, not `CalendarPageView`. The .onChange must live where the state is observable, so the coordinator slot is forwarded as a `TimelinePagerView` prop. Nil throughout S4 → zero behavior change.

3. **Channel 4 `creationPreviewRange`** is a `[Int: Event.TimeRange]` dict. The handler replays every changed entry (~7 entries max) and evicts dropped keys via `setCreationPreviewRange(nil, for:)`. Coordinator's per-day cache handles this; harmless if S5 guards against non-zero offsets.

4. **Channel 6 `dragPreviewDayStep`** is GeometryReader-derived (`dayFrameWidth + daySpacing`), not @State. Mirrored via `.onAppear` + `.onChange(of: dayFrameWidth)` inside the GeometryReader scope.

## Subagent-noted risks (worth eyeballing in review)

1. **Type-checker fragility**: 4 ViewModifier chains added to CalendarPageView body. S5 will add more — watch for the timeout reappearing.
2. **Channel 4 over-mirror**: setter fires for non-zero `dayOffset`s too. Coordinator's setter caches per-day; harmless unless S5 assumes only-dayOffset-0 writes.
3. **Channel 6 seed**: `.onAppear { setDragPreviewDayStep(...) }` fires every appear. Re-fires if GeometryReader re-mounts.
4. **Channel 5 split across 2 files**: hourHeight + frozenSlot in CPV; isPinchActive in TPV. SwiftUI scheduler may reorder independent `.onChange` fires if S5 relies on a strict order.
5. **rangeMode propagation through ViewModifier scope**: presumed fine (existing `.onChange(of: calendarState.rangeMode)` already works in the same body) but worth A/B in S5 dev.

## Test plan

- [ ] Flag OFF + ON: behavior across all paths is byte-identical to king. The added `.onChange` handlers fire (with optional coordinator nil-deref no-op'd), no other state changes.
- [ ] `xcodebuild`: green at every commit + tip (verified by the subagent at each step).
- [ ] Spot-check one channel per file: confirm `.onChange` reads the right state, calls the right setter, doesn't conflict with existing observers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)