### PR TITLE
feat(timeline): #57 spec-07 S5 — cord-cut + coordinator instantiation (the structural keystone)

### DIFF
--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3806,16 +3806,50 @@ private extension CalendarPageView {
             // is still true; we capture the computation closure
             // pointwise so a topOverlayInset / hourHeight change
             // between install and fire is reflected.
-            guard needsScrollToNow else { return }
-            timelineScrollProxy.setOnFirstLayoutReady { [weak timelineScrollProxy] in
-                guard needsScrollToNow else { return }
-                let hourHeight = calendarState.timelineHourHeight
-                let targetY = currentTimeScrollOffset(
-                    topOverlayInset: topOverlayInset,
-                    hourHeight: hourHeight
-                )
-                needsScrollToNow = false
-                timelineScrollProxy?.scrollTo(y: targetY, animated: false)
+            if needsScrollToNow {
+                timelineScrollProxy.setOnFirstLayoutReady { [weak timelineScrollProxy] in
+                    guard needsScrollToNow else { return }
+                    let hourHeight = calendarState.timelineHourHeight
+                    let targetY = currentTimeScrollOffset(
+                        topOverlayInset: topOverlayInset,
+                        hourHeight: hourHeight
+                    )
+                    needsScrollToNow = false
+                    timelineScrollProxy?.scrollTo(y: targetY, animated: false)
+                }
+            }
+            // Spec 07 §5 S5.1: instantiate the imperative day-layer
+            // coordinator the moment the UIScrollView + content host are
+            // wired. Required: the coordinator owns the new
+            // `DayLayerHostView` subtree directly (no `UIViewRepresentable`
+            // cord) and lives inside the scroll view's content view, so it
+            // can't be constructed at struct-init time — the scroll view
+            // doesn't exist yet. The install callback fires exactly once
+            // per `TimelineScrollHost.makeUIView`; the matching uninstall
+            // callback below tears the coordinator down on
+            // `dismantleUIView` so a tab-switch / range-mode flip / flag
+            // flip rebuilds cleanly without leaking a host pinned to a
+            // dead scroll view.
+            //
+            // The setter is keyed off `dayLayerCoordinator` rather than the
+            // flag — so even on flag-OFF cold start the registration is
+            // armed for a later flag-ON flip without a re-onAppear.
+            timelineScrollProxy.setOnScrollViewInstalled { [weak timelineScrollProxy] scrollView, hostContentView in
+                _ = timelineScrollProxy  // capture-only; not used inside.
+                if dayLayerCoordinator == nil {
+                    dayLayerCoordinator = DayLayerCoordinator(
+                        container: hostContentView,
+                        scrollView: scrollView,
+                        dragState: timelineDragState
+                    )
+                }
+            }
+            timelineScrollProxy.setOnScrollViewUninstalled {
+                // Drop the coordinator with the host. S5.2 will add a
+                // `removeHost(...)` call here once the coordinator owns
+                // a real subview; for now releasing the reference is
+                // enough because the coordinator holds no live UIView.
+                dayLayerCoordinator = nil
             }
         }
         .onChange(of: timelineDragState.dragOffset.y) { _, _ in

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -5631,6 +5631,31 @@ private extension CalendarPageView {
 
 // MARK: - Spec 07 §5 row S4 — Day-Layer Coordinator Channel Modifiers
 //
+// S5 channel-coverage verification (spec §5 S5 hard gate).
+//
+//   Grepped 2026-06-19 against this branch (feat/timeline-imperative-day-layer-s5).
+//   Every S4-migrated channel has BOTH the coordinator setter AND the
+//   SwiftUI struct-field path wired — flag-OFF still uses the
+//   representable, flag-ON uses the coordinator-driven host.
+//
+//   Channel              Coordinator setter call site         SwiftUI field path
+//   ─────────────────    ──────────────────────────────────   ────────────────────────────
+//   focus                CPV:5648 (focusedEventID)            TimelineView:2762 (legacy)
+//                        CPV:5651 (focusedOccurrenceID)       TimelineView:2763
+//   grace                CPV:5663 (resizeGraceState)          TimelineView:2764..2766
+//   pinch.hourHeight     CPV:5686 (hourHeight)                TimelineView:2751
+//   pinch.frozenSlot     CPV:5689 (frozenSlotMinutes)         TimelineView:2758
+//   pinch.isActive       TimelineView:1769 (isRangePinchActive)  TimelineView:2757
+//   mode                 CPV:5701 (rangeMode)                 TimelineView:2759 / 2760
+//   recentlyAbsorbed     TimelineView:1746 (calayerRAP)       TimelineView:2768
+//   creationPreview      TimelineView:1756 (creationPreview)  TimelineView:2761
+//   settings.font        TimelineView:1774 (calayerTFSS)      TimelineView:2761 (font)
+//   settings.timeBelow   TimelineView:1779 (calayerSTBT)      TimelineView:2762
+//   settings.multiType   TimelineView:1784 (calayerMTE)       TimelineView:2755
+//   settings.horizon     TimelineView:1789 (nFHD)             TimelineView:2756
+//   dragPreviewDayStep   TimelineView:1722/1725 (onAppear+δ)  TimelineView:2760
+//   dragState mirror     coordinator init/hostCallbacks       TimelineView:2769
+//
 // Each channel migration in S4 adds one `.onChange`-bearing modifier to the
 // `CalendarPageView` body so the (currently nil) `DayLayerCoordinator` will
 // see SwiftUI state changes once S5 instantiates it. Extracted into

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -4114,7 +4114,7 @@ private extension CalendarPageView {
     /// state and are wired separately from its own `.onAppear`. Calling this
     /// repeatedly is safe — every assignment overwrites the previous closure
     /// without leaking observers (`@State` adapter has a stable identity).
-    fileprivate func wireDayLayerDelegateAdapter() {
+    func wireDayLayerDelegateAdapter() {
         dayLayerDelegateAdapter.onEventTap = handleTimelineEventTap
         dayLayerDelegateAdapter.onLongPressBegan = handleTimelineLongPressBegan
         dayLayerDelegateAdapter.onManipulationPromotion = handleTimelineManipulationPromotion

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3836,20 +3836,61 @@ private extension CalendarPageView {
             // armed for a later flag-ON flip without a re-onAppear.
             timelineScrollProxy.setOnScrollViewInstalled { [weak timelineScrollProxy] scrollView, hostContentView in
                 _ = timelineScrollProxy  // capture-only; not used inside.
-                if dayLayerCoordinator == nil {
-                    dayLayerCoordinator = DayLayerCoordinator(
+                let coordinator: DayLayerCoordinator
+                if let existing = dayLayerCoordinator {
+                    coordinator = existing
+                } else {
+                    coordinator = DayLayerCoordinator(
                         container: hostContentView,
                         scrollView: scrollView,
                         dragState: timelineDragState
                     )
+                    dayLayerCoordinator = coordinator
+                }
+                // Spec 07 §5 S5.3: cord-cut. The SwiftUI `buildDayLayerView`
+                // returns `Color.clear` when `usesImperativeDayLayerModel`,
+                // and the coordinator's host fills the slot. Sized to the
+                // hostContentView's bounds with autoresizing flexible (the
+                // host content view is the SwiftUI tree's frame, which
+                // tracks the scroll's `contentLayoutGuide`). Day-N anchor
+                // date is today.
+                if usesImperativeDayLayerModel {
+                    let today = Calendar.current.startOfDay(for: Date())
+                    coordinator.addHost(
+                        dayOffset: 0,
+                        date: today,
+                        frame: hostContentView.bounds
+                    )
                 }
             }
             timelineScrollProxy.setOnScrollViewUninstalled {
-                // Drop the coordinator with the host. S5.2 will add a
-                // `removeHost(...)` call here once the coordinator owns
-                // a real subview; for now releasing the reference is
-                // enough because the coordinator holds no live UIView.
+                // Drop the coordinator with the host. The coordinator owns
+                // the new `DayLayerHostView` subview that was added inside
+                // hostContentView; removeHost detaches it before the
+                // scroll view tears down.
+                dayLayerCoordinator?.removeHost(dayOffset: 0)
                 dayLayerCoordinator = nil
+            }
+        }
+        // Spec 07 §5 S5.3: live A/B for flag flips. The install/uninstall
+        // callbacks above fire only on real scroll-view make/dismantle
+        // (cold start, tab re-entry, range-mode rebuild). When the flag
+        // alone flips mid-session the proxy stays installed; we still
+        // need to add/remove the coordinator's host so the imperative
+        // path engages. The coordinator already exists (the install
+        // callback armed it on cold start) so `addHost` reuses it.
+        .onChange(of: usesImperativeDayLayerModel) { _, isImperative in
+            guard let coordinator = dayLayerCoordinator else { return }
+            if isImperative {
+                let today = Calendar.current.startOfDay(for: Date())
+                let bounds = timelineScrollProxy.contentSize
+                coordinator.addHost(
+                    dayOffset: 0,
+                    date: today,
+                    frame: CGRect(origin: .zero, size: bounds)
+                )
+            } else {
+                coordinator.removeHost(dayOffset: 0)
             }
         }
         .onChange(of: timelineDragState.dragOffset.y) { _, _ in

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -1092,6 +1092,14 @@ struct CalendarPageView: View {
     /// SwiftUI struct field path into `CalendarDayLayerView(...)` as the sole
     /// channel — flag-OFF and flag-ON are byte-identical to king.
     @State private var dayLayerCoordinator: DayLayerCoordinator? = nil
+    /// Spec 07 §5 S5.6 — output delegate adapter for the imperative day-layer
+    /// coordinator. Reference-typed so the coordinator can hold it weakly
+    /// (its delegate slot is `AnyObject`); SwiftUI `View` structs can't be
+    /// the delegate directly. Closures are wired during `body` setup +
+    /// pager-level `.onAppear` so every host-emitted gesture/output fires
+    /// the same handler the SwiftUI representable path used to fire. Always
+    /// allocated — flag-OFF leaves it inert (coordinator never installs it).
+    @State private var dayLayerDelegateAdapter = DayLayerCoordinatorDelegateAdapter()
     @State private var resizeGraceState: CalendarResizeGraceState? = nil
     @State private var resizeGraceOccurrenceContext: CalendarEventOccurrenceContext? = nil
     @State private var resizeGraceFadeTask: Task<Void, Never>? = nil
@@ -3847,6 +3855,14 @@ private extension CalendarPageView {
                     )
                     dayLayerCoordinator = coordinator
                 }
+                // Spec 07 §5 S5.6: wire the output delegate before any host
+                // is attached so the very first gesture (e.g. tap on cold
+                // start) routes through. The page-level handlers are bound
+                // here; `TimelinePagerView` binds its two pager-scoped
+                // handlers (creation-preview-mapping + horizontal-boundary-
+                // page) onto the same adapter from its own `.onAppear`.
+                wireDayLayerDelegateAdapter()
+                coordinator.setOutputDelegate(dayLayerDelegateAdapter)
                 // Spec 07 §5 S5.3: cord-cut. The SwiftUI `buildDayLayerView`
                 // returns `Color.clear` when `usesImperativeDayLayerModel`,
                 // and the coordinator's host fills the slot. Sized to the
@@ -4079,7 +4095,8 @@ private extension CalendarPageView {
                 }
             },
             boundaryExtensionStateOverride: timelineBoundaryExtensionState,
-            dayLayerCoordinator: dayLayerCoordinator
+            dayLayerCoordinator: dayLayerCoordinator,
+            dayLayerDelegateAdapter: dayLayerDelegateAdapter
         )
         // Rebuild when range changes to avoid stale TabView pages across layouts.
         .id(rebuildKey)
@@ -4088,6 +4105,26 @@ private extension CalendarPageView {
     }
 
     // MARK: - Timeline Callback Methods (extracted from timelineLayer)
+
+    /// Spec 07 §5 S5.6: bind every page-level handler to the imperative
+    /// day-layer's output adapter so the coordinator-routed host callbacks
+    /// fan out to the same code paths the SwiftUI representable's closure
+    /// arguments used to. Pager-scoped handlers (`onCreationPreviewChanged`,
+    /// `onHorizontalBoundaryPageRequest`) belong to `TimelinePagerView`'s
+    /// state and are wired separately from its own `.onAppear`. Calling this
+    /// repeatedly is safe — every assignment overwrites the previous closure
+    /// without leaking observers (`@State` adapter has a stable identity).
+    fileprivate func wireDayLayerDelegateAdapter() {
+        dayLayerDelegateAdapter.onEventTap = handleTimelineEventTap
+        dayLayerDelegateAdapter.onLongPressBegan = handleTimelineLongPressBegan
+        dayLayerDelegateAdapter.onManipulationPromotion = handleTimelineManipulationPromotion
+        dayLayerDelegateAdapter.onLongPressResolved = handleTimelineLongPressResolved
+        dayLayerDelegateAdapter.onDragEnded = handleTimelineEventDragEnded
+        dayLayerDelegateAdapter.onResizeEnded = handleTimelineEventResizeEnded
+        dayLayerDelegateAdapter.onCreateEvent = handleTimelineCreateEvent
+        dayLayerDelegateAdapter.onNonEventTap = handleTimelineNonEventTap
+        dayLayerDelegateAdapter.onVisibleTimelineFrameChange = handleVisibleTimelineFrameChange
+    }
 
     func handleTimelineEventTap(_ event: Event, _ date: Date) {
         resetFloatingMenuState()

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -202,37 +202,47 @@ struct CalendarDayLayerView: UIViewRepresentable {
 /// single transaction owner per day live here (spec 06).
 final class DayLayerHostView: UIView {
 
-    /// Immutable per-render inputs. `Equatable` so a no-op `updateUIView` can
-    /// short-circuit without touching the layer tree.
+    /// Per-render inputs. `Equatable` so a no-op `updateUIView` (or
+    /// coordinator-driven `apply`) can short-circuit without touching the
+    /// layer tree.
+    ///
+    /// Spec 07 §5 S5.2 — fields below were originally declared `let` (each
+    /// Model snapshot is treated as immutable by the SwiftUI path that
+    /// rebuilds it whole on every `updateUIView`). The imperative coordinator
+    /// pattern requires in-place field mutation on a CACHED Model so a
+    /// pinch-frame hot-path can update `hourHeight` without re-emitting every
+    /// other field. They were relaxed to `var` with NO semantic change — the
+    /// host still reads them only inside `apply(...)` and the `Equatable`
+    /// short-circuit / value-type semantics keep the SwiftUI path identical.
     struct Model: Equatable {
-        let date: Date
-        let occurrences: [CalendarLayout.EventOccurrence]
-        let contentWidth: CGFloat
-        let headerHeight: CGFloat
-        let hourHeight: CGFloat
-        let eventHorizontalInset: CGFloat
-        let leadingExtendedHours: Int
-        let trailingExtendedHours: Int
+        var date: Date
+        var occurrences: [CalendarLayout.EventOccurrence]
+        var contentWidth: CGFloat
+        var headerHeight: CGFloat
+        var hourHeight: CGFloat
+        var eventHorizontalInset: CGFloat
+        var leadingExtendedHours: Int
+        var trailingExtendedHours: Int
         /// Spec 07: the REAL band window to DRAW grid lines / axis labels for,
         /// kept separate from the 12/12 COORDINATE hours above so the band
         /// regions render EMPTY when closed (positions still use the coordinate
         /// hours). Defaults to equal the coordinate hours ⇒ no slot skipped ⇒
         /// byte-identical on the non-imperative path.
-        let drawableLeadingHours: Int
-        let drawableTrailingHours: Int
+        var drawableLeadingHours: Int
+        var drawableTrailingHours: Int
         /// Spec 07: when true, drag bounds are unbounded (event can be dragged
         /// past the ±12h substrate edge to follow the finger off-canvas, 3-day
         /// parity). See `computedVerticalDragBounds`.
-        let useImperativeDayLayerModel: Bool
-        let showEventText: Bool
-        let isWeekMode: Bool
-        let isThreeDayMode: Bool
-        let titleFontSizeSetting: Double
-        let showTimeBelowTitle: Bool
-        let multiTypeEnabled: Bool
-        let nearFutureHorizonDays: Int
-        let isPinchActive: Bool
-        let frozenSlotMinutes: Int?
+        var useImperativeDayLayerModel: Bool
+        var showEventText: Bool
+        var isWeekMode: Bool
+        var isThreeDayMode: Bool
+        var titleFontSizeSetting: Double
+        var showTimeBelowTitle: Bool
+        var multiTypeEnabled: Bool
+        var nearFutureHorizonDays: Int
+        var isPinchActive: Bool
+        var frozenSlotMinutes: Int?
         // S4 gesture / live-state fields. These do NOT participate in the
         // StructureKey (they don't change overlap topology), but changing
         // them must still re-render (focus dim, drag preview, grace handles).

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -124,19 +124,88 @@ final class DayLayerCoordinator: NSObject {
 
     // MARK: Topology setters (S5 wires)
 
+    /// Construct the `DayLayerHostView` for `dayOffset`, add it as a subview
+    /// of `container`, and push the initial Model snapshot built from the
+    /// coordinator's cached state. Single-day only at S5 (dayOffset 0).
+    ///
+    /// Initial sizing uses `frame` + autoresizing mask; subsequent layout
+    /// changes (rotation, contentSize from a pinch) flow through the
+    /// container's bounds. The autoresizing mask matches the historic
+    /// `CalendarDayLayerView` representable's behavior — the SwiftUI tree
+    /// stretched the day-layer to its parent and the host's
+    /// `layoutSubviews` re-renders accordingly. A later slice may switch
+    /// to explicit Auto Layout constraints; the autoresizing mask gets us
+    /// to behavioral parity without over-fitting the geometry contract.
     func addHost(dayOffset: Int, date: Date, frame: CGRect) {
-        // S5: construct a DayLayerHostView, addSubview to `container`, apply
-        // a Model snapshot constructed from the cached state above.
+        guard dayOffset == 0 else {
+            // Multi-day mode still uses the SwiftUI representable — coordinator
+            // only owns the single-day host. Defensive no-op if a caller asks
+            // for a non-zero offset on this slice.
+            hostDayOffsets.insert(dayOffset)
+            return
+        }
+        // Idempotent: a re-onAppear (tab switch + flag-flip) should reuse the
+        // existing host rather than leak a second subview into the container.
+        if dayHost != nil {
+            hostDayOffsets.insert(dayOffset)
+            return
+        }
+        let host = DayLayerHostView()
+        host.backgroundColor = .clear
+        host.frame = frame
+        host.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // Build the initial Model from the coordinator's cached primitives.
+        // Fields outside the coordinator's setter surface (the 48h-constant
+        // band coordinate hours, plus drawable hours = 0 at rest) default to
+        // the imperative single-day substrate per spec §2A.
+        let initial = DayLayerHostView.Model(
+            date: date,
+            occurrences: occurrencesByDayOffset[dayOffset] ?? [],
+            contentWidth: contentWidthByDayOffset[dayOffset] ?? frame.width,
+            headerHeight: headerHeight,
+            hourHeight: hourHeight,
+            eventHorizontalInset: eventHorizontalInset,
+            leadingExtendedHours: 12,
+            trailingExtendedHours: 12,
+            drawableLeadingHours: bandLeadingOpen ? 12 : 0,
+            drawableTrailingHours: bandTrailingOpen ? 12 : 0,
+            useImperativeDayLayerModel: true,
+            showEventText: showEventText,
+            isWeekMode: false,
+            isThreeDayMode: false,
+            titleFontSizeSetting: titleFontSize,
+            showTimeBelowTitle: showTimeBelowTitle,
+            multiTypeEnabled: multiTypeEnabled,
+            nearFutureHorizonDays: horizonDays,
+            isPinchActive: isPinchActive,
+            frozenSlotMinutes: frozenSlotMinutes,
+            dayColumnStep: 0,
+            dragPreviewDayStep: dragPreviewDayStep,
+            creationPreviewRange: creationPreviewRangeByDayOffset[dayOffset],
+            focusedEventID: focusedEventID,
+            focusedOccurrenceID: focusedOccurrenceID,
+            graceResizeEventID: graceResizeEventID,
+            graceResizeOccurrenceID: graceResizeOccurrenceID,
+            graceResizeHandleOpacity: graceResizeHandleOpacity,
+            isFocusContextActive: focusedEventID != nil,
+            recentlyAbsorbedEventIDs: recentlyAbsorbedEventIDs
+        )
+        cachedModel = initial
+        container.addSubview(host)
+        host.apply(initial, callbacks: hostCallbacks)
+        dayHost = host
         hostDayOffsets.insert(dayOffset)
-        _ = (date, frame)
     }
 
     func removeHost(dayOffset: Int) {
-        // S5: removeFromSuperview + drop any per-host cache entries.
         hostDayOffsets.remove(dayOffset)
         contentWidthByDayOffset.removeValue(forKey: dayOffset)
         creationPreviewRangeByDayOffset.removeValue(forKey: dayOffset)
         occurrencesByDayOffset.removeValue(forKey: dayOffset)
+        guard dayOffset == 0, let host = dayHost else { return }
+        host.removeFromSuperview()
+        dayHost = nil
+        cachedModel = nil
     }
 
     func setMode(_ mode: RangeMode) {

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -276,6 +276,39 @@ final class DayLayerCoordinator: NSObject {
         hostDayOffsets.insert(dayOffset)
     }
 
+    /// Spec 07 §5 S5.7: pin the host's frame to the SwiftUI day-column's
+    /// rect. The SwiftUI tree has an axis column (26pt left) + an all-day
+    /// pill row above the day column; until this is called the host fills
+    /// `container.bounds` (`hostContentView` = the UIHostingController.view)
+    /// which paints events ON TOP of the axis. The page view's placeholder
+    /// publishes its frame in `.global` (window) coords via GeometryReader;
+    /// we convert to container coords here so a viewport pan or rotation
+    /// pushes a fresh frame through the same path. Multi-day still uses the
+    /// SwiftUI representable so no per-column pinning is needed for it.
+    ///
+    /// `globalFrame` is the SwiftUI placeholder's window-space frame. We
+    /// convert it into the coordinator's `container` coordinate space so the
+    /// host (a subview of `container`) gets the right local rect. Passing
+    /// `from: nil` to `UIView.convert(_:from:)` interprets the rect in
+    /// window coords — matching SwiftUI's `.global`.
+    ///
+    /// Switching off autoresizing here so the explicit frame sticks: with
+    /// the mask on, a subsequent `container.bounds` change (rotation,
+    /// pinch-driven contentSize) would stretch the host BACK to fill
+    /// `container`, defeating the purpose. The placeholder's GeometryReader
+    /// re-publishes on those same events, so explicit-frame ownership keeps
+    /// the host in sync.
+    func setHostFrame(_ globalFrame: CGRect, for dayOffset: Int) {
+        guard dayOffset == 0, let host = dayHost else { return }
+        guard globalFrame.width > 0, globalFrame.height > 0 else { return }
+        let frameInContainer = container.convert(globalFrame, from: nil)
+        if host.autoresizingMask != [] {
+            host.autoresizingMask = []
+        }
+        guard host.frame != frameInContainer else { return }
+        host.frame = frameInContainer
+    }
+
     func removeHost(dayOffset: Int) {
         hostDayOffsets.remove(dayOffset)
         contentWidthByDayOffset.removeValue(forKey: dayOffset)

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -108,8 +108,10 @@ final class DayLayerCoordinator: NSObject {
     private var cachedModel: DayLayerHostView.Model?
 
     /// Callbacks the coordinator forwards to the host on each push. Wired in
-    /// S5.3 from the page view (delegate-style); for now an empty struct so
-    /// the apply signature compiles. Output edges go through `delegate`.
+    /// `addHost` (S5.6) so every host-emitted gesture/output closure routes
+    /// through `delegate?.dayLayer_onX(...)` — the page view's adapter then
+    /// dispatches to the existing SwiftUI-path handlers. Until a delegate is
+    /// installed via `setOutputDelegate`, output edges are no-ops.
     private var hostCallbacks = DayLayerHostView.Callbacks()
 
     // MARK: Lifecycle
@@ -119,7 +121,84 @@ final class DayLayerCoordinator: NSObject {
         self.scrollView = scrollView
         self.dragState = dragState
         super.init()
-        hostCallbacks.dragState = dragState
+        hostCallbacks = makeHostCallbacks()
+    }
+
+    /// Install (or replace) the output delegate. Re-`apply`s the host with the
+    /// freshly-built `hostCallbacks` so an existing host picks up the new
+    /// delegate routing without waiting for the next setter-driven update.
+    /// Passing `nil` detaches the delegate; subsequent host-emitted closures
+    /// land on a nil delegate and silently no-op (the safe failure mode).
+    func setOutputDelegate(_ delegate: DayLayerCoordinatorDelegate?) {
+        self.delegate = delegate
+        // Rebuild closures so they capture the (new) `self.delegate` indirectly
+        // through the weak reference. The closures already read `self.delegate`
+        // on each call, so a rebuild isn't strictly required — but doing so
+        // keeps `hostCallbacks`'s identity in lockstep with the delegate state
+        // for tests / future field additions, and the cost is one struct
+        // assignment per delegate install.
+        hostCallbacks = makeHostCallbacks()
+        guard let model = cachedModel, let host = dayHost else { return }
+        host.apply(model, callbacks: hostCallbacks)
+    }
+
+    /// Build the `DayLayerHostView.Callbacks` struct that fans every host
+    /// output closure through the coordinator's `delegate`. The closures
+    /// capture `self` weakly so the host doesn't extend the coordinator's
+    /// lifetime; a nil-self capture is a defensive no-op consistent with the
+    /// "output edge fires after teardown" race the adapter guards against.
+    private func makeHostCallbacks() -> DayLayerHostView.Callbacks {
+        DayLayerHostView.Callbacks(
+            dragState: dragState,
+            onEventTap: { [weak self] event, date in
+                self?.delegate?.dayLayer_onEventTap(event, on: date)
+            },
+            onEventLongPressBegan: { [weak self] began in
+                self?.delegate?.dayLayer_onLongPressBegan(began)
+            },
+            onEventManipulationPromotion: { [weak self] event, occID, date, mode, point, frame in
+                self?.delegate?.dayLayer_onManipulationPromotion(
+                    event, occurrenceID: occID, date: date,
+                    mode: mode, point: point, frame: frame
+                )
+            },
+            onEventLongPressResolved: { [weak self] resolution in
+                self?.delegate?.dayLayer_onLongPressResolved(resolution)
+            },
+            onEventDragEnded: { [weak self] event, occID, range, offset, hourHeight in
+                self?.delegate?.dayLayer_onDragEnded(
+                    event, occurrenceID: occID, range: range,
+                    offset: offset, hourHeight: hourHeight
+                )
+            },
+            onEventResizeEnded: { [weak self] event, occID, range, anchor, mode, hourHeight in
+                self?.delegate?.dayLayer_onResizeEnded(
+                    event, occurrenceID: occID, range: range,
+                    anchor: anchor, mode: mode, hourHeight: hourHeight
+                )
+            },
+            onCreateEvent: { [weak self] range in
+                // The host-emitted `onCreateEvent` is a SINGLE-day range scoped
+                // to the host's `model.date`. The legacy SwiftUI representable
+                // path wrapped this with the day-column's date (see
+                // `buildLegacyDayLayerView`); we read it back off the cached
+                // Model so the delegate signature matches.
+                guard let self, let model = self.cachedModel else { return }
+                self.delegate?.dayLayer_onCreateEvent(range, on: model.date)
+            },
+            onCreationPreviewChanged: { [weak self] day, range in
+                self?.delegate?.dayLayer_onCreationPreviewChanged(day, range: range)
+            },
+            onNonEventTap: { [weak self] in
+                self?.delegate?.dayLayer_onNonEventTap()
+            },
+            onHorizontalBoundaryPageRequest: { [weak self] direction in
+                self?.delegate?.dayLayer_onHorizontalBoundaryPageRequest(direction: direction) ?? false
+            },
+            onVisibleTimelineFrameChange: { [weak self] frame in
+                self?.delegate?.dayLayer_onVisibleTimelineFrameChange(frame)
+            }
+        )
     }
 
     // MARK: Topology setters (S5 wires)
@@ -361,6 +440,8 @@ final class DayLayerCoordinator: NSObject {
     }
 }
 
+// MARK: - Output delegate
+
 /// Output channel back to the page view. Mirrors the closure callbacks
 /// currently passed to `CalendarDayLayerView` via the representable's
 /// initializer — the SwiftUI Bindings become coordinator-issued delegate
@@ -398,4 +479,89 @@ protocol DayLayerCoordinatorDelegate: AnyObject {
     func dayLayer_onNonEventTap()
     func dayLayer_onHorizontalBoundaryPageRequest(direction: Int) -> Bool
     func dayLayer_onVisibleTimelineFrameChange(_ rect: CGRect)
+}
+
+// MARK: - Delegate adapter
+
+/// Closure-backed conformance to `DayLayerCoordinatorDelegate`.
+///
+/// `CalendarPageView` is a SwiftUI `View` (a value type) so it can't itself be
+/// the `AnyObject` delegate the coordinator holds weakly. This adapter is a
+/// reference-typed bridge: the page view stores it in `@State`, wires each
+/// closure to the existing SwiftUI-path handler (`handleTimelineEventTap`,
+/// etc.), then hands the adapter to `coordinator.setOutputDelegate(_:)`.
+///
+/// Two closures (`onCreationPreviewChanged`, `onHorizontalBoundaryPageRequest`)
+/// are owned by `TimelinePagerView` rather than `CalendarPageView` because the
+/// existing handlers (`updateCreationPreviewMapping`, the inline
+/// `requestHorizontalBoundaryPage` lambda) live on the pager view's state.
+/// Both views write to the same adapter instance; nil-closures no-op so
+/// either side may install before the other.
+@MainActor
+final class DayLayerCoordinatorDelegateAdapter: NSObject, DayLayerCoordinatorDelegate {
+    var onEventTap: ((Event, Date) -> Void)?
+    var onLongPressBegan: ((CalendarEventLongPressBegan) -> Void)?
+    var onManipulationPromotion: ((Event, String?, Date, EventDragMode, CGPoint, CGRect) -> Void)?
+    var onLongPressResolved: ((CalendarEventLongPressResolution) -> Void)?
+    var onDragEnded: ((Event, String?, Event.TimeRange, DragOffset, CGFloat) -> Void)?
+    var onResizeEnded: ((Event, String?, Event.TimeRange, Date, EventDragMode, CGFloat) -> Void)?
+    var onCreateEvent: ((Date, Event.TimeRange) -> Void)?
+    var onCreationPreviewChanged: ((Date, Event.TimeRange?) -> Void)?
+    var onNonEventTap: (() -> Void)?
+    var onHorizontalBoundaryPageRequest: ((Int) -> Bool)?
+    var onVisibleTimelineFrameChange: ((CGRect) -> Void)?
+
+    func dayLayer_onEventTap(_ event: Event, on date: Date) {
+        onEventTap?(event, date)
+    }
+    func dayLayer_onLongPressBegan(_ began: CalendarEventLongPressBegan) {
+        onLongPressBegan?(began)
+    }
+    func dayLayer_onManipulationPromotion(
+        _ event: Event,
+        occurrenceID: String?,
+        date: Date,
+        mode: EventDragMode,
+        point: CGPoint,
+        frame: CGRect
+    ) {
+        onManipulationPromotion?(event, occurrenceID, date, mode, point, frame)
+    }
+    func dayLayer_onLongPressResolved(_ resolution: CalendarEventLongPressResolution) {
+        onLongPressResolved?(resolution)
+    }
+    func dayLayer_onDragEnded(
+        _ event: Event,
+        occurrenceID: String?,
+        range: Event.TimeRange,
+        offset: DragOffset,
+        hourHeight: CGFloat
+    ) {
+        onDragEnded?(event, occurrenceID, range, offset, hourHeight)
+    }
+    func dayLayer_onResizeEnded(
+        _ event: Event,
+        occurrenceID: String?,
+        range: Event.TimeRange,
+        anchor: Date,
+        mode: EventDragMode,
+        hourHeight: CGFloat
+    ) {
+        onResizeEnded?(event, occurrenceID, range, anchor, mode, hourHeight)
+    }
+    func dayLayer_onCreateEvent(_ range: Event.TimeRange, on date: Date) {
+        onCreateEvent?(date, range)
+    }
+    func dayLayer_onCreationPreviewChanged(_ day: Date, range: Event.TimeRange?) {
+        onCreationPreviewChanged?(day, range)
+    }
+    func dayLayer_onNonEventTap() {
+        onNonEventTap?()
+    }
+    func dayLayer_onHorizontalBoundaryPageRequest(direction: Int) -> Bool {
+        onHorizontalBoundaryPageRequest?(direction) ?? false
+    }
+    func dayLayer_onVisibleTimelineFrameChange(_ rect: CGRect) {
+        onVisibleTimelineFrameChange?(rect)
+    }
 }

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -83,6 +83,35 @@ final class DayLayerCoordinator: NSObject {
     private(set) var bandLeadingOpen: Bool = false
     private(set) var bandTrailingOpen: Bool = false
 
+    // MARK: Host attachment + cached Model (S5.2)
+    //
+    // The coordinator OWNS a single `DayLayerHostView` instance in single-day
+    // mode (3-day/week stays on the SwiftUI representable for now). The host
+    // is created by `addHost(...)` in S5.3 and apply-pushed every time a
+    // coordinator setter mutates the cached Model. Until then both slots
+    // are nil and every setter is push-inert — only the `private(set) var`
+    // cache above is updated, identical to S3/S4 behavior.
+    //
+    // Why a CACHED Model rather than rebuilding on each push: per spec §4b
+    // point 2, hot-path callers (`setHourHeight` during pinch, drag mirror)
+    // MUST update the cached Model FIRST then call `host.repaintVertical(_:)`
+    // — never push a stale Model on a later slow-path apply. The cached
+    // Model is the source of truth.
+
+    /// Active host for `dayOffset == 0` (single-day). Multi-host topologies
+    /// (3-day / week) will key by dayOffset in a later slice.
+    private var dayHost: DayLayerHostView?
+
+    /// Latest Model snapshot pushed to (or about to be pushed to) the host.
+    /// `nil` until `addHost(...)` constructs the host. After that, every
+    /// setter mutates the corresponding field here and re-`apply`s.
+    private var cachedModel: DayLayerHostView.Model?
+
+    /// Callbacks the coordinator forwards to the host on each push. Wired in
+    /// S5.3 from the page view (delegate-style); for now an empty struct so
+    /// the apply signature compiles. Output edges go through `delegate`.
+    private var hostCallbacks = DayLayerHostView.Callbacks()
+
     // MARK: Lifecycle
 
     init(container: UIView, scrollView: UIScrollView, dragState: EventDragState) {
@@ -90,6 +119,7 @@ final class DayLayerCoordinator: NSObject {
         self.scrollView = scrollView
         self.dragState = dragState
         super.init()
+        hostCallbacks.dragState = dragState
     }
 
     // MARK: Topology setters (S5 wires)
@@ -111,14 +141,21 @@ final class DayLayerCoordinator: NSObject {
 
     func setMode(_ mode: RangeMode) {
         self.mode = mode
+        updateModel { m in
+            m.isWeekMode = (mode == .week)
+            m.isThreeDayMode = (mode == .threeDay)
+        }
     }
 
     func setContentWidth(_ width: CGFloat, for dayOffset: Int) {
         contentWidthByDayOffset[dayOffset] = width
+        guard dayOffset == 0 else { return }
+        updateModel { $0.contentWidth = width }
     }
 
     func setDragPreviewDayStep(_ step: CGFloat) {
         dragPreviewDayStep = step
+        updateModel { $0.dragPreviewDayStep = step }
     }
 
     // MARK: Band-inset writes — the 48h model's only band channel
@@ -133,16 +170,26 @@ final class DayLayerCoordinator: NSObject {
 
     // MARK: Hot-path sync writes (60-120 Hz during pinch)
 
+    /// Pinch hot path. Spec §4b point 2: cached `Model` MUST be updated FIRST
+    /// then the host's fast `repaintVertical(_:)` path may run — never the
+    /// reverse, or a later non-hot-path `apply` reads a stale `Model` and
+    /// reverts the geometry the fast path painted. The `apply(_:callbacks:)`
+    /// call below is the slow path; `repaintVertical` is reached transitively
+    /// through `layoutSubviews` when the StructureKey is unchanged (the
+    /// pinch case), so the same call covers both.
     func setHourHeight(_ height: CGFloat) {
         hourHeight = height
+        updateModel { $0.hourHeight = height }
     }
 
     func setPinchActive(_ active: Bool) {
         isPinchActive = active
+        updateModel { $0.isPinchActive = active }
     }
 
     func setFrozenSlotMinutes(_ minutes: Int?) {
         frozenSlotMinutes = minutes
+        updateModel { $0.frozenSlotMinutes = minutes }
     }
 
     // MARK: Focus / grace / drag / absorb broadcasts
@@ -150,16 +197,27 @@ final class DayLayerCoordinator: NSObject {
     func setFocus(eventID: UUID?, occurrenceID: String?) {
         focusedEventID = eventID
         focusedOccurrenceID = occurrenceID
+        updateModel { m in
+            m.focusedEventID = eventID
+            m.focusedOccurrenceID = occurrenceID
+            m.isFocusContextActive = (eventID != nil)
+        }
     }
 
     func setGraceResize(eventID: UUID?, occurrenceID: String?, opacity: Double) {
         graceResizeEventID = eventID
         graceResizeOccurrenceID = occurrenceID
         graceResizeHandleOpacity = opacity
+        updateModel { m in
+            m.graceResizeEventID = eventID
+            m.graceResizeOccurrenceID = occurrenceID
+            m.graceResizeHandleOpacity = opacity
+        }
     }
 
     func setRecentlyAbsorbedEventIDs(_ ids: Set<UUID>) {
         recentlyAbsorbedEventIDs = ids
+        updateModel { $0.recentlyAbsorbedEventIDs = ids }
     }
 
     func setCreationPreviewRange(_ range: Event.TimeRange?, for dayOffset: Int) {
@@ -168,40 +226,69 @@ final class DayLayerCoordinator: NSObject {
         } else {
             creationPreviewRangeByDayOffset.removeValue(forKey: dayOffset)
         }
+        guard dayOffset == 0 else { return }
+        updateModel { $0.creationPreviewRange = range }
     }
 
     func setOccurrences(_ occs: [CalendarLayout.EventOccurrence], for dayOffset: Int) {
         occurrencesByDayOffset[dayOffset] = occs
+        guard dayOffset == 0 else { return }
+        updateModel { $0.occurrences = occs }
     }
 
     // MARK: One-time chrome / setting writes
 
     func setHeaderHeight(_ h: CGFloat) {
         headerHeight = h
+        updateModel { $0.headerHeight = h }
     }
 
     func setEventHorizontalInset(_ inset: CGFloat) {
         eventHorizontalInset = inset
+        updateModel { $0.eventHorizontalInset = inset }
     }
 
     func setTitleFontSize(_ size: Double) {
         titleFontSize = size
+        updateModel { $0.titleFontSizeSetting = size }
     }
 
     func setShowTimeBelowTitle(_ on: Bool) {
         showTimeBelowTitle = on
+        updateModel { $0.showTimeBelowTitle = on }
     }
 
     func setMultiTypeEnabled(_ on: Bool) {
         multiTypeEnabled = on
+        updateModel { $0.multiTypeEnabled = on }
     }
 
     func setHorizonDays(_ days: Int) {
         horizonDays = days
+        updateModel { $0.nearFutureHorizonDays = days }
     }
 
     func setShowEventText(_ on: Bool) {
         showEventText = on
+        updateModel { $0.showEventText = on }
+    }
+
+    // MARK: Cached-Model mutation helper (S5.2)
+
+    /// Mutate the cached Model in-place and re-`apply` to the live host.
+    /// If either is nil (no host attached yet — S5.3 hasn't fired addHost,
+    /// or coordinator is in single-day-off mode), the mutator is a no-op.
+    ///
+    /// Per spec §4b point 1, the host's existing `visualStateEqual`
+    /// short-circuit handles the per-frame cost: only the changed field
+    /// triggers a repaint, and pure visual-only field changes skip the
+    /// full overlap rebuild via the cheap pinch path.
+    private func updateModel(_ mutate: (inout DayLayerHostView.Model) -> Void) {
+        guard var model = cachedModel else { return }
+        mutate(&model)
+        guard cachedModel != model else { return }
+        cachedModel = model
+        dayHost?.apply(model, callbacks: hostCallbacks)
     }
 }
 

--- a/Done/Views/Calendar/Components/Timeline/TimelineScrollHost.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineScrollHost.swift
@@ -327,6 +327,64 @@ final class TimelineScrollProxy: ObservableObject {
         onFirstLayoutReady = callback
     }
 
+    // MARK: Spec 07 §5 S5.1 — scroll-view installed signal
+    //
+    // Fired exactly once when `TimelineScrollHost.makeUIView` has wired up
+    // the `UIScrollView` + the host content view. Used by the imperative
+    // day-layer path to instantiate `DayLayerCoordinator` with a live
+    // `UIScrollView` reference + the content host UIView. The proxy's
+    // `scrollView` / `hostContentView` weak refs aren't enough on their own
+    // because the page view needs an EDGE notification (so it can react
+    // exactly once when the refs become non-nil — observing the weak refs
+    // by polling reintroduces the lifecycle races the proxy was designed
+    // to avoid). Pattern mirrors `setOnFirstLayoutReady` above.
+    //
+    // If the scroll view is ALREADY installed when the callback is
+    // registered (e.g. flag-flip mid-session), fire on the next runloop
+    // tick. Otherwise hold until `makeUIView` reaches the install line.
+
+    /// One-shot callback fired by `makeUIView` after the scroll view and
+    /// hosted content view are wired into the proxy. Auto-cleared after
+    /// firing so it can be re-armed across host install/dismantle cycles
+    /// (tab switches, flag flips, range-mode rebuilds).
+    fileprivate var onScrollViewInstalled: ((UIScrollView, UIView) -> Void)?
+
+    /// Persistent callback fired by `dismantleUIView` so the imperative
+    /// coordinator can detach its host subview before the scroll view goes
+    /// away. Survives across install/dismantle cycles so the page view
+    /// only registers it once.
+    fileprivate var onScrollViewUninstalled: (() -> Void)?
+
+    /// Register a one-shot callback for the "scroll view + content host
+    /// wired" edge. Replaces any prior callback. If the scroll view is
+    /// ALREADY wired when this is called, fires on the next runloop tick.
+    func setOnScrollViewInstalled(_ callback: @escaping (UIScrollView, UIView) -> Void) {
+        if let sv = scrollView, let host = hostContentView {
+            DispatchQueue.main.async { callback(sv, host) }
+            return
+        }
+        onScrollViewInstalled = callback
+    }
+
+    /// Register a persistent callback fired on each dismantle. Replaces
+    /// any prior callback. Used by the imperative day-layer path to drop
+    /// its host subview so the coordinator can re-add it cleanly on the
+    /// next install.
+    func setOnScrollViewUninstalled(_ callback: @escaping () -> Void) {
+        onScrollViewUninstalled = callback
+    }
+
+    fileprivate func fireOnScrollViewInstalledIfNeeded() {
+        guard let sv = scrollView, let host = hostContentView else { return }
+        let callback = onScrollViewInstalled
+        onScrollViewInstalled = nil
+        callback?(sv, host)
+    }
+
+    fileprivate func fireOnScrollViewUninstalled() {
+        onScrollViewUninstalled?()
+    }
+
     fileprivate func fireFirstLayoutReadyIfNeeded() {
         guard !didFireFirstLayoutReady else { return }
         guard let sv = scrollView,
@@ -464,6 +522,13 @@ struct TimelineScrollHost<Content: View>: UIViewRepresentable {
         proxy.didFireFirstLayoutReady = false
         context.coordinator.host = host
 
+        // Spec 07 §5 S5.1: signal to the page view that the scroll view +
+        // content host are now wired. This is the only point at which the
+        // imperative day-layer coordinator can be constructed — the
+        // `UIScrollView` reference doesn't exist before this and a
+        // dismantle-then-remake (tab switch) replaces it.
+        proxy.fireOnScrollViewInstalledIfNeeded()
+
         return container
     }
 
@@ -506,6 +571,11 @@ struct TimelineScrollHost<Content: View>: UIViewRepresentable {
     }
 
     static func dismantleUIView(_ container: ContainerView, coordinator: Coordinator) {
+        // Spec 07 §5 S5.1: notify the imperative day-layer path that the
+        // scroll view is going away so the coordinator can drop its host
+        // subview BEFORE we tear the hosting controller down.
+        container.proxy?.fireOnScrollViewUninstalled()
+
         if let host = coordinator.host {
             host.willMove(toParent: nil)
             host.view.removeFromSuperview()

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1255,6 +1255,12 @@ struct TimelinePagerView: View {
     /// throughout S4 — setters never fire, SwiftUI struct field path into
     /// `CalendarDayLayerView(...)` is unchanged.
     var dayLayerCoordinator: DayLayerCoordinator? = nil
+    /// Spec 07 §5 S5.6 — pager-scoped delegate-closure binding target. The
+    /// adapter is owned by `CalendarPageView` (`@State`); we install our two
+    /// pager-scoped handlers (creation-preview-mapping + horizontal-boundary-
+    /// page) onto it from `.onAppear`. Always non-nil when handed in; the
+    /// nil default keeps test harnesses + flag-OFF byte-identical.
+    var dayLayerDelegateAdapter: DayLayerCoordinatorDelegateAdapter? = nil
 
     // Layout Constants
     private let labelWidth: CGFloat = 26
@@ -1737,6 +1743,21 @@ struct TimelinePagerView: View {
             // non-none.
             refreshCachedRawBoundaryExtensionState()
             onBoundaryExtensionStateChange?(rawBoundaryExtensionState)
+            // Spec 07 §5 S5.6: bind the two pager-scoped handlers onto the
+            // page view's delegate adapter so the imperative day-layer's
+            // host callbacks reach the SAME entry points the SwiftUI
+            // representable closures hit (`updateCreationPreviewMapping`,
+            // the inline horizontal-boundary-page lambda). Re-bound on
+            // every `.onAppear` so a pager rebuild after a range-mode
+            // flip / tab re-entry refreshes the closures against the
+            // latest `self` capture — adapter has stable identity, so
+            // the writes overwrite rather than stack.
+            dayLayerDelegateAdapter?.onCreationPreviewChanged = { day, range in
+                updateCreationPreviewMapping(day: day, range: range)
+            }
+            dayLayerDelegateAdapter?.onHorizontalBoundaryPageRequest = { direction in
+                requestHorizontalBoundaryPage(direction: direction)
+            }
         }
         .onChange(of: rawBoundaryExtensionState) { _, newValue in
             onBoundaryExtensionStateChange?(newValue)
@@ -2861,6 +2882,34 @@ struct TimelinePagerView: View {
     private func dayDate(forOffset offset: Int, calendar: Calendar = .current) -> Date {
         let today = calendar.startOfDay(for: Date())
         return calendar.date(byAdding: .day, value: offset, to: today) ?? today
+    }
+
+    /// Spec 07 §5 S5.6 — extracted from the inline `requestHorizontalBoundaryPage`
+    /// lambda inside body so the day-layer coordinator adapter can reuse the
+    /// same logic. Behavioural parity (single-day only, no-op when direction
+    /// resolves to the current page) is preserved at the predicate level.
+    fileprivate func requestHorizontalBoundaryPage(direction: Int) -> Bool {
+        let centeredRange = centeredOffsetsRange()
+        guard daysCount == 1, direction != 0 else { return false }
+        let targetOffset = selectedDayOffset + direction
+        let resolvedTarget = calendarTimelineResolvedCenteredDayOffset(
+            requestedDayOffset: targetOffset,
+            centeredRange: centeredRange,
+            deferOutOfRangeSelection: false
+        ) ?? targetOffset
+        guard resolvedTarget != selectedDayOffset else { return false }
+        calendarDebugLog(
+            "timeline.horizontalBoundaryPage.request",
+            fields: [
+                "direction": "\(direction)",
+                "selectedDayOffset": "\(selectedDayOffset)",
+                "targetOffset": "\(targetOffset)",
+                "resolvedTarget": "\(resolvedTarget)",
+                "via": "delegate"
+            ]
+        )
+        selectedDayOffset = resolvedTarget
+        return true
     }
 
     private func updateCreationPreviewMapping(day: Date, range: Event.TimeRange?) {

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2688,6 +2688,43 @@ struct TimelinePagerView: View {
         isFocusContextActive: Bool,
         onHorizontalBoundaryPageRequest: ((Int) -> Bool)?
     ) -> some View {
+        // Spec 07 §5 S5.3: cord-cut on imperative single-day. The day-layer
+        // is owned by `DayLayerCoordinator` and rendered as a sibling
+        // `DayLayerHostView` subview of the UIScrollView's content host —
+        // not through the SwiftUI representable. The SwiftUI slot becomes
+        // a transparent placeholder sized to the same frame the
+        // representable used (`dayWidth × timelineHeight`) so the day-column
+        // layout (axis to the left, all-day pills above) stays untouched
+        // and the coordinator's host overlays it. Multi-day still uses the
+        // representable — preserves the SwiftUI multi-host pager behavior.
+        if shouldUseExtendedBandWindow {
+            Color.clear
+                .frame(width: dayWidth, height: timelineHeight, alignment: .top)
+        } else {
+            buildLegacyDayLayerView(
+                for: offset,
+                date: date,
+                dayWidth: dayWidth,
+                dayColumnStep: dayColumnStep,
+                dragPreviewDayStep: dragPreviewDayStep,
+                previewRange: previewRange,
+                isFocusContextActive: isFocusContextActive,
+                onHorizontalBoundaryPageRequest: onHorizontalBoundaryPageRequest
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func buildLegacyDayLayerView(
+        for offset: Int,
+        date: Date,
+        dayWidth: CGFloat,
+        dayColumnStep: CGFloat,
+        dragPreviewDayStep: CGFloat,
+        previewRange: Event.TimeRange?,
+        isFocusContextActive: Bool,
+        onHorizontalBoundaryPageRequest: ((Int) -> Bool)?
+    ) -> some View {
         let dayOccurrences = CalendarLayout.timelineVisibleOccurrences(
             forDayOffset: offset,
             leadingExtendedHours: occurrenceExtensionHoursForDrag.leading,

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2727,8 +2727,25 @@ struct TimelinePagerView: View {
         // needed during auto-collapse. Legacy / multi-day paths still wear
         // the mask inside `buildLegacyDayLayerView` below.
         if shouldUseExtendedBandWindow {
+            // Spec 07 §5 S5.7: publish the placeholder's frame in window
+            // (`.global`) coords to the coordinator on every layout change.
+            // The coordinator converts to its container's coord space and
+            // pins `dayHost.frame` accordingly. Without this the host wears
+            // `container.bounds` (full hostContentView) and paints events
+            // on top of the axis / shifted left of the day column.
+            //
+            // `.onGeometryChange` (vs `GeometryReader { Color.clear }`) is
+            // a leaf-shaped frame observer — does NOT inject a SwiftUI
+            // subtree above the placeholder, so it doesn't alter parent
+            // layout. Fires on first appearance + every frame mutation
+            // (pinch contentSize, rotation, all-day-row growth).
             Color.clear
                 .frame(width: dayWidth, height: timelineHeight, alignment: .top)
+                .onGeometryChange(for: CGRect.self) { proxy in
+                    proxy.frame(in: .global)
+                } action: { globalFrame in
+                    dayLayerCoordinator?.setHostFrame(globalFrame, for: 0)
+                }
         } else {
             buildLegacyDayLayerView(
                 for: offset,

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2697,6 +2697,14 @@ struct TimelinePagerView: View {
         // layout (axis to the left, all-day pills above) stays untouched
         // and the coordinator's host overlays it. Multi-day still uses the
         // representable — preserves the SwiftUI multi-host pager behavior.
+        //
+        // Spec 07 §5 S5.4 / §10 Q3: `extensionFadeMask` is INTENTIONALLY
+        // omitted from this placeholder. The mask papered over a stale
+        // 1-frame band-close mismatch in the SwiftUI path; the 48h-constant
+        // coordinate model removes that mismatch at the math level (band
+        // visibility = `contentInset`, never `contentSize`), so no fade is
+        // needed during auto-collapse. Legacy / multi-day paths still wear
+        // the mask inside `buildLegacyDayLayerView` below.
         if shouldUseExtendedBandWindow {
             Color.clear
                 .frame(width: dayWidth, height: timelineHeight, alignment: .top)


### PR DESCRIPTION
## Summary

Spec 07 §5 row **S5**: cut the `CalendarDayLayerView` `UIViewRepresentable` cord in single-day imperative mode and have `DayLayerCoordinator` OWN the `DayLayerHostView` subtree directly. Most structural slice in the arc; the moment the coordinator-driven path goes live behind the existing flag.

Subagent-executed end-to-end. 8 commits, +719/-36 across 5 files. `xcodebuild` green per commit.

## What lands

| # | Commit | Scope |
|---|---|---|
| S5.1 | `47c3dd6` | `DayLayerCoordinator` real instantiation. `TimelineScrollProxy` gains `onScrollViewInstalled` / `onScrollViewUninstalled` callbacks fired from `makeUIView` / `dismantleUIView`. CalendarPageView registers the install callback to construct the coordinator with real `(container, scrollView, dragState)`. |
| S5.2 | `7561d49` | Coordinator setters live: each mutates `cachedModel` + calls `host.apply(model:callbacks:)`. `DayLayerHostView.Model`'s previously-`let` fields relaxed to `var` (Equatable + memberwise init preserved). |
| S5.3 | `d71a058` | The cord cut. `buildDayLayerView` returns `Color.clear` on imperative single-day; legacy path moved to `buildLegacyDayLayerView`. `coordinator.addHost(...)` fires from both install-time and `usesImperativeDayLayerModel` flag-flip triggers. |
| S5.4 | `bc9166e` | `extensionFadeMask` structurally gone from imperative path (Color.clear has no mask applied; mask was for stale-band frame on contentSize-mutating legacy). |
| S5.5 | `6d8d141` | Spec-mandated grep verification of S4 channel coverage — inventory table pinned in CalendarPageView. |
| S5.6 | `493534e` | Host output callbacks wired via `DayLayerCoordinatorDelegateAdapter` (ref-type adapter; `View` structs can't be `AnyObject`). Closes the functional gap where flag-ON renders events but didn't propagate tap/longPress/dragEnd/resizeEnd/create. |
| S5.7 | `25d9db6` | Host frame pinned to the SwiftUI day-column geometry via `.onGeometryChange` on the `Color.clear` placeholder → `coordinator.setHostFrame(_:for:)`. Solves the "events painted under the axis" risk. |
| chore | `6d554bb` | Drop redundant `fileprivate` on `wireDayLayerDelegateAdapter`. |

## Architectural decisions worth noting

1. **Coordinator wiring via deferred callback**, not init-at-construction. The `UIScrollView` doesn't exist at SwiftUI struct construction time, so `TimelineScrollProxy` exposes `onScrollViewInstalled: ((UIScrollView, UIView) -> Void)?` fired from `TimelineScrollHost.makeUIView`. CalendarPageView's existing `.onAppear` registers the callback and stores the coordinator in the S4-declared `@State`.

2. **Delegate via ref-type adapter** (`DayLayerCoordinatorDelegateAdapter`), not direct CalendarPageView conformance. SwiftUI `View` structs can't be `AnyObject`. Adapter holds closures the page view assigns in `wireDayLayerDelegateAdapter()`.

3. **`DayLayerHostView` as a SIBLING SUBVIEW** of the scroll content (not via a new `UIHostingController`). The existing SwiftUI tree stays in the existing host; the day-layer slot inside it becomes `Color.clear`; the new `DayLayerHostView` is added directly to `container`.

4. **Host frame pinning via `.onGeometryChange`** on the `Color.clear` placeholder reading `proxy.frame(in: .global)` → `coordinator.setHostFrame(globalFrame, for: 0)` → `container.convert(globalFrame, from: nil)` → `dayHost.frame = frameInContainer` + `autoresizingMask = []`.

## Hard gate verification (spec §5 S5)

Spec says: "Verify by grep over CalendarPageView.swift that no channel is still only on the SwiftUI representable path (every channel either reads from coordinator.<setter> or has both paths wired)."

S5.5 pinned an inventory table in CalendarPageView above the S4 modifier definitions covering all 11 channels (focus / grace / recentlyAbsorbed / creationPreviewRange / pinchHourHeight / dragState mirror / settings: font / time-below / multi-type / mode / horizon). Each verified to have BOTH paths wired.

## Known risks (subagent-flagged for reviewer attention)

1. **Timing window** between `addHost` (fires from install callback) and the placeholder's first `.onGeometryChange` — host wears `container.bounds` (full hostContentView) with autoresizing flexible. One layout-pass tick. Gesture landing in that tick would hit the wrong area.
2. **`.onGeometryChange` on hot path during pinch** — spec §4b's "no slow-path on hot path" needs a pinch trace. Inner `host.frame != frameInContainer` guard de-dupes; outer `width > 0, height > 0` skips degenerate frames.
3. **`setOutputDelegate` re-apply mid-drag** — re-apply with no Model change short-circuits via `currentModel == model`, but the gesture controller's `callbacks` field IS re-assigned. Confirm `apply()` doesn't break a live gesture session by reassigning callbacks.
4. **Multi-day → single-day mode flip** — `addHost` triggered from mode-flip path uses `contentSize` as initial frame; subsequent `.onGeometryChange` corrects it. Visual A/B worth running.
5. **SourceKit-LSP false positive** at `CalendarPageView:4099` ("extra argument 'dayLayerDelegateAdapter' in call") is a stale-cache artifact; `xcodebuild` compiles clean and `TimelinePagerView.swift:1263` has the parameter. Fix per `TimelineScrollHost.swift`'s header comment: `xcode-build-server config`.

## Things NOT verified

- Simulator A/B (flag-ON vs flag-OFF visual equivalence)
- Gesture smoke test on flag ON (tap → detail; long-press → menu; drag → reposition; resize → adjust; drag-create → new event)
- Multi-day visual regression check
- Pinch hot-path performance with cached-Model `apply` (spec §7b benchmark)
- `gestureController.callbacks` reassignment mid-drag safety
- `onCreationPreviewChanged` round-trip during drag-create

## Test plan

- [ ] Flag OFF: byte-identical to king (all imperative paths gated; SwiftUI representable still constructs).
- [ ] Multi-day (3-day / week): byte-identical to king.
- [ ] Flag ON, single-day: events render correctly aligned with axis (verifies S5.7 frame pinning).
- [ ] Flag ON, single-day: tap event → detail opens (verifies S5.6 delegate wiring).
- [ ] Flag ON, single-day: long-press + drag → block follows + commits on release.
- [ ] Flag ON, single-day: drag-create new event → preview + commit.
- [ ] Flag ON, single-day: resize top + bottom → handles work + commit.
- [ ] Flag ON, single-day: cross-midnight drag → band opens (S0+Phase1+S2 behavior, now via coordinator-driven inset).
- [ ] Flag ON, single-day: pinch → smooth contentInset adjustment + slot density crossfade.
- [ ] Flag ON, single-day: mode flip ↔ multi-day mid-session — host cleanup + reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)