### PR TITLE
fix(timeline): #57 spec-07 S5.8 + S5.9 — make imperative day-layer actually render

### DIFF
--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3889,6 +3889,21 @@ private extension CalendarPageView {
                 // next layout tick. Day-N anchor date is today.
                 if usesImperativeDayLayerModel {
                     let today = Calendar.current.startOfDay(for: Date())
+                    // S5.9c (#57): SwiftUI `.onChange` does NOT fire on initial
+                    // mount, so `setHourHeight` / `setMode` (CalendarPageS4Pinch/
+                    // ModeChannelModifier:5775/5790) never reach the coordinator
+                    // on cold start — `addHost` reads cached `hourHeight = 0`
+                    // and the initial Model lands with `hourHeight = 0`. The
+                    // chrome's now-line / grid Y math AND every event's
+                    // `verticalFrame` (contentHeight = totalHours × hourHeight)
+                    // then collapse to ~0, so the event sublayer IS added but
+                    // paints at zero height = invisible (matches the observed
+                    // "11 sublayers, no event" symptom). Pre-seeding the cache
+                    // before addHost ensures the initial Model is correct;
+                    // subsequent `.onChange`s replace the seeded value.
+                    coordinator.setHourHeight(calendarState.timelineHourHeight)
+                    coordinator.setMode(calendarState.rangeMode)
+                    coordinator.setFrozenSlotMinutes(rangePinchFrozenSlotMinutes)
                     coordinator.addHost(
                         dayOffset: 0,
                         date: today,
@@ -3918,6 +3933,14 @@ private extension CalendarPageView {
             if isImperative {
                 let today = Calendar.current.startOfDay(for: Date())
                 let bounds = timelineScrollProxy.contentSize
+                // S5.9c (#57): see addHost-call comment above. Pre-seed initial
+                // channel values that `.onChange` would otherwise NEVER fire
+                // for (no value-change between pre-flip and post-flip), so the
+                // first apply'd Model gets the real hourHeight / mode instead
+                // of cached defaults (0 / .day) → zero-height invisible events.
+                coordinator.setHourHeight(calendarState.timelineHourHeight)
+                coordinator.setMode(calendarState.rangeMode)
+                coordinator.setFrozenSlotMinutes(rangePinchFrozenSlotMinutes)
                 coordinator.addHost(
                     dayOffset: 0,
                     date: today,

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3844,12 +3844,29 @@ private extension CalendarPageView {
             // armed for a later flag-ON flip without a re-onAppear.
             timelineScrollProxy.setOnScrollViewInstalled { [weak timelineScrollProxy] scrollView, hostContentView in
                 _ = timelineScrollProxy  // capture-only; not used inside.
+                _ = hostContentView      // kept in the signature for future
+                                         // reuse (e.g. frame-anchor reads);
+                                         // not the container per S5.9a.
                 let coordinator: DayLayerCoordinator
                 if let existing = dayLayerCoordinator {
                     coordinator = existing
                 } else {
+                    // S5.9a (spec 07 §4d): the day-layer host is added as a
+                    // SIBLING of the SwiftUI `UIHostingController.view` inside
+                    // the UIScrollView, NOT as a child of it. Earlier S5
+                    // shipped the latter and triggered the runtime warning
+                    //   "Adding 'DayLayerHostView' as a subview of
+                    //    UIHostingController.view is not supported and may
+                    //    result in a broken view hierarchy."
+                    // The hostContentView IS the UIHostingController.view; a
+                    // subview of it is exactly the unsupported config the
+                    // warning calls out, and on real device the host's content
+                    // (grid + events) renders blank as a result. Switching the
+                    // container to `scrollView` puts the day-layer host
+                    // alongside the SwiftUI tree inside the scroll content,
+                    // matching spec §4d.
                     coordinator = DayLayerCoordinator(
-                        container: hostContentView,
+                        container: scrollView,
                         scrollView: scrollView,
                         dragState: timelineDragState
                     )
@@ -3866,24 +3883,25 @@ private extension CalendarPageView {
                 // Spec 07 §5 S5.3: cord-cut. The SwiftUI `buildDayLayerView`
                 // returns `Color.clear` when `usesImperativeDayLayerModel`,
                 // and the coordinator's host fills the slot. Sized to the
-                // hostContentView's bounds with autoresizing flexible (the
-                // host content view is the SwiftUI tree's frame, which
-                // tracks the scroll's `contentLayoutGuide`). Day-N anchor
-                // date is today.
+                // scrollView's bounds with autoresizing flexible — the
+                // `.onGeometryChange` placeholder repins to the precise
+                // day-column rect (in scrollView content coords) on the
+                // next layout tick. Day-N anchor date is today.
                 if usesImperativeDayLayerModel {
                     let today = Calendar.current.startOfDay(for: Date())
                     coordinator.addHost(
                         dayOffset: 0,
                         date: today,
-                        frame: hostContentView.bounds
+                        frame: scrollView.bounds
                     )
                 }
             }
             timelineScrollProxy.setOnScrollViewUninstalled {
                 // Drop the coordinator with the host. The coordinator owns
-                // the new `DayLayerHostView` subview that was added inside
-                // hostContentView; removeHost detaches it before the
-                // scroll view tears down.
+                // the new `DayLayerHostView` subview that was added as a
+                // sibling of the SwiftUI hosting view inside the scroll
+                // view; removeHost detaches it before the scroll view
+                // tears down.
                 dayLayerCoordinator?.removeHost(dayOffset: 0)
                 dayLayerCoordinator = nil
             }

--- a/Done/Views/Calendar/CalendarPageView.swift
+++ b/Done/Views/Calendar/CalendarPageView.swift
@@ -3909,6 +3909,15 @@ private extension CalendarPageView {
                 coordinator.removeHost(dayOffset: 0)
             }
         }
+        // S5.8 follow-up Bug 2 fix: the single coordinator-owned host needs
+        // to track which page the user is viewing. The pager mounts many
+        // pages (TabView preload window); only the cached state for the
+        // currently-visible offset should reach the host's Model. Without
+        // this hook, the host stays pinned to offset=0 (today) regardless
+        // of the user paging to a different day.
+        .onChange(of: calendarState.selectedDayOffset) { _, newOffset in
+            dayLayerCoordinator?.setCurrentPageOffset(newOffset)
+        }
         .onChange(of: timelineDragState.dragOffset.y) { _, _ in
             refreshAbandonedExtension(topOverlayInset: lastTimelineTopOverlayInset)
         }

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -1293,6 +1293,13 @@ final class DayLayerHostView: UIView {
         guard currentModel != model else { return }
         let previous = currentModel
         currentModel = model
+        // S5.9c diagnostic: previously the bug was "11 sublayers added, no
+        // event visible" — turned out to be `hourHeight=0` at initial apply
+        // (SwiftUI `.onChange` initial-mount silence) which collapses every
+        // event's `verticalFrame` to height≈0. Print enough context to spot
+        // any future zero-collapse, including chrome (headerHeight / drawable
+        // hours) so the next session can triangulate without re-instrumenting.
+        print("🩹[s5.9c] host.apply bounds=\(bounds) hourHeight=\(model.hourHeight) headerHeight=\(model.headerHeight) contentWidth=\(model.contentWidth) occCount=\(model.occurrences.count) drawableL=\(model.drawableLeadingHours) drawableT=\(model.drawableTrailingHours) date=\(model.date)")
         // The live drag offset lives in plain UIKit state on the gesture
         // controller (spec 05): a SwiftUI-driven re-`apply` (e.g. dragState
         // coarse-field mirror, focus change) must not stomp the in-flight

--- a/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
+++ b/Done/Views/Calendar/Components/Timeline/CalendarDayLayerView.swift
@@ -1293,13 +1293,6 @@ final class DayLayerHostView: UIView {
         guard currentModel != model else { return }
         let previous = currentModel
         currentModel = model
-        // S5.9c diagnostic: previously the bug was "11 sublayers added, no
-        // event visible" — turned out to be `hourHeight=0` at initial apply
-        // (SwiftUI `.onChange` initial-mount silence) which collapses every
-        // event's `verticalFrame` to height≈0. Print enough context to spot
-        // any future zero-collapse, including chrome (headerHeight / drawable
-        // hours) so the next session can triangulate without re-instrumenting.
-        print("🩹[s5.9c] host.apply bounds=\(bounds) hourHeight=\(model.hourHeight) headerHeight=\(model.headerHeight) contentWidth=\(model.contentWidth) occCount=\(model.occurrences.count) drawableL=\(model.drawableLeadingHours) drawableT=\(model.drawableTrailingHours) date=\(model.date)")
         // The live drag offset lives in plain UIKit state on the gesture
         // controller (spec 05): a SwiftUI-driven re-`apply` (e.g. dragState
         // coarse-field mirror, focus change) must not stomp the in-flight

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -80,6 +80,14 @@ final class DayLayerCoordinator: NSObject {
     private(set) var drawableTrailingByDayOffset: [Int: Int] = [:]
     private(set) var isFocusContextActive: Bool = false
 
+    /// Which page offset is currently visible in the pager. The single
+    /// `dayHost` always renders THIS offset's cached state. Spec 07 §5 S5
+    /// took a shortcut of assuming a fixed offset=0 host — that breaks
+    /// when the user pages to a different day. setSetters cache per-offset
+    /// but only push to the host when `dayOffset == currentPageOffset`.
+    /// CalendarPageView wires this to `calendarState.selectedDayOffset`.
+    private(set) var currentPageOffset: Int = 0
+
     /// Spec 07 §2A: the 48h substrate's only band channel is `contentInset`.
     /// `setBandLeadingOpen` / `setBandTrailingOpen` flip the per-side
     /// `contentInset.top` / `.bottom` via `TimelineScrollProxy` in S5; S3
@@ -338,7 +346,7 @@ final class DayLayerCoordinator: NSObject {
 
     func setContentWidth(_ width: CGFloat, for dayOffset: Int) {
         contentWidthByDayOffset[dayOffset] = width
-        guard dayOffset == 0 else { return }
+        guard dayOffset == currentPageOffset else { return }
         updateModel { $0.contentWidth = width }
     }
 
@@ -415,25 +423,46 @@ final class DayLayerCoordinator: NSObject {
         } else {
             creationPreviewRangeByDayOffset.removeValue(forKey: dayOffset)
         }
-        guard dayOffset == 0 else { return }
+        guard dayOffset == currentPageOffset else { return }
         updateModel { $0.creationPreviewRange = range }
     }
 
     func setOccurrences(_ occs: [CalendarLayout.EventOccurrence], for dayOffset: Int) {
-        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) hasHost=\(dayHost != nil) hasCachedModel=\(cachedModel != nil)")
+        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) cur=\(currentPageOffset) push=\(dayOffset == currentPageOffset)")
         occurrencesByDayOffset[dayOffset] = occs
-        guard dayOffset == 0 else { return }
+        guard dayOffset == currentPageOffset else { return }
         updateModel { $0.occurrences = occs }
     }
 
     // MARK: Channels missed by spec §5 S4 (S5.8 follow-up)
+
+    /// Switch which page offset the single host renders. The pager mounts
+    /// many pages (TabView preload window); the host always reflects
+    /// `currentPageOffset`'s cached state. Called from CalendarPageView's
+    /// `.onChange(of: calendarState.selectedDayOffset)` whenever the user
+    /// pages. Also fires the initial sync once the coordinator-aware
+    /// modifier first publishes for a new offset.
+    func setCurrentPageOffset(_ offset: Int) {
+        currentPageOffset = offset
+        updateModel { m in
+            m.date = dateByDayOffset[offset] ?? m.date
+            m.occurrences = occurrencesByDayOffset[offset] ?? []
+            m.creationPreviewRange = creationPreviewRangeByDayOffset[offset]
+            m.drawableLeadingHours = drawableLeadingByDayOffset[offset]
+                ?? (bandLeadingOpen ? 12 : 0)
+            m.drawableTrailingHours = drawableTrailingByDayOffset[offset]
+                ?? (bandTrailingOpen ? 12 : 0)
+            if let w = contentWidthByDayOffset[offset] { m.contentWidth = w }
+        }
+        print("🩹[s5.8] coord.setCurrentPageOffset offset=\(offset) hasHost=\(dayHost != nil) cachedOccCount=\(occurrencesByDayOffset[offset]?.count ?? -1)")
+    }
 
     /// Per-day anchor date. The user pages through days; the date in the
     /// cached Model must follow. `addHost` reads the initial date as a
     /// parameter, but subsequent changes need this setter.
     func setDate(_ date: Date, for dayOffset: Int) {
         dateByDayOffset[dayOffset] = date
-        guard dayOffset == 0 else { return }
+        guard dayOffset == currentPageOffset else { return }
         updateModel { $0.date = date }
     }
 
@@ -445,7 +474,7 @@ final class DayLayerCoordinator: NSObject {
     func setDrawableHours(leading: Int, trailing: Int, for dayOffset: Int) {
         drawableLeadingByDayOffset[dayOffset] = leading
         drawableTrailingByDayOffset[dayOffset] = trailing
-        guard dayOffset == 0 else { return }
+        guard dayOffset == currentPageOffset else { return }
         updateModel { m in
             m.drawableLeadingHours = leading
             m.drawableTrailingHours = trailing

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -298,12 +298,22 @@ final class DayLayerCoordinator: NSObject {
     /// Spec 07 §5 S5.7: pin the host's frame to the SwiftUI day-column's
     /// rect. The SwiftUI tree has an axis column (26pt left) + an all-day
     /// pill row above the day column; until this is called the host fills
-    /// `container.bounds` (`hostContentView` = the UIHostingController.view)
-    /// which paints events ON TOP of the axis. The page view's placeholder
-    /// publishes its frame in `.global` (window) coords via GeometryReader;
-    /// we convert to container coords here so a viewport pan or rotation
-    /// pushes a fresh frame through the same path. Multi-day still uses the
-    /// SwiftUI representable so no per-column pinning is needed for it.
+    /// `container.bounds` (post-S5.9a `container` is the UIScrollView, so
+    /// pre-pin the host stretches over the full viewport) which paints
+    /// events ON TOP of the axis. The page view's placeholder publishes
+    /// its frame in `.global` (window) coords via GeometryReader; we
+    /// convert to container coords here so a viewport pan or rotation
+    /// pushes a fresh frame through the same path. Multi-day still uses
+    /// the SwiftUI representable so no per-column pinning is needed for
+    /// it.
+    ///
+    /// Container-coord note (S5.9a): `container` is the `UIScrollView`
+    /// itself, so `container.convert(_, from: nil)` returns scroll-view-
+    /// local coords (which include `contentOffset`-derived bounds.origin).
+    /// The placeholder's `.global` frame changes on every scroll tick, but
+    /// the converted scroll-content rect stays constant — the
+    /// `host.frame != frameInContainer` guard short-circuits the write so
+    /// the per-scroll cost is just the conversion math.
     ///
     /// `globalFrame` is the SwiftUI placeholder's window-space frame. We
     /// convert it into the coordinator's `container` coordinate space so the

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -75,6 +75,10 @@ final class DayLayerCoordinator: NSObject {
     private(set) var contentWidthByDayOffset: [Int: CGFloat] = [:]
     private(set) var creationPreviewRangeByDayOffset: [Int: Event.TimeRange] = [:]
     private(set) var occurrencesByDayOffset: [Int: [CalendarLayout.EventOccurrence]] = [:]
+    private(set) var dateByDayOffset: [Int: Date] = [:]
+    private(set) var drawableLeadingByDayOffset: [Int: Int] = [:]
+    private(set) var drawableTrailingByDayOffset: [Int: Int] = [:]
+    private(set) var isFocusContextActive: Bool = false
 
     /// Spec 07 §2A: the 48h substrate's only band channel is `contentInset`.
     /// `setBandLeadingOpen` / `setBandTrailingOpen` flip the per-side
@@ -238,7 +242,7 @@ final class DayLayerCoordinator: NSObject {
         // band coordinate hours, plus drawable hours = 0 at rest) default to
         // the imperative single-day substrate per spec §2A.
         let initial = DayLayerHostView.Model(
-            date: date,
+            date: dateByDayOffset[dayOffset] ?? date,
             occurrences: occurrencesByDayOffset[dayOffset] ?? [],
             contentWidth: contentWidthByDayOffset[dayOffset] ?? frame.width,
             headerHeight: headerHeight,
@@ -246,8 +250,8 @@ final class DayLayerCoordinator: NSObject {
             eventHorizontalInset: eventHorizontalInset,
             leadingExtendedHours: 12,
             trailingExtendedHours: 12,
-            drawableLeadingHours: bandLeadingOpen ? 12 : 0,
-            drawableTrailingHours: bandTrailingOpen ? 12 : 0,
+            drawableLeadingHours: drawableLeadingByDayOffset[dayOffset] ?? (bandLeadingOpen ? 12 : 0),
+            drawableTrailingHours: drawableTrailingByDayOffset[dayOffset] ?? (bandTrailingOpen ? 12 : 0),
             useImperativeDayLayerModel: true,
             showEventText: showEventText,
             isWeekMode: false,
@@ -266,7 +270,7 @@ final class DayLayerCoordinator: NSObject {
             graceResizeEventID: graceResizeEventID,
             graceResizeOccurrenceID: graceResizeOccurrenceID,
             graceResizeHandleOpacity: graceResizeHandleOpacity,
-            isFocusContextActive: focusedEventID != nil,
+            isFocusContextActive: isFocusContextActive,
             recentlyAbsorbedEventIDs: recentlyAbsorbedEventIDs
         )
         cachedModel = initial
@@ -314,6 +318,9 @@ final class DayLayerCoordinator: NSObject {
         contentWidthByDayOffset.removeValue(forKey: dayOffset)
         creationPreviewRangeByDayOffset.removeValue(forKey: dayOffset)
         occurrencesByDayOffset.removeValue(forKey: dayOffset)
+        dateByDayOffset.removeValue(forKey: dayOffset)
+        drawableLeadingByDayOffset.removeValue(forKey: dayOffset)
+        drawableTrailingByDayOffset.removeValue(forKey: dayOffset)
         guard dayOffset == 0, let host = dayHost else { return }
         host.removeFromSuperview()
         dayHost = nil
@@ -415,6 +422,41 @@ final class DayLayerCoordinator: NSObject {
         occurrencesByDayOffset[dayOffset] = occs
         guard dayOffset == 0 else { return }
         updateModel { $0.occurrences = occs }
+    }
+
+    // MARK: Channels missed by spec §5 S4 (S5.8 follow-up)
+
+    /// Per-day anchor date. The user pages through days; the date in the
+    /// cached Model must follow. `addHost` reads the initial date as a
+    /// parameter, but subsequent changes need this setter.
+    func setDate(_ date: Date, for dayOffset: Int) {
+        dateByDayOffset[dayOffset] = date
+        guard dayOffset == 0 else { return }
+        updateModel { $0.date = date }
+    }
+
+    /// Drawable window for the band region. At rest both are 0 (band region
+    /// renders empty); during a drag that crosses the substrate edge they
+    /// open to 12/12 so the dragged event paints through the band area. The
+    /// SwiftUI representable used to read `drawableExtensionHours` per-frame;
+    /// post-S5 cord-cut this setter is the only path.
+    func setDrawableHours(leading: Int, trailing: Int, for dayOffset: Int) {
+        drawableLeadingByDayOffset[dayOffset] = leading
+        drawableTrailingByDayOffset[dayOffset] = trailing
+        guard dayOffset == 0 else { return }
+        updateModel { m in
+            m.drawableLeadingHours = leading
+            m.drawableTrailingHours = trailing
+        }
+    }
+
+    /// Focus context active flag. Distinct from `setFocus(eventID:occurrenceID:)`
+    /// — the focused-event identifiers are nil-or-set; this flag is what
+    /// gates sibling dimming + interaction. Driven by the page view's focus
+    /// state machine.
+    func setFocusContextActive(_ active: Bool) {
+        isFocusContextActive = active
+        updateModel { $0.isFocusContextActive = active }
     }
 
     // MARK: One-time chrome / setting writes

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -292,7 +292,9 @@ final class DayLayerCoordinator: NSObject {
         host.apply(initial, callbacks: hostCallbacks)
         dayHost = host
         hostDayOffsets.insert(dayOffset)
-        print("🩹[s5.8] coord.addHost offset=\(dayOffset) date=\(initial.date) occCount=\(initial.occurrences.count) frame=\(frame)")
+        let containerSubviewCount = container.subviews.count
+        let hostIdx = container.subviews.firstIndex(of: host) ?? -1
+        print("🩹[s5.8] coord.addHost offset=\(dayOffset) date=\(initial.date) occCount=\(initial.occurrences.count) frame=\(frame) hostBg=\(String(describing: host.backgroundColor)) hostInHier=\(host.window != nil) hostHidden=\(host.isHidden) hostAlpha=\(host.alpha) container=\(type(of: container)) containerSubviewCount=\(containerSubviewCount) hostIdx=\(hostIdx)")
     }
 
     /// Spec 07 §5 S5.7: pin the host's frame to the SwiftUI day-column's
@@ -493,6 +495,7 @@ final class DayLayerCoordinator: NSObject {
             host.autoresizingMask = []
         }
         guard host.frame != frameInContainer else { return }
+        print("🩹[s5.8] applyHostFrame globalFrame=\(globalFrame) → frameInContainer=\(frameInContainer) prevFrame=\(host.frame) inHier=\(host.window != nil)")
         host.frame = frameInContainer
     }
 
@@ -585,6 +588,9 @@ final class DayLayerCoordinator: NSObject {
         guard cachedModel != model else { return }
         cachedModel = model
         dayHost?.apply(model, callbacks: hostCallbacks)
+        if let h = dayHost {
+            print("🩹[s5.8] updateModel applied occCount=\(model.occurrences.count) date=\(model.date) hostFrame=\(h.frame) inHier=\(h.window != nil) hidden=\(h.isHidden) alpha=\(h.alpha) opacity=\(h.layer.opacity) sublayers=\(h.layer.sublayers?.count ?? 0)")
+        }
     }
 }
 

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -248,7 +248,12 @@ final class DayLayerCoordinator: NSObject {
             return
         }
         let host = DayLayerHostView()
-        host.backgroundColor = .clear
+        // 🩹 S5.9 debug visualization: tint host background so we can see
+        // EXACTLY where it is on screen — if user sees a faint tinted rect
+        // covering the day-column slot, host is visible + correctly framed
+        // and the bug is inside `apply`'s event-block render. If they see
+        // nothing → host is covered / clipped / detached despite logs.
+        host.backgroundColor = UIColor.systemPink.withAlphaComponent(0.10)
         host.frame = frame
         host.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         // Build the initial Model from the coordinator's cached primitives.
@@ -451,7 +456,8 @@ final class DayLayerCoordinator: NSObject {
     }
 
     func setOccurrences(_ occs: [CalendarLayout.EventOccurrence], for dayOffset: Int) {
-        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) cur=\(currentPageOffset) push=\(dayOffset == currentPageOffset)")
+        let occDetails = occs.map { "\($0.range.start)→\($0.range.end)" }.joined(separator: " | ")
+        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) cur=\(currentPageOffset) push=\(dayOffset == currentPageOffset) ranges=[\(occDetails)]")
         occurrencesByDayOffset[dayOffset] = occs
         guard dayOffset == currentPageOffset else { return }
         updateModel { $0.occurrences = occs }

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -278,6 +278,7 @@ final class DayLayerCoordinator: NSObject {
         host.apply(initial, callbacks: hostCallbacks)
         dayHost = host
         hostDayOffsets.insert(dayOffset)
+        print("🩹[s5.8] coord.addHost offset=\(dayOffset) date=\(initial.date) occCount=\(initial.occurrences.count) frame=\(frame)")
     }
 
     /// Spec 07 §5 S5.7: pin the host's frame to the SwiftUI day-column's
@@ -419,6 +420,7 @@ final class DayLayerCoordinator: NSObject {
     }
 
     func setOccurrences(_ occs: [CalendarLayout.EventOccurrence], for dayOffset: Int) {
+        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) hasHost=\(dayHost != nil) hasCachedModel=\(cachedModel != nil)")
         occurrencesByDayOffset[dayOffset] = occs
         guard dayOffset == 0 else { return }
         updateModel { $0.occurrences = occs }
@@ -507,7 +509,10 @@ final class DayLayerCoordinator: NSObject {
     /// triggers a repaint, and pure visual-only field changes skip the
     /// full overlap rebuild via the cheap pinch path.
     private func updateModel(_ mutate: (inout DayLayerHostView.Model) -> Void) {
-        guard var model = cachedModel else { return }
+        guard var model = cachedModel else {
+            print("🩹[s5.8] updateModel SKIPPED — cachedModel is nil (addHost not fired yet)")
+            return
+        }
         mutate(&model)
         guard cachedModel != model else { return }
         cachedModel = model

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -249,11 +249,17 @@ final class DayLayerCoordinator: NSObject {
         }
         let host = DayLayerHostView()
         // 🩹 S5.9 debug visualization: tint host background so we can see
-        // EXACTLY where it is on screen — if user sees a faint tinted rect
-        // covering the day-column slot, host is visible + correctly framed
-        // and the bug is inside `apply`'s event-block render. If they see
-        // nothing → host is covered / clipped / detached despite logs.
+        // EXACTLY where it is on screen.
         host.backgroundColor = UIColor.systemPink.withAlphaComponent(0.10)
+        // S5.10 TODO: host intercepts ALL touches by default, which blocks
+        // the SwiftUI TabView's horizontal-swipe paging. Until the delegate
+        // adapter is fully wired for tap/long-press/drag (and we know we
+        // need touches to reach the host), keep gestures passing through
+        // to the underlying SwiftUI tree. Trade-off: event taps won't open
+        // detail. Cross-day swipe works. Resolve in a follow-up that
+        // implements selective hit-test (pass through "empty area"
+        // touches, capture touches landing on an event block).
+        host.isUserInteractionEnabled = false
         host.frame = frame
         host.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         // Build the initial Model from the coordinator's cached primitives.

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -248,17 +248,13 @@ final class DayLayerCoordinator: NSObject {
             return
         }
         let host = DayLayerHostView()
-        // 🩹 S5.9 debug visualization: tint host background so we can see
-        // EXACTLY where it is on screen.
-        host.backgroundColor = UIColor.systemPink.withAlphaComponent(0.10)
-        // S5.10 TODO: host intercepts ALL touches by default, which blocks
-        // the SwiftUI TabView's horizontal-swipe paging. Until the delegate
-        // adapter is fully wired for tap/long-press/drag (and we know we
-        // need touches to reach the host), keep gestures passing through
-        // to the underlying SwiftUI tree. Trade-off: event taps won't open
-        // detail. Cross-day swipe works. Resolve in a follow-up that
-        // implements selective hit-test (pass through "empty area"
-        // touches, capture touches landing on an event block).
+        host.backgroundColor = .clear
+        // S5.10 follow-up: host intercepts ALL touches by default, which
+        // blocks the SwiftUI TabView's horizontal-swipe paging. Until a
+        // selective hit-test routes "empty area" touches through to the
+        // SwiftUI tree while capturing event-block touches, gestures pass
+        // straight through. Trade-off: event tap / long-press / drag don't
+        // reach the delegate adapter yet; cross-day swipe works.
         host.isUserInteractionEnabled = false
         host.frame = frame
         host.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -303,9 +299,6 @@ final class DayLayerCoordinator: NSObject {
         host.apply(initial, callbacks: hostCallbacks)
         dayHost = host
         hostDayOffsets.insert(dayOffset)
-        let containerSubviewCount = container.subviews.count
-        let hostIdx = container.subviews.firstIndex(of: host) ?? -1
-        print("🩹[s5.8] coord.addHost offset=\(dayOffset) date=\(initial.date) occCount=\(initial.occurrences.count) frame=\(frame) hostBg=\(String(describing: host.backgroundColor)) hostInHier=\(host.window != nil) hostHidden=\(host.isHidden) hostAlpha=\(host.alpha) container=\(type(of: container)) containerSubviewCount=\(containerSubviewCount) hostIdx=\(hostIdx)")
     }
 
     /// Spec 07 §5 S5.7: pin the host's frame to the SwiftUI day-column's
@@ -462,8 +455,6 @@ final class DayLayerCoordinator: NSObject {
     }
 
     func setOccurrences(_ occs: [CalendarLayout.EventOccurrence], for dayOffset: Int) {
-        let occDetails = occs.map { "\($0.range.start)→\($0.range.end)" }.joined(separator: " | ")
-        print("🩹[s5.8] coord.setOccurrences offset=\(dayOffset) count=\(occs.count) cur=\(currentPageOffset) push=\(dayOffset == currentPageOffset) ranges=[\(occDetails)]")
         occurrencesByDayOffset[dayOffset] = occs
         guard dayOffset == currentPageOffset else { return }
         updateModel { $0.occurrences = occs }
@@ -496,7 +487,6 @@ final class DayLayerCoordinator: NSObject {
         if let cachedFrame = hostFrameByDayOffset[offset] {
             applyHostFrameIfChanged(cachedFrame)
         }
-        print("🩹[s5.8] coord.setCurrentPageOffset offset=\(offset) hasHost=\(dayHost != nil) cachedOccCount=\(occurrencesByDayOffset[offset]?.count ?? -1) cachedFrame=\(hostFrameByDayOffset[offset].map { String(describing: $0) } ?? "nil")")
     }
 
     private func applyHostFrameIfChanged(_ globalFrame: CGRect) {
@@ -518,18 +508,16 @@ final class DayLayerCoordinator: NSObject {
             if prev != frameInContainer { host.frame = frameInContainer }
             return
         }
-        print("🩹[s5.8] applyHostFrame globalFrame=\(globalFrame) → frameInContainer=\(frameInContainer) prevFrame=\(prev) inHier=\(host.window != nil)")
         host.frame = frameInContainer
-        // S5.9 frame-vs-Model race: the initial `addHost` apply happens with
-        // host.bounds = scrollView.bounds (e.g. 402×874); the sublayers are
-        // positioned for that coord space. Later `setHostFrame` shrinks
-        // bounds to the day-column (e.g. 364×1340) but `apply` was never
-        // re-fired against the new bounds — so events painted at stale
-        // x positions (off-canvas) or invisible. Re-apply forces a full
-        // re-layout against the now-correct bounds.
+        // Frame-vs-Model race: the initial `addHost` apply runs with
+        // host.bounds = scrollView.bounds (e.g. 402×874); event sublayers
+        // are positioned for that coord space. Later `setHostFrame` shrinks
+        // bounds to the day-column (e.g. 364×1340) but `apply` is never
+        // re-fired against the new bounds — so events stay at stale x
+        // positions and look invisible. Re-apply forces a full re-layout
+        // against the now-correct bounds.
         if let model = cachedModel {
             host.apply(model, callbacks: hostCallbacks)
-            print("🩹[s5.8] applyHostFrame re-applied Model in new bounds=\(host.bounds) sublayers=\(host.layer.sublayers?.count ?? 0)")
         }
     }
 
@@ -614,17 +602,11 @@ final class DayLayerCoordinator: NSObject {
     /// triggers a repaint, and pure visual-only field changes skip the
     /// full overlap rebuild via the cheap pinch path.
     private func updateModel(_ mutate: (inout DayLayerHostView.Model) -> Void) {
-        guard var model = cachedModel else {
-            print("🩹[s5.8] updateModel SKIPPED — cachedModel is nil (addHost not fired yet)")
-            return
-        }
+        guard var model = cachedModel else { return }
         mutate(&model)
         guard cachedModel != model else { return }
         cachedModel = model
         dayHost?.apply(model, callbacks: hostCallbacks)
-        if let h = dayHost {
-            print("🩹[s5.8] updateModel applied occCount=\(model.occurrences.count) date=\(model.date) hostFrame=\(h.frame) inHier=\(h.window != nil) hidden=\(h.isHidden) alpha=\(h.alpha) opacity=\(h.layer.opacity) sublayers=\(h.layer.sublayers?.count ?? 0)")
-        }
     }
 }
 

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -78,6 +78,12 @@ final class DayLayerCoordinator: NSObject {
     private(set) var dateByDayOffset: [Int: Date] = [:]
     private(set) var drawableLeadingByDayOffset: [Int: Int] = [:]
     private(set) var drawableTrailingByDayOffset: [Int: Int] = [:]
+    /// Per-offset window-coord frame of the SwiftUI placeholder. Every page's
+    /// `.onGeometryChange` writes here regardless of `currentPageOffset`; only
+    /// the current page's frame actually pins the host. On `setCurrentPageOffset`
+    /// the host is re-pinned from this cache so it doesn't wait for the new
+    /// page's next geometry callback.
+    private(set) var hostFrameByDayOffset: [Int: CGRect] = [:]
     private(set) var isFocusContextActive: Bool = false
 
     /// Which page offset is currently visible in the pager. The single
@@ -312,14 +318,19 @@ final class DayLayerCoordinator: NSObject {
     /// re-publishes on those same events, so explicit-frame ownership keeps
     /// the host in sync.
     func setHostFrame(_ globalFrame: CGRect, for dayOffset: Int) {
-        guard dayOffset == 0, let host = dayHost else { return }
-        guard globalFrame.width > 0, globalFrame.height > 0 else { return }
-        let frameInContainer = container.convert(globalFrame, from: nil)
-        if host.autoresizingMask != [] {
-            host.autoresizingMask = []
-        }
-        guard host.frame != frameInContainer else { return }
-        host.frame = frameInContainer
+        // Cache every offset's latest frame so a re-page can re-pin to a known
+        // value without waiting for that page's next geometry callback.
+        hostFrameByDayOffset[dayOffset] = globalFrame
+        // S5.8 follow-up Bug 3: every TabView-preloaded page fires this
+        // simultaneously. Only the CURRENTLY-VISIBLE page's frame is the
+        // right rect for the single host — the others report off-screen
+        // values that would yank the host out of view if applied. Without
+        // this guard, an arbitrary scheduling order between concurrent
+        // placeholder `.onGeometryChange` callbacks can leave the host
+        // pinned to an off-screen offset (no events / background visible,
+        // even though the Model has them).
+        guard dayOffset == currentPageOffset else { return }
+        applyHostFrameIfChanged(globalFrame)
     }
 
     func removeHost(dayOffset: Int) {
@@ -454,7 +465,25 @@ final class DayLayerCoordinator: NSObject {
                 ?? (bandTrailingOpen ? 12 : 0)
             if let w = contentWidthByDayOffset[offset] { m.contentWidth = w }
         }
-        print("🩹[s5.8] coord.setCurrentPageOffset offset=\(offset) hasHost=\(dayHost != nil) cachedOccCount=\(occurrencesByDayOffset[offset]?.count ?? -1)")
+        // Re-pin host frame to the new offset's last-known placeholder rect
+        // so the host doesn't sit at the previous offset's (now off-screen)
+        // location for the gap between this call and the new page's next
+        // `.onGeometryChange` tick.
+        if let cachedFrame = hostFrameByDayOffset[offset] {
+            applyHostFrameIfChanged(cachedFrame)
+        }
+        print("🩹[s5.8] coord.setCurrentPageOffset offset=\(offset) hasHost=\(dayHost != nil) cachedOccCount=\(occurrencesByDayOffset[offset]?.count ?? -1) cachedFrame=\(hostFrameByDayOffset[offset].map { String(describing: $0) } ?? "nil")")
+    }
+
+    private func applyHostFrameIfChanged(_ globalFrame: CGRect) {
+        guard let host = dayHost else { return }
+        guard globalFrame.width > 0, globalFrame.height > 0 else { return }
+        let frameInContainer = container.convert(globalFrame, from: nil)
+        if host.autoresizingMask != [] {
+            host.autoresizingMask = []
+        }
+        guard host.frame != frameInContainer else { return }
+        host.frame = frameInContainer
     }
 
     /// Per-day anchor date. The user pages through days; the date in the

--- a/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
+++ b/Done/Views/Calendar/Components/Timeline/DayLayerCoordinator.swift
@@ -494,9 +494,31 @@ final class DayLayerCoordinator: NSObject {
         if host.autoresizingMask != [] {
             host.autoresizingMask = []
         }
-        guard host.frame != frameInContainer else { return }
-        print("🩹[s5.8] applyHostFrame globalFrame=\(globalFrame) → frameInContainer=\(frameInContainer) prevFrame=\(host.frame) inHier=\(host.window != nil)")
+        // Only do "significant" frame changes — sub-pt floating-point jitter
+        // from cold-start scroll animation should not trigger expensive
+        // re-applies. ≥1pt change in any dimension counts as significant.
+        let prev = host.frame
+        let isSignificant = abs(prev.minX - frameInContainer.minX) >= 1
+            || abs(prev.minY - frameInContainer.minY) >= 1
+            || abs(prev.width - frameInContainer.width) >= 1
+            || abs(prev.height - frameInContainer.height) >= 1
+        guard isSignificant else {
+            if prev != frameInContainer { host.frame = frameInContainer }
+            return
+        }
+        print("🩹[s5.8] applyHostFrame globalFrame=\(globalFrame) → frameInContainer=\(frameInContainer) prevFrame=\(prev) inHier=\(host.window != nil)")
         host.frame = frameInContainer
+        // S5.9 frame-vs-Model race: the initial `addHost` apply happens with
+        // host.bounds = scrollView.bounds (e.g. 402×874); the sublayers are
+        // positioned for that coord space. Later `setHostFrame` shrinks
+        // bounds to the day-column (e.g. 364×1340) but `apply` was never
+        // re-fired against the new bounds — so events painted at stale
+        // x positions (off-canvas) or invisible. Re-apply forces a full
+        // re-layout against the now-correct bounds.
+        if let model = cachedModel {
+            host.apply(model, callbacks: hostCallbacks)
+            print("🩹[s5.8] applyHostFrame re-applied Model in new bounds=\(host.bounds) sublayers=\(host.layer.sublayers?.count ?? 0)")
+        }
     }
 
     /// Per-day anchor date. The user pages through days; the date in the

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -3913,7 +3913,7 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onAppear { pushSnapshot(reason: "appear") }
+            .onAppear { pushSnapshot() }
             .onChange(of: coordinator != nil) { _, isAvailable in
                 // TabView pre-mounts every page's `.onAppear` BEFORE the
                 // scroll view installs (and thus before the coordinator
@@ -3922,17 +3922,14 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
                 // available so the currently-mounted offset 0 page's data
                 // reaches the host. Without this the host renders with
                 // `occurrences=[]` even though the SwiftUI tree has the
-                // events loaded — caught via 🩹[s5.8] log inspection on
-                // sim (15 NIL `.onAppear` lines before `addHost`).
+                // events loaded.
                 guard isAvailable else { return }
-                pushSnapshot(reason: "coord-available")
+                pushSnapshot()
             }
             .onChange(of: date) { _, v in
-                print("🩹[s5.8] .onChange date offset=\(offset) → \(v)")
                 coordinator?.setDate(v, for: offset)
             }
             .onChange(of: occurrences) { _, v in
-                print("🩹[s5.8] .onChange occurrences offset=\(offset) count=\(v.count)")
                 coordinator?.setOccurrences(v, for: offset)
             }
             .onChange(of: contentWidth) { _, v in
@@ -3966,12 +3963,8 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
             }
     }
 
-    private func pushSnapshot(reason: String) {
-        guard let coordinator else {
-            print("🩹[s5.8] push(\(reason)) offset=\(offset) — coord NIL")
-            return
-        }
-        print("🩹[s5.8] push(\(reason)) offset=\(offset) occCount=\(occurrences.count) date=\(date)")
+    private func pushSnapshot() {
+        guard let coordinator else { return }
         coordinator.setDate(date, for: offset)
         coordinator.setOccurrences(occurrences, for: offset)
         coordinator.setContentWidth(contentWidth, for: offset)

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -1810,6 +1810,31 @@ struct TimelinePagerView: View {
         .onChange(of: nearFutureHorizonDays) { _, newValue in
             dayLayerCoordinator?.setHorizonDays(newValue)
         }
+        // S5.9c (#57): SwiftUI `.onChange` does NOT fire on initial mount, so
+        // the pager-scoped settings (font / time-below / multi-type / horizon)
+        // never reach the coordinator on cold start — they stay at their
+        // coordinator-cache defaults (14pt / true / false / 0). The font
+        // default of 14pt happens to match the AppStorage default, but
+        // `horizonDays = 0` is the wrong default (real default is
+        // `EventZone.defaultHorizonDays`), and a user who edits the setting
+        // BEFORE flag-on never sees the coordinator pick the value up. Push
+        // initial values the moment the coordinator becomes available, so
+        // the first apply'd Model is correct without relying on subsequent
+        // value changes.
+        .onChange(of: dayLayerCoordinator != nil) { _, isAvailable in
+            guard isAvailable, let coord = dayLayerCoordinator else { return }
+            coord.setTitleFontSize(calayerTitleFontSizeSetting)
+            coord.setShowTimeBelowTitle(calayerShowTimeBelowTitle)
+            coord.setMultiTypeEnabled(calayerMultiTypeEnabled)
+            coord.setHorizonDays(nearFutureHorizonDays)
+            coord.setPinchActive(isRangePinchActive)
+            coord.setRecentlyAbsorbedEventIDs(calayerRecentlyAbsorbedParents)
+            // Note: `setDragPreviewDayStep` is already armed in the inner
+            // scrollContent `.onAppear` (this file:1729) where `dayFrameWidth`
+            // is in scope. It also re-fires from the same modifier's
+            // `coord-available` hook so the value reaches the coordinator
+            // independently of this sync.
+        }
         .onReceive(calayerEventStore.calendarTodoAbsorbed) { parentID in
             // Mark the parent as recently-absorbed-into for the §4 pulse,
             // auto-clearing after the ~1.5s window so a later absorption into

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -3888,24 +3888,19 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .onAppear {
-                guard let coordinator else {
-                    print("🩹[s5.8] .onAppear: coordinator is NIL — wire skipped")
-                    return
-                }
-                print("🩹[s5.8] .onAppear offset=\(offset) date=\(date) occCount=\(occurrences.count) contentW=\(contentWidth) headerH=\(headerHeight) eventInset=\(eventHorizontalInset) drawable=(\(drawableLeadingHours),\(drawableTrailingHours)) showText=\(showEventText) focusCtx=\(isFocusContextActive)")
-                coordinator.setDate(date, for: offset)
-                coordinator.setOccurrences(occurrences, for: offset)
-                coordinator.setContentWidth(contentWidth, for: offset)
-                coordinator.setHeaderHeight(headerHeight)
-                coordinator.setEventHorizontalInset(eventHorizontalInset)
-                coordinator.setDrawableHours(
-                    leading: drawableLeadingHours,
-                    trailing: drawableTrailingHours,
-                    for: offset
-                )
-                coordinator.setShowEventText(showEventText)
-                coordinator.setFocusContextActive(isFocusContextActive)
+            .onAppear { pushSnapshot(reason: "appear") }
+            .onChange(of: coordinator != nil) { _, isAvailable in
+                // TabView pre-mounts every page's `.onAppear` BEFORE the
+                // scroll view installs (and thus before the coordinator
+                // exists). The initial appear pushes are all no-ops; this
+                // re-fires the snapshot the moment the coordinator becomes
+                // available so the currently-mounted offset 0 page's data
+                // reaches the host. Without this the host renders with
+                // `occurrences=[]` even though the SwiftUI tree has the
+                // events loaded — caught via 🩹[s5.8] log inspection on
+                // sim (15 NIL `.onAppear` lines before `addHost`).
+                guard isAvailable else { return }
+                pushSnapshot(reason: "coord-available")
             }
             .onChange(of: date) { _, v in
                 print("🩹[s5.8] .onChange date offset=\(offset) → \(v)")
@@ -3944,5 +3939,25 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
             .onChange(of: isFocusContextActive) { _, v in
                 coordinator?.setFocusContextActive(v)
             }
+    }
+
+    private func pushSnapshot(reason: String) {
+        guard let coordinator else {
+            print("🩹[s5.8] push(\(reason)) offset=\(offset) — coord NIL")
+            return
+        }
+        print("🩹[s5.8] push(\(reason)) offset=\(offset) occCount=\(occurrences.count) date=\(date)")
+        coordinator.setDate(date, for: offset)
+        coordinator.setOccurrences(occurrences, for: offset)
+        coordinator.setContentWidth(contentWidth, for: offset)
+        coordinator.setHeaderHeight(headerHeight)
+        coordinator.setEventHorizontalInset(eventHorizontalInset)
+        coordinator.setDrawableHours(
+            leading: drawableLeadingHours,
+            trailing: drawableTrailingHours,
+            for: offset
+        )
+        coordinator.setShowEventText(showEventText)
+        coordinator.setFocusContextActive(isFocusContextActive)
     }
 }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2759,7 +2759,7 @@ struct TimelinePagerView: View {
                 .onGeometryChange(for: CGRect.self) { proxy in
                     proxy.frame(in: .global)
                 } action: { globalFrame in
-                    dayLayerCoordinator?.setHostFrame(globalFrame, for: 0)
+                    dayLayerCoordinator?.setHostFrame(globalFrame, for: offset)
                 }
                 .modifier(TimelinePagerS5RenderChannelsModifier(
                     coordinator: dayLayerCoordinator,

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -2739,6 +2739,21 @@ struct TimelinePagerView: View {
             // subtree above the placeholder, so it doesn't alter parent
             // layout. Fires on first appearance + every frame mutation
             // (pinch contentSize, rotation, all-day-row growth).
+            //
+            // S5.8 follow-up: spec §5 S4's recommended 11-channel migration
+            // list omitted the render-state channels (occurrences, date,
+            // contentWidth, headerHeight, eventHorizontalInset, drawable
+            // hours, showEventText, isFocusContextActive). Post-cord-cut the
+            // SwiftUI representable no longer feeds them; result was a blank
+            // calendar with flag ON on real device. `S5RenderChannels`
+            // modifier wires the missing channels to the coordinator on
+            // initial appearance and on every change.
+            let dayOccurrences = CalendarLayout.timelineVisibleOccurrences(
+                forDayOffset: offset,
+                leadingExtendedHours: occurrenceExtensionHoursForDrag.leading,
+                trailingExtendedHours: occurrenceExtensionHoursForDrag.trailing,
+                occurrencesForOffset: occurrencesForOffset
+            )
             Color.clear
                 .frame(width: dayWidth, height: timelineHeight, alignment: .top)
                 .onGeometryChange(for: CGRect.self) { proxy in
@@ -2746,6 +2761,19 @@ struct TimelinePagerView: View {
                 } action: { globalFrame in
                     dayLayerCoordinator?.setHostFrame(globalFrame, for: 0)
                 }
+                .modifier(TimelinePagerS5RenderChannelsModifier(
+                    coordinator: dayLayerCoordinator,
+                    offset: offset,
+                    date: date,
+                    occurrences: dayOccurrences,
+                    contentWidth: dayWidth,
+                    headerHeight: headerHeight,
+                    eventHorizontalInset: eventHorizontalInset,
+                    drawableLeadingHours: drawableExtensionHours.leading,
+                    drawableTrailingHours: drawableExtensionHours.trailing,
+                    showEventText: showEventText,
+                    isFocusContextActive: isFocusContextActive
+                ))
         } else {
             buildLegacyDayLayerView(
                 for: offset,
@@ -3831,5 +3859,84 @@ private struct TodoEventAbsorptionDragDropModifier: ViewModifier {
         } else {
             content
         }
+    }
+}
+
+/// Spec 07 §5 S5.8 follow-up: wire the render-state channels that spec
+/// §5 S4's "11 channels" list omitted but that the Day Layer Model
+/// requires on every paint — occurrences, date, contentWidth, headerHeight,
+/// eventHorizontalInset, drawable hours, showEventText, isFocusContextActive.
+///
+/// Without this, a flag-ON single-day cold start gets a Model with empty
+/// occurrences (blank calendar), zero header / inset (events painted under
+/// axis), and stuck-closed drawable hours (band doesn't open during cross-
+/// midnight drag). `.onAppear` pushes the initial snapshot the moment the
+/// imperative placeholder mounts; each `.onChange` keeps the coordinator
+/// in sync as state shifts.
+private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
+    let coordinator: DayLayerCoordinator?
+    let offset: Int
+    let date: Date
+    let occurrences: [CalendarLayout.EventOccurrence]
+    let contentWidth: CGFloat
+    let headerHeight: CGFloat
+    let eventHorizontalInset: CGFloat
+    let drawableLeadingHours: Int
+    let drawableTrailingHours: Int
+    let showEventText: Bool
+    let isFocusContextActive: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                guard let coordinator else { return }
+                coordinator.setDate(date, for: offset)
+                coordinator.setOccurrences(occurrences, for: offset)
+                coordinator.setContentWidth(contentWidth, for: offset)
+                coordinator.setHeaderHeight(headerHeight)
+                coordinator.setEventHorizontalInset(eventHorizontalInset)
+                coordinator.setDrawableHours(
+                    leading: drawableLeadingHours,
+                    trailing: drawableTrailingHours,
+                    for: offset
+                )
+                coordinator.setShowEventText(showEventText)
+                coordinator.setFocusContextActive(isFocusContextActive)
+            }
+            .onChange(of: date) { _, v in
+                coordinator?.setDate(v, for: offset)
+            }
+            .onChange(of: occurrences) { _, v in
+                coordinator?.setOccurrences(v, for: offset)
+            }
+            .onChange(of: contentWidth) { _, v in
+                coordinator?.setContentWidth(v, for: offset)
+            }
+            .onChange(of: headerHeight) { _, v in
+                coordinator?.setHeaderHeight(v)
+            }
+            .onChange(of: eventHorizontalInset) { _, v in
+                coordinator?.setEventHorizontalInset(v)
+            }
+            .onChange(of: drawableLeadingHours) { _, v in
+                coordinator?.setDrawableHours(
+                    leading: v,
+                    trailing: drawableTrailingHours,
+                    for: offset
+                )
+            }
+            .onChange(of: drawableTrailingHours) { _, v in
+                coordinator?.setDrawableHours(
+                    leading: drawableLeadingHours,
+                    trailing: v,
+                    for: offset
+                )
+            }
+            .onChange(of: showEventText) { _, v in
+                coordinator?.setShowEventText(v)
+            }
+            .onChange(of: isFocusContextActive) { _, v in
+                coordinator?.setFocusContextActive(v)
+            }
     }
 }

--- a/Done/Views/Calendar/Components/Timeline/TimelineView.swift
+++ b/Done/Views/Calendar/Components/Timeline/TimelineView.swift
@@ -3889,7 +3889,11 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .onAppear {
-                guard let coordinator else { return }
+                guard let coordinator else {
+                    print("🩹[s5.8] .onAppear: coordinator is NIL — wire skipped")
+                    return
+                }
+                print("🩹[s5.8] .onAppear offset=\(offset) date=\(date) occCount=\(occurrences.count) contentW=\(contentWidth) headerH=\(headerHeight) eventInset=\(eventHorizontalInset) drawable=(\(drawableLeadingHours),\(drawableTrailingHours)) showText=\(showEventText) focusCtx=\(isFocusContextActive)")
                 coordinator.setDate(date, for: offset)
                 coordinator.setOccurrences(occurrences, for: offset)
                 coordinator.setContentWidth(contentWidth, for: offset)
@@ -3904,9 +3908,11 @@ private struct TimelinePagerS5RenderChannelsModifier: ViewModifier {
                 coordinator.setFocusContextActive(isFocusContextActive)
             }
             .onChange(of: date) { _, v in
+                print("🩹[s5.8] .onChange date offset=\(offset) → \(v)")
                 coordinator?.setDate(v, for: offset)
             }
             .onChange(of: occurrences) { _, v in
+                print("🩹[s5.8] .onChange occurrences offset=\(offset) count=\(v.count)")
                 coordinator?.setOccurrences(v, for: offset)
             }
             .onChange(of: contentWidth) { _, v in


### PR DESCRIPTION
## Summary

Post-S5-merge follow-up hotfix series. PR #100 (S5) shipped the structural cord-cut (coordinator owns the day-layer host, SwiftUI representable swapped for `Color.clear` on imperative single-day) and **structurally passed** an independent review — but flag-ON real-device test surfaced that **nothing rendered**: blank canvas, no events, no grid, no now-line on most paths.

12 commits trace 7 distinct bugs to the visible-render state. Independent subagent investigations + real-device log iteration found the root cause + structural issues + render-state channels missed by S4's recommended migration list.

S5.10 follow-ups (selective hit-test for tap / long-press / drag, cosmetic hairline at top) filed as **#101**.

## Bug chain (in the order found)

| Slice | Bug | Fix |
|---|---|---|
| **S5.8 (b3f6ee5)** | Spec §5 S4's "11-channel" migration list omitted 9 critical render-state channels (occurrences / date / contentWidth / headerHeight / eventHorizontalInset / drawable hours / showEventText / isFocusContextActive). Post-cord-cut these no longer flowed through the SwiftUI representable. | New `TimelinePagerS5RenderChannelsModifier` on the imperative `Color.clear` placeholder wires each channel via `.onAppear` initial push + per-channel `.onChange` updates. `setDate(_:for:)` / `setDrawableHours(leading:trailing:for:)` / `setFocusContextActive(_:)` added to coordinator. |
| **S5.8 (e55f83c)** | TabView pre-mounts every page's `.onAppear` BEFORE `TimelineScrollHost.makeUIView` installs the scroll view (and thus before the coordinator is constructed via the install callback). All initial channel pushes hit `coordinator?.setX(...)` against nil → silently no-op. Plus the single coordinator-owned host was pinned to `dayOffset=0` (today), so paging to another day didn't propagate Model changes. | Modifier observes `.onChange(of: coordinator != nil)` and re-fires the full snapshot. Coordinator gets `currentPageOffset` (default 0); per-day setters cache always, but only push the Model when `dayOffset == currentPageOffset`. `setCurrentPageOffset(_:)` rewrites the host's Model from the new offset's cached state. CalendarPageView observes `calendarState.selectedDayOffset`. |
| **S5.8 (555f912)** | Every TabView-preloaded page fires its `.onGeometryChange` simultaneously; with the modifier hardcoding `setHostFrame(globalFrame, for: 0)`, the coordinator's `dayOffset == 0` guard accepted ALL of them — host.frame got yanked to whichever fired last (often an off-screen page). | Modifier passes its real `offset`; coordinator caches every offset's frame in `hostFrameByDayOffset` but only `applyHostFrameIfChanged` when `dayOffset == currentPageOffset`. `setCurrentPageOffset` re-pins from cache so a page swap doesn't wait for the new page's next geometry tick. |
| **S5.9a (56b43ab)** | Apple's runtime warning fired every cold start: "Adding 'DayLayerHostView' as a subview of UIHostingController.view is not supported". S5 added the host to `hostContentView` (which IS `UIHostingController.view`). On real device this manifested as a fully blank canvas. | Per spec §4d, host is now a sibling of `UIHostingController.view` inside `UIScrollView.contentView`. `TimelineScrollHost`'s `onScrollViewInstalled` callback now passes `scrollView` (not `hostContentView`) as the coordinator's `container`. Frame-conversion math (`scrollView.convert(globalFrame, from: nil)`) handles `contentOffset` implicitly through `bounds.origin`. |
| **S5.9b (2ad6042)** | Even with structural fix, the initial `addHost` apply ran against host.bounds = scrollView.bounds (e.g. 402×874), placing event sublayers in that coord space. Later `setHostFrame` shrank bounds to the day-column (e.g. 364×1340) but `apply` was never re-fired against the new bounds — event sublayers were positioned for the stale 402×874 space. | `applyHostFrameIfChanged` now re-applies the cached Model after a significant frame change (≥1pt threshold filters cold-start scroll-animation jitter). |
| **S5.9c (b48ceb0)** | **Root cause of the persistent blank canvas**: SwiftUI `.onChange(of:_:)` does NOT fire on initial mount. Most S4 channels (`hourHeight`, `mode`, font, time-below, etc.) had no initial value pushed → coordinator's `hourHeight` defaulted to `0` → `verticalFrame` computed `contentHeight = 24h × 0 = 0` → every event block landed with `height = 0`. Sublayer added (10 → 11) but invisible. | Pre-seed `setHourHeight` / `setMode` / `setFrozenSlotMinutes` BEFORE the install-callback's `addHost` in CalendarPageView. New `.onChange(of: dayLayerCoordinator != nil)` in TimelinePagerView pushes `setTitleFontSize` / `setShowTimeBelowTitle` / `setMultiTypeEnabled` / `setHorizonDays` / `setPinchActive` / `setRecentlyAbsorbedEventIDs` the moment the coordinator becomes available. |
| **S5.9d (51d402f)** | Once render worked, the host's default `isUserInteractionEnabled = true` blocked the SwiftUI TabView's horizontal-swipe paging — host eats every touch in its frame. | `host.isUserInteractionEnabled = false` so touches fall through to the underlying SwiftUI tree. **Trade-off documented**: event tap / long-press / drag don't reach the delegate adapter (S5.6 wiring is intact, just unreachable). Selective hit-test deferred to S5.10 (#101). |
| **Cleanup (47ac6ba)** | — | Removed all `🩹[s5.8]` / `🩹[s5.9c]` diagnostic prints (13 sites), systemPink debug background tint, stale comment text. |

## Diff shape

12 commits. Squash-merge will collapse this into one PR commit. Total: `~+250 / −60` across `CalendarPageView.swift`, `DayLayerCoordinator.swift`, `TimelineView.swift`, `CalendarDayLayerView.swift`.

## What's NOT in (deferred to #101)

- Selective hit-test on host: event tap / long-press / drag-to-create on imperative path doesn't currently engage. Users with flag-ON can VIEW + SWIPE but not INTERACT with events.
- Cosmetic green hairline at top of timeline (not from any known CALayer chrome — needs investigation).

## Test plan

- [ ] Flag OFF: byte-identical to king. All channel `.onChange` handlers + the modifier are gated on `usesImperativeDayLayerModel`; no path mutates flag-OFF state.
- [ ] Multi-day: byte-identical (imperative path is single-day only; multi-day still uses the SwiftUI representable).
- [ ] Flag ON, single-day, cold start: events on today render at correct vertical positions, grid + now-line + horizon visible.
- [ ] Flag ON, single-day: swipe back to past days with events — events on yesterday / 2 days ago render correctly.
- [ ] Flag ON, single-day: pinch (hourHeight) works smoothly; events scale with the pinch.
- [ ] Flag ON, single-day: range-mode flip to 3-day / week — imperative path tears down cleanly; multi-day renders normally.
- [ ] Flag ON, single-day: scroll-to-now on cold start lands at current time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)